### PR TITLE
Exposed modification time for .7z archives

### DIFF
--- a/SharpCompress/Common/SevenZip/SevenZipEntry.cs
+++ b/SharpCompress/Common/SevenZip/SevenZipEntry.cs
@@ -39,7 +39,7 @@ namespace SharpCompress.Common.SevenZip
 
         public override DateTime? LastModifiedTime
         {
-            get { throw new NotImplementedException(); }
+            get { return FilePart.Header.MTime; }
         }
 
         public override DateTime? CreatedTime


### PR DESCRIPTION
As in the title...

I don't know why it hasn't been done before as the reading of the time from .7z archive is already implemented and seems to work just fine.
