### PR TITLE
ZipWriter: use ArchiveEncoding.Default

### DIFF
--- a/SharpCompress/Writer/Zip/ZipWriter.cs
+++ b/SharpCompress/Writer/Zip/ZipWriter.cs
@@ -123,11 +123,11 @@ namespace SharpCompress.Writer.Zip
 
         private int WriteHeader(string filename, DateTime? modificationTime)
         {
-            byte[] encodedFilename = Encoding.UTF8.GetBytes(filename);
+            byte[] encodedFilename = ArchiveEncoding.Default.GetBytes(filename);
 
             OutputStream.Write(BitConverter.GetBytes(ZipHeaderFactory.ENTRY_HEADER_BYTES), 0, 4);
             OutputStream.Write(new byte[] {63, 0}, 0, 2); //version
-            HeaderFlags flags = HeaderFlags.UTF8;
+            HeaderFlags flags = ArchiveEncoding.Default == Encoding.UTF8 ? HeaderFlags.UTF8 : (HeaderFlags)0;
             if (!OutputStream.CanSeek)
             {
                 flags |= HeaderFlags.UsePostDataDescriptor;
@@ -158,7 +158,7 @@ namespace SharpCompress.Writer.Zip
 
         private void WriteEndRecord(uint size)
         {
-            byte[] encodedComment = Encoding.UTF8.GetBytes(zipComment);
+            byte[] encodedComment = ArchiveEncoding.Default.GetBytes(zipComment);
 
             OutputStream.Write(new byte[] {80, 75, 5, 6, 0, 0, 0, 0}, 0, 8);
             OutputStream.Write(BitConverter.GetBytes((ushort) entries.Count), 0, 2);


### PR DESCRIPTION
ShaprCompress is used internally in Mono to implement
System.IO.Compression, which allows the user to specify path encoding.
The change allows for specifying the encoding via
ArchiveEncoding.Default.