### PR TITLE
Made the assembly CLSCompliant.

### DIFF
--- a/SharpCompress/Archive/GZip/GZipWritableArchiveEntry.cs
+++ b/SharpCompress/Archive/GZip/GZipWritableArchiveEntry.cs
@@ -25,7 +25,7 @@ namespace SharpCompress.Archive.GZip
             this.closeStream = closeStream;
         }
 
-        public override uint Crc
+        public override long Crc
         {
             get { return 0; }
         }

--- a/SharpCompress/Archive/Rar/RarArchiveEntry.cs
+++ b/SharpCompress/Archive/Rar/RarArchiveEntry.cs
@@ -42,7 +42,7 @@ namespace SharpCompress.Archive.Rar
             get { return parts.First().FileHeader; }
         }
 
-        public override uint Crc
+        public override long Crc
         {
             get
             {

--- a/SharpCompress/Archive/Tar/TarWritableArchiveEntry.cs
+++ b/SharpCompress/Archive/Tar/TarWritableArchiveEntry.cs
@@ -25,7 +25,7 @@ namespace SharpCompress.Archive.Tar
             this.closeStream = closeStream;
         }
 
-        public override uint Crc
+        public override long Crc
         {
             get { return 0; }
         }

--- a/SharpCompress/Archive/Zip/ZipWritableArchiveEntry.cs
+++ b/SharpCompress/Archive/Zip/ZipWritableArchiveEntry.cs
@@ -26,7 +26,7 @@ namespace SharpCompress.Archive.Zip
             this.closeStream = closeStream;
         }
 
-        public override uint Crc
+        public override long Crc
         {
             get { return 0; }
         }

--- a/SharpCompress/AssemblyInfo.cs
+++ b/SharpCompress/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 #if PORTABLE
@@ -17,3 +18,5 @@ InternalsVisibleTo(
         "SharpCompress.Test.Portable, PublicKey=002400000480000094000000060200000024000052534131000400000100010005d6ae1b0f6875393da83c920a5b9408f5191aaf4e8b3c2c476ad2a11f5041ecae84ce9298bc4c203637e2fd3a80ad5378a9fa8da1363e98cea45c73969198a4b64510927c910001491cebbadf597b22448ad103b0a4007e339faf8fe8665dcdb70d65b27ac05b1977c0655fad06b372b820ecbdccf10a0f214fee0986dfeded"
         )]
 #endif
+
+[assembly: CLSCompliant(true)]

--- a/SharpCompress/Common/Entry.cs
+++ b/SharpCompress/Common/Entry.cs
@@ -8,7 +8,7 @@ namespace SharpCompress.Common
         /// <summary>
         /// The File's 32 bit CRC Hash
         /// </summary>
-        public abstract uint Crc { get; }
+        public abstract long Crc { get; }
 
         /// <summary>
         /// The string key of the file internal to the Archive.

--- a/SharpCompress/Common/GZip/GZipEntry.cs
+++ b/SharpCompress/Common/GZip/GZipEntry.cs
@@ -18,7 +18,7 @@ namespace SharpCompress.Common.GZip
             get { return CompressionType.GZip; }
         }
 
-        public override uint Crc
+        public override long Crc
         {
             get { return 0; }
         }

--- a/SharpCompress/Common/IEntry.cs
+++ b/SharpCompress/Common/IEntry.cs
@@ -7,7 +7,7 @@ namespace SharpCompress.Common
         CompressionType CompressionType { get; }
         DateTime? ArchivedTime { get; }
         long CompressedSize { get; }
-        uint Crc { get; }
+        long Crc { get; }
         DateTime? CreatedTime { get; }
         string Key { get; }
         bool IsDirectory { get; }

--- a/SharpCompress/Common/Rar/RarEntry.cs
+++ b/SharpCompress/Common/Rar/RarEntry.cs
@@ -10,7 +10,7 @@ namespace SharpCompress.Common.Rar
         /// <summary>
         /// The File's 32 bit CRC Hash
         /// </summary>
-        public override uint Crc
+        public override long Crc
         {
             get { return FileHeader.FileCRC; }
         }

--- a/SharpCompress/Common/SevenZip/SevenZipEntry.cs
+++ b/SharpCompress/Common/SevenZip/SevenZipEntry.cs
@@ -17,7 +17,7 @@ namespace SharpCompress.Common.SevenZip
             get { return FilePart.CompressionType; }
         }
 
-        public override uint Crc
+        public override long Crc
         {
             get { return FilePart.Header.Crc ?? 0; }
         }

--- a/SharpCompress/Common/Tar/TarEntry.cs
+++ b/SharpCompress/Common/Tar/TarEntry.cs
@@ -22,7 +22,7 @@ namespace SharpCompress.Common.Tar
             get { return type; }
         }
 
-        public override uint Crc
+        public override long Crc
         {
             get { return 0; }
         }

--- a/SharpCompress/Common/Zip/ZipEntry.cs
+++ b/SharpCompress/Common/Zip/ZipEntry.cs
@@ -53,7 +53,7 @@ namespace SharpCompress.Common.Zip
             }
         }
 
-        public override uint Crc
+        public override long Crc
         {
             get { return filePart.Header.Crc; }
         }


### PR DESCRIPTION
Added attribute [assembly: CLSCompliant(true)] and changed type of
public Crc properties from uint to long to satisfy CLS compliance.