### PR TITLE
Fixed bug where tar.bz2 compression did not work

### DIFF
--- a/SharpCompress/Writer/Tar/TarWriter.cs
+++ b/SharpCompress/Writer/Tar/TarWriter.cs
@@ -91,6 +91,7 @@ namespace SharpCompress.Writer.Tar
             {
                 PadTo512(0, true);
                 PadTo512(0, true);
+                OutputStream.Dispose(); // required when bzip2 compression is used
             }
             base.Dispose(isDisposing);
         }


### PR DESCRIPTION
Commit d36ae445e29de46879bfb23299ad8fa9ea59d4b1 caused tar.bz2 file generation and the Tar_BZip2_Writer test to fail. This reverts that commit.