### PR TITLE
Added .NET 2.0 version (with LinqBridge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ TestArchives/Scratch/
 TestArchives/Scratch2/
 TestResults/
 *.nupkg
+packages/*/

--- a/SharpCompress.sln
+++ b/SharpCompress.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.30110.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Testing", "Testing", "{932BBFCC-76E3-45FF-90CA-6BE4FBF4A097}"
 EndProject
@@ -21,6 +21,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpCompress.PortableTest", "SharpCompress\SharpCompress.PortableTest.csproj", "{EFDCAF57-FD4D-4E5D-A3D5-F26B875817ED}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpCompress.Test.Portable", "SharpCompress.Test\SharpCompress.Test.Portable.csproj", "{E9C3C94B-FB27-4B4F-B225-57513C254D37}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpCompress.LinqBridge", "SharpCompress\SharpCompress.LinqBridge.csproj", "{9A6F69DC-258D-4EB4-859E-09EFC7A14A3F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -52,6 +54,10 @@ Global
 		{E9C3C94B-FB27-4B4F-B225-57513C254D37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9C3C94B-FB27-4B4F-B225-57513C254D37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9C3C94B-FB27-4B4F-B225-57513C254D37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A6F69DC-258D-4EB4-859E-09EFC7A14A3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A6F69DC-258D-4EB4-859E-09EFC7A14A3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A6F69DC-258D-4EB4-859E-09EFC7A14A3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A6F69DC-258D-4EB4-859E-09EFC7A14A3F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SharpCompress/Archive/AbstractWritableArchive.Extensions.cs
+++ b/SharpCompress/Archive/AbstractWritableArchive.Extensions.cs
@@ -74,7 +74,7 @@ namespace SharpCompress.Archive
             where TEntry : IArchiveEntry
             where TVolume : IVolume
         {
-            foreach (var path in Directory.EnumerateFiles(filePath, searchPattern, searchOption))
+            foreach (var path in Directory.GetFiles(filePath, searchPattern, searchOption))
             {
                 var fileInfo = new FileInfo(path);
                 writableArchive.AddEntry(path.Substring(filePath.Length), fileInfo.OpenRead(), true, fileInfo.Length,

--- a/SharpCompress/Archive/Rar/RarArchiveEntry.cs
+++ b/SharpCompress/Archive/Rar/RarArchiveEntry.cs
@@ -34,7 +34,7 @@ namespace SharpCompress.Archive.Rar
 
         internal override IEnumerable<FilePart> Parts
         {
-            get { return parts; }
+            get { return parts.Cast<FilePart>(); }
         }
 
         internal override FileHeader FileHeader

--- a/SharpCompress/Common/Rar/Headers/RarHeaderFactory.cs
+++ b/SharpCompress/Common/Rar/Headers/RarHeaderFactory.cs
@@ -93,7 +93,7 @@ namespace SharpCompress.Common.Rar.Headers
             {
                 if (!Options.HasFlag(Options.KeepStreamsOpen))
                 {
-                    reader.Dispose();
+                    reader.Close();
                 }
                 throw new InvalidFormatException("Error trying to read rar signature.", e);
             }

--- a/SharpCompress/Common/Rar/RarRijndael.cs
+++ b/SharpCompress/Common/Rar/RarRijndael.cs
@@ -106,7 +106,7 @@ namespace SharpCompress.Common.Rar
 
         public void Dispose()
         {
-            rijndael.Dispose();
+            ((IDisposable)rijndael).Dispose();
         }
     }
 }

--- a/SharpCompress/Compressor/LZMA/AesDecoderStream.cs
+++ b/SharpCompress/Compressor/LZMA/AesDecoderStream.cs
@@ -39,7 +39,7 @@ namespace SharpCompress.Compressor.LZMA
             byte[] password = Encoding.Unicode.GetBytes(pass.CryptoGetTextPassword());
             byte[] key = InitKey(numCyclesPower, salt, password);
 
-            using (var aes = Aes.Create())
+            using (var aes = Rijndael.Create())
             {
                 aes.Mode = CipherMode.CBC;
                 aes.Padding = PaddingMode.None;

--- a/SharpCompress/EnumExtensions.cs
+++ b/SharpCompress/EnumExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace SharpCompress
+{
+    internal static class EnumExtensions
+    {
+        public static bool HasFlag(this Enum enumRef, Enum flag)
+        {
+            long value = Convert.ToInt64(enumRef);
+            long flagVal = Convert.ToInt64(flag);
+
+            return (value & flagVal) == flagVal;
+        }
+    }
+}

--- a/SharpCompress/SharpCompress.LinqBridge.csproj
+++ b/SharpCompress/SharpCompress.LinqBridge.csproj
@@ -1,0 +1,389 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9A6F69DC-258D-4EB4-859E-09EFC7A14A3F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SharpCompress</RootNamespace>
+    <AssemblyName>SharpCompress</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <StartupObject>
+    </StartupObject>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <BaseIntermediateOutputPath>obj\LinqBridge\</BaseIntermediateOutputPath>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\sharpcompress\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\LinqBridge\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;DISABLE_TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>1591</NoWarn>
+    <DocumentationFile>
+    </DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\LinqBridge\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>
+    </DocumentationFile>
+    <NoWarn>1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>SharpCompress.pfx</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="LinqBridge">
+      <HintPath>..\packages\LinqBridge.1.3.0\lib\net20\LinqBridge.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Archive\IWritableArchiveEntry.cs" />
+    <Compile Include="Archive\Rar\FileInfoRarFilePart.cs" />
+    <Compile Include="Common\ArchiveEncoding.cs" />
+    <Compile Include="Archive\AbstractWritableArchive.cs" />
+    <Compile Include="Archive\AbstractArchive.cs" />
+    <Compile Include="Archive\AbstractWritableArchive.Extensions.cs" />
+    <Compile Include="Archive\ArchiveFactory.cs" />
+    <Compile Include="Archive\GZip\GZipWritableArchiveEntry.cs" />
+    <Compile Include="Archive\IArchive.Extensions.cs" />
+    <Compile Include="Archive\GZip\GZipArchive.cs" />
+    <Compile Include="Archive\GZip\GZipArchiveEntry.cs" />
+    <Compile Include="Archive\IArchiveEntry.cs" />
+    <Compile Include="Archive\Rar\RarArchiveEntryFactory.cs" />
+    <Compile Include="Archive\IArchive.cs" />
+    <Compile Include="Archive\Rar\StreamRarArchiveVolume.cs" />
+    <Compile Include="Archive\SevenZip\SevenZipArchive.cs" />
+    <Compile Include="Archive\SevenZip\SevenZipArchiveEntry.cs" />
+    <Compile Include="Archive\Tar\TarArchive.cs" />
+    <Compile Include="Archive\Tar\TarArchiveEntry.cs" />
+    <Compile Include="Archive\Tar\TarWritableArchiveEntry.cs" />
+    <Compile Include="Archive\Zip\ZipWritableArchiveEntry.cs" />
+    <Compile Include="Archive\Zip\ZipArchive.cs" />
+    <Compile Include="Archive\Zip\ZipArchiveEntry.cs" />
+    <Compile Include="Common\ArchiveException.cs" />
+    <Compile Include="Common\ArchiveExtractionEventArgs.cs" />
+    <Compile Include="Common\CompressedBytesReadEventArgs.cs" />
+    <Compile Include="Common\CompressionInfo.cs" />
+    <Compile Include="Common\CompressionType.cs" />
+    <Compile Include="Common\FilePartExtractionBeginEventArgs.cs" />
+    <Compile Include="Archive\IArchiveExtractionListener.cs" />
+    <Compile Include="Common\IncompleteArchiveException.cs" />
+    <Compile Include="Common\MultiVolumeExtractionException.cs" />
+    <Compile Include="Common\PasswordProtectedException.cs" />
+    <Compile Include="Common\CryptographicException.cs" />
+    <Compile Include="Common\FlagUtility.cs" />
+    <Compile Include="Common\GZip\GZipEntry.cs" />
+    <Compile Include="Common\GZip\GZipFilePart.cs" />
+    <Compile Include="Common\GZip\GZipVolume.cs" />
+    <Compile Include="Common\ExtractOptions.cs" />
+    <Compile Include="Common\FilePart.cs" />
+    <Compile Include="Common\Entry.cs" />
+    <Compile Include="Common\IEntry.cs" />
+    <Compile Include="Common\IVolume.cs" />
+    <Compile Include="Common\Rar\RarCryptoWrapper.cs" />
+    <Compile Include="Common\Rar\RarRijndael.cs" />
+    <Compile Include="Common\SevenZip\CBindPair.cs" />
+    <Compile Include="Common\SevenZip\CCoderInfo.cs" />
+    <Compile Include="Common\SevenZip\CFileItem.cs" />
+    <Compile Include="Common\SevenZip\CFolder.cs" />
+    <Compile Include="Common\SevenZip\CStreamSwitch.cs" />
+    <Compile Include="Common\SevenZip\DataReader.cs" />
+    <Compile Include="Common\SevenZip\SevenZipEntry.cs" />
+    <Compile Include="Common\SevenZip\SevenZipFilePart.cs" />
+    <Compile Include="Common\SevenZip\SevenZipVolume.cs" />
+    <Compile Include="Common\Tar\Headers\TarHeader.cs" />
+    <Compile Include="Common\Tar\TarReadOnlySubStream.cs" />
+    <Compile Include="Common\Tar\TarVolume.cs" />
+    <Compile Include="Common\Tar\TarEntry.cs" />
+    <Compile Include="Common\Tar\TarFilePart.cs" />
+    <Compile Include="Common\Tar\TarHeaderFactory.cs" />
+    <Compile Include="Common\Zip\Headers\HeaderFlags.cs" />
+    <Compile Include="Common\Zip\Headers\IgnoreHeader.cs" />
+    <Compile Include="Common\Zip\Headers\SplitHeader.cs" />
+    <Compile Include="Common\Zip\Headers\ZipFileEntry..cs" />
+    <Compile Include="Common\Zip\Headers\ZipHeaderType.cs" />
+    <Compile Include="Common\Zip\SeekableZipFilePart.cs" />
+    <Compile Include="Common\Zip\SeekableZipHeaderFactory.cs" />
+    <Compile Include="Common\Zip\StreamingZipFilePart.cs" />
+    <Compile Include="Common\Zip\StreamingZipHeaderFactory.cs" />
+    <Compile Include="Common\Zip\WinzipAesCryptoStream.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Common\Zip\WinzipAesEncryptionData.cs" />
+    <Compile Include="Common\Zip\WinzipAesKeySize.cs" />
+    <Compile Include="Common\Zip\ZipVolume.cs" />
+    <Compile Include="Compressor\BZip2\BZip2Constants.cs" />
+    <Compile Include="Compressor\BZip2\BZip2Stream.cs" />
+    <Compile Include="Compressor\BZip2\CBZip2InputStream.cs" />
+    <Compile Include="Compressor\BZip2\CBZip2OutputStream.cs" />
+    <Compile Include="Compressor\BZip2\CRC.cs" />
+    <Compile Include="Compressor\CompressionMode.cs" />
+    <Compile Include="Compressor\Deflate\FlushType.cs" />
+    <Compile Include="Common\Zip\PkwareTraditionalCryptoStream.cs" />
+    <Compile Include="Common\Zip\PkwareTraditionalEncryptionData.cs" />
+    <Compile Include="Compressor\Deflate\GZipStream.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Compressor\Filters\BCJ2Filter.cs" />
+    <Compile Include="Compressor\Filters\BCJFilter.cs" />
+    <Compile Include="Compressor\Filters\Filter.cs" />
+    <Compile Include="Compressor\LZMA\BitVector.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Compressor\LZMA\LZ\CRC.cs" />
+    <Compile Include="Compressor\LZMA\CRC.cs" />
+    <Compile Include="Common\SevenZip\ArchiveDatabase.cs" />
+    <Compile Include="Common\SevenZip\ArchiveReader.cs" />
+    <Compile Include="Common\SevenZip\CMethodId.cs" />
+    <Compile Include="Compressor\LZMA\AesDecoderStream.cs" />
+    <Compile Include="Compressor\LZMA\Bcj2DecoderStream.cs" />
+    <Compile Include="Compressor\LZMA\DecoderStream.cs" />
+    <Compile Include="Compressor\LZMA\Registry.cs" />
+    <Compile Include="Compressor\LZMA\ICoder.cs" />
+    <Compile Include="Compressor\LZMA\Log.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Compressor\LZMA\LzmaBase.cs" />
+    <Compile Include="Compressor\LZMA\LzmaDecoder.cs" />
+    <Compile Include="Compressor\LZMA\LzmaEncoder.cs" />
+    <Compile Include="Compressor\LZMA\LzmaEncoderProperties.cs" />
+    <Compile Include="Compressor\LZMA\LzmaStream.cs" />
+    <Compile Include="Compressor\LZMA\LZ\LzBinTree.cs" />
+    <Compile Include="Compressor\LZMA\LZ\LzInWindow.cs" />
+    <Compile Include="Compressor\LZMA\LZ\LzOutWindow.cs" />
+    <Compile Include="Compressor\LZMA\RangeCoder\RangeCoder.cs" />
+    <Compile Include="Compressor\LZMA\RangeCoder\RangeCoderBit.cs" />
+    <Compile Include="Compressor\LZMA\RangeCoder\RangeCoderBitTree.cs" />
+    <Compile Include="Compressor\LZMA\Utilites\CrcBuilderStream.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Compressor\LZMA\Utilites\CrcCheckStream.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Compressor\LZMA\Utilites\IPasswordProvider.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Compressor\LZMA\Utilites\Utils.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Compressor\PPMd\H\FreqData.cs" />
+    <Compile Include="Compressor\PPMd\H\ModelPPM.cs" />
+    <Compile Include="Compressor\PPMd\H\Pointer.cs" />
+    <Compile Include="Compressor\PPMd\H\PPMContext.cs" />
+    <Compile Include="Compressor\PPMd\H\RangeCoder.cs" />
+    <Compile Include="Compressor\PPMd\H\RarMemBlock.cs" />
+    <Compile Include="Compressor\PPMd\H\RarNode.cs" />
+    <Compile Include="Compressor\PPMd\H\SEE2Context.cs" />
+    <Compile Include="Compressor\PPMd\H\State.cs" />
+    <Compile Include="Compressor\PPMd\H\StateRef.cs" />
+    <Compile Include="Compressor\PPMd\H\SubAllocator.cs" />
+    <Compile Include="Compressor\PPMd\I1\Allocator.cs" />
+    <Compile Include="Compressor\PPMd\I1\Coder.cs" />
+    <Compile Include="Compressor\PPMd\I1\MemoryNode.cs" />
+    <Compile Include="Compressor\PPMd\I1\Model.cs" />
+    <Compile Include="Compressor\PPMd\I1\ModelRestorationMethod.cs" />
+    <Compile Include="Compressor\PPMd\I1\Pointer.cs" />
+    <Compile Include="Compressor\PPMd\I1\PpmContext.cs" />
+    <Compile Include="Compressor\PPMd\I1\PpmState.cs" />
+    <Compile Include="Compressor\PPMd\I1\See2Context.cs" />
+    <Compile Include="Compressor\PPMd\PpmdProperties.cs" />
+    <Compile Include="Compressor\PPMd\PpmdStream.cs" />
+    <Compile Include="Compressor\Rar\RarStream.cs" />
+    <Compile Include="EnumExtensions.cs" />
+    <Compile Include="IO\CountingWritableSubStream.cs" />
+    <Compile Include="Common\EntryStream.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="IO\ListeningStream.cs" />
+    <Compile Include="IO\NonDisposingStream.cs" />
+    <Compile Include="Common\Rar\RarCryptoBinaryReader.cs" />
+    <Compile Include="IO\RewindableStream.cs" />
+    <Compile Include="Reader\GZip\GZipReader.cs" />
+    <Compile Include="Reader\ReaderFactory.cs" />
+    <Compile Include="Reader\AbstractReader.cs" />
+    <Compile Include="Common\Volume.cs" />
+    <Compile Include="Compressor\Deflate\CRC32.cs" />
+    <Compile Include="Compressor\Deflate\DeflateManager.cs" />
+    <Compile Include="Compressor\Deflate\DeflateStream.cs" />
+    <Compile Include="Compressor\Deflate\Inflate.cs" />
+    <Compile Include="Compressor\Deflate\InfTree.cs" />
+    <Compile Include="Compressor\Deflate\Tree.cs" />
+    <Compile Include="Compressor\Deflate\Zlib.cs" />
+    <Compile Include="Compressor\Deflate\ZlibBaseStream.cs" />
+    <Compile Include="Compressor\Deflate\ZlibCodec.cs" />
+    <Compile Include="Compressor\Deflate\ZlibConstants.cs" />
+    <Compile Include="Compressor\Deflate\ZlibStream.cs" />
+    <Compile Include="Common\Rar\Headers\FileNameDecoder.cs" />
+    <Compile Include="Common\InvalidFormatException.cs" />
+    <Compile Include="IO\ReadOnlySubStream.cs" />
+    <Compile Include="IO\StreamingMode.cs" />
+    <Compile Include="Common\IExtractionListener.cs" />
+    <Compile Include="Common\MultipartStreamRequiredException.cs" />
+    <Compile Include="LazyReadOnlyCollection.cs" />
+    <Compile Include="Archive\Rar\RarArchive.Extensions.cs" />
+    <Compile Include="Archive\IArchiveEntry.Extensions.cs" />
+    <Compile Include="Archive\Rar\RarArchiveEntry.cs" />
+    <Compile Include="Common\ExtractionException.cs" />
+    <Compile Include="Common\Rar\RarEntry.cs" />
+    <Compile Include="Common\Options.cs" />
+    <Compile Include="Reader\IReader.cs" />
+    <Compile Include="Reader\Rar\MultiVolumeRarReader.cs" />
+    <Compile Include="Reader\Rar\RarReader.cs" />
+    <Compile Include="Reader\IReader.Extensions.cs" />
+    <Compile Include="Reader\Rar\RarReaderEntry.cs" />
+    <Compile Include="Archive\Rar\SeekableFilePart.cs" />
+    <Compile Include="Reader\Rar\SingleVolumeRarReader.cs" />
+    <Compile Include="Common\ArchiveType.cs" />
+    <Compile Include="Reader\Tar\TarReader.cs" />
+    <Compile Include="ReadOnlyCollection.cs" />
+    <Compile Include="VersionInfo.cs" />
+    <Compile Include="Archive\Rar\FileInfoRarArchiveVolume.cs" />
+    <Compile Include="Common\Rar\RarFilePart.cs" />
+    <Compile Include="Common\Rar\Headers\AVHeader.cs" />
+    <Compile Include="Common\Rar\Headers\CommentHeader.cs" />
+    <Compile Include="Common\Rar\Headers\EndArchiveHeader.cs" />
+    <Compile Include="Common\Rar\Headers\SignHeader.cs" />
+    <Compile Include="Common\Rar\RarVolume.cs" />
+    <Compile Include="Compressor\Rar\UnpackUtility.cs" />
+    <Compile Include="Archive\Rar\RarArchive.cs" />
+    <Compile Include="Compressor\Rar\MultiVolumeReadOnlyStream.cs" />
+    <Compile Include="Compressor\Rar\RarCRC.cs" />
+    <Compile Include="Common\Rar\Headers\FileHeader.cs" />
+    <Compile Include="Common\Rar\Headers\ArchiveHeader.cs" />
+    <Compile Include="Common\Rar\Headers\RarHeader.cs" />
+    <Compile Include="IO\MarkingBinaryReader.cs" />
+    <Compile Include="Common\Rar\Headers\NewSubHeader.cs" />
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Common\Rar\Headers\RarHeaderFactory.cs" />
+    <Compile Include="Common\Rar\Headers\Flags.cs" />
+    <Compile Include="Compressor\Rar\Decode\AudioVariables.cs" />
+    <Compile Include="Compressor\Rar\Decode\BitDecode.cs" />
+    <Compile Include="Compressor\Rar\Decode\CodeType.cs" />
+    <Compile Include="Compressor\Rar\Decode\Compress.cs" />
+    <Compile Include="Compressor\Rar\Decode\Decode.cs" />
+    <Compile Include="Compressor\Rar\Decode\DistDecode.cs" />
+    <Compile Include="Compressor\Rar\Decode\FilterType.cs" />
+    <Compile Include="Compressor\Rar\Decode\LitDecode.cs" />
+    <Compile Include="Compressor\Rar\Decode\LowDistDecode.cs" />
+    <Compile Include="Compressor\Rar\Decode\MultDecode.cs" />
+    <Compile Include="Compressor\Rar\Decode\RepDecode.cs" />
+    <Compile Include="Compressor\Rar\PPM\BlockTypes.cs" />
+    <Compile Include="Compressor\Rar\Unpack.cs" />
+    <Compile Include="Compressor\Rar\Unpack15.cs" />
+    <Compile Include="Compressor\Rar\Unpack20.cs" />
+    <Compile Include="Compressor\Rar\UnpackFilter.cs" />
+    <Compile Include="Compressor\Rar\VM\BitInput.cs" />
+    <Compile Include="Compressor\Rar\VM\RarVM.cs" />
+    <Compile Include="Compressor\Rar\VM\VMCmdFlags.cs" />
+    <Compile Include="Compressor\Rar\VM\VMCommands.cs" />
+    <Compile Include="Compressor\Rar\VM\VMFlags.cs" />
+    <Compile Include="Compressor\Rar\VM\VMOpType.cs" />
+    <Compile Include="Compressor\Rar\VM\VMPreparedCommand.cs" />
+    <Compile Include="Compressor\Rar\VM\VMPreparedOperand.cs" />
+    <Compile Include="Compressor\Rar\VM\VMPreparedProgram.cs" />
+    <Compile Include="Compressor\Rar\VM\VMStandardFilters.cs" />
+    <Compile Include="Compressor\Rar\VM\VMStandardFilterSignature.cs" />
+    <Compile Include="Utility.cs" />
+    <Compile Include="Common\Rar\Headers\MarkHeader.cs" />
+    <Compile Include="Archive\Rar\RarArchiveVolumeFactory.cs" />
+    <Compile Include="Reader\Rar\NonSeekableStreamFilePart.cs" />
+    <Compile Include="Reader\Rar\RarReaderVolume.cs" />
+    <Compile Include="Common\Zip\ZipCompressionMethod.cs" />
+    <Compile Include="Common\Zip\Headers\DirectoryEndHeader.cs" />
+    <Compile Include="Common\Zip\Headers\DirectoryEntryHeader.cs" />
+    <Compile Include="Common\Zip\Headers\LocalEntryHeader.cs" />
+    <Compile Include="Common\Zip\ZipFilePart.cs" />
+    <Compile Include="Common\Zip\Headers\ZipHeader.cs" />
+    <Compile Include="Common\Zip\ZipHeaderFactory.cs" />
+    <Compile Include="Reader\Zip\ZipReader.cs" />
+    <Compile Include="Common\Zip\ZipEntry.cs" />
+    <Compile Include="Writer\AbstractWriter.cs" />
+    <Compile Include="Writer\GZip\GZipWriter.cs" />
+    <Compile Include="Writer\IWriter.Extensions.cs" />
+    <Compile Include="Writer\IWriter.cs" />
+    <Compile Include="Writer\Tar\TarWriter.cs" />
+    <Compile Include="Writer\WriterFactory.cs" />
+    <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipWriter.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="SharpCompress.pfx" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SharpCompress/Writer/IWriter.Extensions.cs
+++ b/SharpCompress/Writer/IWriter.Extensions.cs
@@ -35,7 +35,7 @@ namespace SharpCompress.Writer
             {
                 throw new ArgumentException("Directory does not exist: " + directory);
             }
-            foreach (string file in Directory.EnumerateFiles(directory, searchPattern, option))
+            foreach (string file in Directory.GetFiles(directory, searchPattern, option))
             {
                 writer.Write(file.Substring(directory.Length), file);
             }

--- a/SharpCompress/packages.config
+++ b/SharpCompress/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LinqBridge" version="1.3.0" targetFramework="net20" />
+</packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<repositories>
+  <repository path="..\SharpCompress\packages.config" />
+</repositories>


### PR DESCRIPTION
I am developing a package manager called [Zero Install](https://github.com/0install/0install-win). To ensure it runs out-of-the-box without additional dependency installations on most Windows boxes it still targets .NET 2.0.

I would like to use SharpCompress in Zero Install, so I added a project file that targets .NET 2.0.
In order to replace the missing LINQ functionality I used [LinqBridge](https://code.google.com/p/linqbridge/). The other compatibility changes were rather minor.
