### PR TITLE
Added read support for RARs with Protect Headers

### DIFF
--- a/SharpCompress/Common/Rar/Headers/ProtectHeader.cs
+++ b/SharpCompress/Common/Rar/Headers/ProtectHeader.cs
@@ -1,0 +1,22 @@
+﻿using SharpCompress.IO;
+
+namespace SharpCompress.Common.Rar.Headers
+{
+    // ProtectHeader is part of the Recovery Record feature
+    internal class ProtectHeader : RarHeader
+    {
+        protected override void ReadFromReader(MarkingBinaryReader reader)
+        {
+            Version = reader.ReadByte();
+            RecSectors = reader.ReadUInt16();
+            TotalBlocks = reader.ReadUInt32();
+            Mark = reader.ReadBytes(8);
+        }
+
+        internal uint DataSize { get { return AdditionalSize; } }
+        internal byte Version { get; private set; }
+        internal ushort RecSectors { get; private set; }
+        internal uint TotalBlocks { get; private set; }
+        internal byte[] Mark { get; private set; }
+    }
+}

--- a/SharpCompress/Common/Rar/Headers/RarHeaderFactory.cs
+++ b/SharpCompress/Common/Rar/Headers/RarHeaderFactory.cs
@@ -151,6 +151,33 @@ namespace SharpCompress.Common.Rar.Headers
                     {
                         return header.PromoteHeader<MarkHeader>(reader);
                     }
+
+                case HeaderType.ProtectHeader:
+                    {
+                        ProtectHeader ph = header.PromoteHeader<ProtectHeader>(reader);
+                        
+                        // skip the recovery record data, we do not use it.
+                        switch (StreamingMode)
+                        {
+                            case StreamingMode.Seekable:
+                                {
+                                    reader.BaseStream.Position += ph.DataSize;
+                                }
+                                break;
+                            case StreamingMode.Streaming:
+                                {
+                                    reader.BaseStream.Skip(ph.DataSize);
+                                }
+                                break;
+                            default:
+                                {
+                                    throw new InvalidFormatException("Invalid StreamingMode");
+                                }
+                        }
+
+                        return ph;
+                    }
+
                 case HeaderType.NewSubHeader:
                     {
                         FileHeader fh = header.PromoteHeader<FileHeader>(reader);

--- a/SharpCompress/SharpCompress.NET2.csproj
+++ b/SharpCompress/SharpCompress.NET2.csproj
@@ -307,6 +307,7 @@
     <Compile Include="Common\Rar\Headers\RarHeader.cs" />
     <Compile Include="IO\MarkingBinaryReader.cs" />
     <Compile Include="Common\Rar\Headers\NewSubHeader.cs" />
+    <Compile Include="Common\Rar\Headers\ProtectHeader.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Common\Rar\Headers\RarHeaderFactory.cs" />
     <Compile Include="Common\Rar\Headers\Flags.cs" />

--- a/SharpCompress/SharpCompress.Portable.csproj
+++ b/SharpCompress/SharpCompress.Portable.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Common\Rar\Headers\Flags.cs" />
     <Compile Include="Common\Rar\Headers\MarkHeader.cs" />
     <Compile Include="Common\Rar\Headers\NewSubHeader.cs" />
+    <Compile Include="Common\Rar\Headers\ProtectHeader.cs" />
     <Compile Include="Common\Rar\Headers\RarHeader.cs" />
     <Compile Include="Common\Rar\Headers\RarHeaderFactory.cs" />
     <Compile Include="Common\Rar\Headers\SignHeader.cs" />

--- a/SharpCompress/SharpCompress.PortableTest.csproj
+++ b/SharpCompress/SharpCompress.PortableTest.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Common\Rar\Headers\RarHeader.cs" />
     <Compile Include="IO\MarkingBinaryReader.cs" />
     <Compile Include="Common\Rar\Headers\NewSubHeader.cs" />
+    <Compile Include="Common\Rar\Headers\ProtectHeader.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Common\Rar\Headers\RarHeaderFactory.cs" />
     <Compile Include="Common\Rar\Headers\Flags.cs" />

--- a/SharpCompress/SharpCompress.WindowsStore.csproj
+++ b/SharpCompress/SharpCompress.WindowsStore.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Common\Rar\Headers\Flags.cs" />
     <Compile Include="Common\Rar\Headers\MarkHeader.cs" />
     <Compile Include="Common\Rar\Headers\NewSubHeader.cs" />
+    <Compile Include="Common\Rar\Headers\ProtectHeader.cs" />
     <Compile Include="Common\Rar\Headers\RarHeader.cs" />
     <Compile Include="Common\Rar\Headers\RarHeaderFactory.cs" />
     <Compile Include="Common\Rar\Headers\SignHeader.cs" />

--- a/SharpCompress/SharpCompress.csproj
+++ b/SharpCompress/SharpCompress.csproj
@@ -307,6 +307,7 @@
     <Compile Include="Common\Rar\Headers\RarHeader.cs" />
     <Compile Include="IO\MarkingBinaryReader.cs" />
     <Compile Include="Common\Rar\Headers\NewSubHeader.cs" />
+    <Compile Include="Common\Rar\Headers\ProtectHeader.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Common\Rar\Headers\RarHeaderFactory.cs" />
     <Compile Include="Common\Rar\Headers\Flags.cs" />


### PR DESCRIPTION
Some RARs with recovery records contain Protect Headers, I've added
support for parsing them so that RARs containing them can be read,
instead of an invalid-header exception being thrown. Parsing logic taken
from unrar reference source.