### PR TITLE
Inconsistent time format

### DIFF
--- a/SharpCompress/Common/SevenZip/ArchiveReader.cs
+++ b/SharpCompress/Common/SevenZip/ArchiveReader.cs
@@ -159,7 +159,7 @@ namespace SharpCompress.Common.SevenZip
         private DateTime TranslateTime(long time)
         {
             // FILETIME = 100-nanosecond intervals since January 1, 1601 (UTC)
-            return DateTime.FromFileTimeUtc(time);
+            return DateTime.FromFileTimeUtc(time).ToLocalTime();
         }
 
         private DateTime? TranslateTime(long? time)

--- a/SharpCompress/Common/Tar/Headers/TarHeader.cs
+++ b/SharpCompress/Common/Tar/Headers/TarHeader.cs
@@ -25,7 +25,7 @@ namespace SharpCompress.Common.Tar.Headers
 
     internal class TarHeader
     {
-        internal static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0);
+        internal static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         internal string Name { get; set; }
         //internal int Mode { get; set; }
@@ -42,7 +42,7 @@ namespace SharpCompress.Common.Tar.Headers
         {
             if (Name.Length > 255)
             {
-                throw new InvalidFormatException("UsTar fileName can not be longer thatn 255 chars");
+                throw new InvalidFormatException("UsTar fileName can not be longer than 255 chars");
             }
             byte[] buffer = new byte[512];
             string name = Name;
@@ -56,7 +56,7 @@ namespace SharpCompress.Common.Tar.Headers
             WriteOctalBytes(0, buffer, 108, 8);
             WriteOctalBytes(0, buffer, 116, 8);
             WriteOctalBytes(Size, buffer, 124, 12);
-            var time = (long) (LastModifiedTime - Epoch).TotalSeconds;
+            var time = (long) (LastModifiedTime.ToUniversalTime() - Epoch).TotalSeconds;
             WriteOctalBytes(time, buffer, 136, 12);
 
             buffer[156] = (byte) EntryType;
@@ -115,7 +115,7 @@ namespace SharpCompress.Common.Tar.Headers
                 Size = ReadASCIIInt64Base8(buffer, 124, 11);
             }
             long unixTimeStamp = ReadASCIIInt64Base8(buffer, 136, 11);
-            LastModifiedTime = Epoch.AddSeconds(unixTimeStamp);
+            LastModifiedTime = Epoch.AddSeconds(unixTimeStamp).ToLocalTime();
 
 
             Magic = ArchiveEncoding.Default.GetString(buffer, 257, 6).TrimNulls();

--- a/SharpCompress/Utility.cs
+++ b/SharpCompress/Utility.cs
@@ -372,7 +372,7 @@ namespace SharpCompress
             DateTime dt;
             try
             {
-                dt = new DateTime(year, month, day, hour, minute, second);
+                dt = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Local);
             }
             catch
             {
@@ -387,10 +387,13 @@ namespace SharpCompress
             {
                 return 0;
             }
+
+            var localDateTime = dateTime.Value.ToLocalTime();
+
             return (uint)(
-                              (dateTime.Value.Second / 2) | (dateTime.Value.Minute << 5) | (dateTime.Value.Hour << 11) |
-                              (dateTime.Value.Day << 16) | (dateTime.Value.Month << 21) |
-                              ((dateTime.Value.Year - 1980) << 25));
+                              (localDateTime.Second / 2) | (localDateTime.Minute << 5) | (localDateTime.Hour << 11) |
+                              (localDateTime.Day << 16) | (localDateTime.Month << 21) |
+                              ((localDateTime.Year - 1980) << 25));
         }
 
 


### PR DESCRIPTION
Currently, not all archive types return the modification time of entry in the same format. ZIP returns the time in local time, while TAR and 7Z returns UTC time.
This has caused that in my timezone the modification time for .zip entries were correct, while the ones for .tar and .7z entries were 1 hour off.

I have fixed it, so that now every archive returns time as local time.

I was not sure whether it's better to always return local or UTC time, but I have decided to return local time as it is a bit more intuitive for a user. In the long term, it does not matter, as there is conversion available between them with the usage of .ToLocalTime() and ToUniversalTime() .methods, what matters is that returned times have to be consistent for all supported formats.