### PR TITLE
Fixed .NET2 Release build

### DIFF
--- a/SharpCompress/SharpCompress.NET2.csproj
+++ b/SharpCompress/SharpCompress.NET2.csproj
@@ -64,7 +64,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\bin\NET2\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET2</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
The .NET2 project only built in Debug configuration due to not including
the compilation symbol NET2 in the Release configuration.