### PR TITLE
Changed the order of detecting whether the archive is in .rar format.

### DIFF
--- a/SharpCompress/Archive/ArchiveFactory.cs
+++ b/SharpCompress/Archive/ArchiveFactory.cs
@@ -31,12 +31,6 @@ namespace SharpCompress.Archive
                 return ZipArchive.Open(stream, options, null);
             }
             stream.Seek(0, SeekOrigin.Begin);
-            if (RarArchive.IsRarFile(stream, Options.LookForHeader | Options.KeepStreamsOpen))
-            {
-                stream.Seek(0, SeekOrigin.Begin);
-                return RarArchive.Open(stream, options);
-            }
-            stream.Seek(0, SeekOrigin.Begin);
             if (TarArchive.IsTarFile(stream))
             {
                 stream.Seek(0, SeekOrigin.Begin);
@@ -54,7 +48,13 @@ namespace SharpCompress.Archive
                 stream.Seek(0, SeekOrigin.Begin);
                 return GZipArchive.Open(stream, options);
             }
-            throw new InvalidOperationException("Cannot determine compressed stream type.  Supported Archive Formats: Zip, GZip, Tar, Rar, 7Zip");
+            stream.Seek(0, SeekOrigin.Begin);
+            if(RarArchive.IsRarFile(stream, Options.LookForHeader | Options.KeepStreamsOpen))
+            {
+               stream.Seek(0, SeekOrigin.Begin);
+               return RarArchive.Open(stream, options);
+            }
+            throw new InvalidOperationException("Cannot determine compressed stream type. Supported Archive Formats: Zip, GZip, Tar, Rar, 7Zip");
         }
 
         public static IArchive Create(ArchiveType type)
@@ -122,12 +122,6 @@ namespace SharpCompress.Archive
                     return ZipArchive.Open(fileInfo, options, null);
                 }
                 stream.Seek(0, SeekOrigin.Begin);
-                if (RarArchive.IsRarFile(stream, Options.LookForHeader | Options.KeepStreamsOpen))
-                {
-                    stream.Dispose();
-                    return RarArchive.Open(fileInfo, options);
-                }
-                stream.Seek(0, SeekOrigin.Begin);
                 if (TarArchive.IsTarFile(stream))
                 {
                     stream.Dispose();
@@ -145,7 +139,13 @@ namespace SharpCompress.Archive
                     stream.Dispose();
                     return GZipArchive.Open(fileInfo, options);
                 }
-                throw new InvalidOperationException("Cannot determine compressed stream type.");
+                stream.Seek(0, SeekOrigin.Begin);
+                if(RarArchive.IsRarFile(stream, Options.LookForHeader | Options.KeepStreamsOpen))
+                {
+                   stream.Dispose();
+                   return RarArchive.Open(fileInfo, options);
+                }
+                throw new InvalidOperationException("Cannot determine compressed stream type. Supported Archive Formats: Zip, GZip, Tar, Rar, 7Zip");
             }
         }
 


### PR DESCRIPTION
Detecting whether the archive is in .rar format currently requires reading entire archive byte by byte 
which is very slow when the archive is big and as it's done before checking for .tar and .7z formats, so the opening of archive is very slow even for those formats.

Because of this I have reordered the checks, so that detecting if this is RAR archive is done last, so that .tar and .7z formats can be loaded fast and entire archive checking will only occur when the archive is in unsupported format.

I'm not sure whether the checking of entire archive is required for RAR format, so I didn't touch it.
