### PR TITLE
.NET 2.0 version in NuGet package with limited dependency on LinqBridge

### DIFF
--- a/NuGet/sharpcompress.nuspec
+++ b/NuGet/sharpcompress.nuspec
@@ -13,10 +13,17 @@
         <releaseNotes />
         <language>en-US</language>
         <tags>rar unrar zip unzip bzip2 gzip tar 7zip</tags>
+        <dependencies>
+            <group />
+            <group targetFramework="net20">
+                <dependency id="LinqBridge" version="1.3.0" />
+            </group>
+        </dependencies>
     </metadata>
     <files>
         <file src="..\bin\Full\SharpCompress.dll" target="lib\net40\SharpCompress.dll" />
         <file src="..\bin\WindowsStore\SharpCompress.dll" target="lib\netcore45\SharpCompress.dll" />
         <file src="..\bin\Portable\SharpCompress.dll" target="lib\portable-net4+sl5+wp8+win8\SharpCompress.dll" />
+        <file src="..\bin\LinqBridge\SharpCompress.dll" target="lib\net20\SharpCompress.dll" />
     </files>
 </package>


### PR DESCRIPTION
I think I found a better solution than the separate NuGet package I suggested in pull request #12.
Turns out NuGet allows you to specify dependencies for specific Frameworks.
