### PR TITLE
fixed: .NET2 project is not compiling

### DIFF
--- a/SharpCompress/SharpCompress.NET2.csproj
+++ b/SharpCompress/SharpCompress.NET2.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Common\IVolume.cs" />
     <Compile Include="Common\Rar\RarCryptoWrapper.cs" />
     <Compile Include="Common\Rar\RarRijndael.cs" />
+    <Compile Include="Common\ReaderExtractionEventArgs.cs" />
     <Compile Include="Common\SevenZip\CBindPair.cs" />
     <Compile Include="Common\SevenZip\CCoderInfo.cs" />
     <Compile Include="Common\SevenZip\CFileItem.cs" />
@@ -149,8 +150,9 @@
     <Compile Include="Common\Tar\TarHeaderFactory.cs" />
     <Compile Include="Common\Zip\Headers\HeaderFlags.cs" />
     <Compile Include="Common\Zip\Headers\IgnoreHeader.cs" />
+    <Compile Include="Common\Zip\Headers\LocalEntryHeaderExtraFactory.cs" />
     <Compile Include="Common\Zip\Headers\SplitHeader.cs" />
-    <Compile Include="Common\Zip\Headers\ZipFileEntry..cs" />
+    <Compile Include="Common\Zip\Headers\ZipFileEntry.cs" />
     <Compile Include="Common\Zip\Headers\ZipHeaderType.cs" />
     <Compile Include="Common\Zip\SeekableZipFilePart.cs" />
     <Compile Include="Common\Zip\SeekableZipHeaderFactory.cs" />
@@ -249,6 +251,7 @@
     <Compile Include="Common\Rar\RarCryptoBinaryReader.cs" />
     <Compile Include="IO\RewindableStream.cs" />
     <Compile Include="Reader\GZip\GZipReader.cs" />
+    <Compile Include="Reader\IReaderExtractionListener.cs" />
     <Compile Include="Reader\ReaderFactory.cs" />
     <Compile Include="Reader\AbstractReader.cs" />
     <Compile Include="Common\Volume.cs" />


### PR DESCRIPTION
Fixed typo and include missing files into NET2 project.