### PR TITLE
Skip entry stream on dispose

### DIFF
--- a/SharpCompress/Archive/SevenZip/SevenZipArchive.cs
+++ b/SharpCompress/Archive/SevenZip/SevenZipArchive.cs
@@ -236,7 +236,7 @@ namespace SharpCompress.Archive.SevenZip
 
             protected override EntryStream GetEntryStream()
             {
-                return new EntryStream(new ReadOnlySubStream(currentStream, currentItem.Size));
+                return CreateEntryStream(new ReadOnlySubStream(currentStream, currentItem.Size));
             }
         }
     }

--- a/SharpCompress/Common/EntryStream.cs
+++ b/SharpCompress/Common/EntryStream.cs
@@ -1,16 +1,19 @@
 ﻿using System;
 using System.IO;
+using SharpCompress.Reader;
 
 namespace SharpCompress.Common
 {
     public class EntryStream : Stream
     {
+        public IReader Reader { get; private set; }
         private Stream stream;
         private bool completed;
         private bool isDisposed;
 
-        internal EntryStream(Stream stream)
+        internal EntryStream(IReader reader, Stream stream)
         {
+            this.Reader = reader;
             this.stream = stream;
         }
 
@@ -26,25 +29,9 @@ namespace SharpCompress.Common
             completed = true;
         }
 
-        public bool Cancelled { get; private set; }
-
-        /// <summary>
-        /// Indicates that the remainder of the stream is not required.
-        /// On dispose, the entry will not be skipped, so it helps with efficiency.
-        /// The downside is that subsequent entries are not usable, as the compressed stream is not positioned at an entry boundary.
-        /// </summary>
-        public void Cancel()
-        {
-          if (!completed)
-          {
-            Cancelled = true;
-            stream.Close();
-          }
-        }
-
         protected override void Dispose(bool disposing)
         {
-            if (!(completed || Cancelled))
+            if (!(completed || Reader.Cancelled))
             {
                 SkipEntry();
             }

--- a/SharpCompress/Common/EntryStream.cs
+++ b/SharpCompress/Common/EntryStream.cs
@@ -26,12 +26,27 @@ namespace SharpCompress.Common
             completed = true;
         }
 
+        public bool Cancelled { get; private set; }
+
+        /// <summary>
+        /// Indicates that the remainder of the stream is not required.
+        /// On dispose, the entry will not be skipped, so it helps with efficiency.
+        /// The downside is that subsequent entries are not usable, as the compressed stream is not positioned at an entry boundary.
+        /// </summary>
+        public void Cancel()
+        {
+          if (!completed)
+          {
+            Cancelled = true;
+            stream.Close();
+          }
+        }
+
         protected override void Dispose(bool disposing)
         {
-            if (!completed)
+            if (!(completed || Cancelled))
             {
-                throw new InvalidOperationException(
-                    "EntryStream has not been fully consumed.  Read the entire stream or use SkipEntry.");
+                SkipEntry();
             }
             if (isDisposed)
             {

--- a/SharpCompress/Reader/AbstractReader.cs
+++ b/SharpCompress/Reader/AbstractReader.cs
@@ -77,6 +77,12 @@ namespace SharpCompress.Reader
             {
                 return LoadStreamForReading(RequestInitialStream());
             }
+
+            if (currentEntryStream != null && currentEntryStream.Cancelled)
+            {
+              throw new InvalidOperationException("EntryStream has not been fully consumed.  Read the entire stream or use SkipEntry.");
+            }
+
             if (!wroteCurrentEntry)
             {
                 SkipEntry();
@@ -197,9 +203,19 @@ namespace SharpCompress.Reader
             return stream;
         }
 
+        private EntryStream currentEntryStream;
+
+        /// <summary>
+        /// Retains a reference to the entry stream, so we can check whether it completed later.
+        /// </summary>
+        protected EntryStream CreateEntryStream(Stream decompressed)
+        {
+          return currentEntryStream = new EntryStream(decompressed);
+        }
+
         protected virtual EntryStream GetEntryStream()
         {
-            return new EntryStream(Entry.Parts.First().GetCompressedStream());
+          return CreateEntryStream(Entry.Parts.First().GetCompressedStream());
         }
 
         #endregion

--- a/SharpCompress/Reader/IReader.cs
+++ b/SharpCompress/Reader/IReader.cs
@@ -22,6 +22,9 @@ namespace SharpCompress.Reader
         /// <param name="writableStream"></param>
         void WriteEntryTo(Stream writableStream);
 
+        bool Cancelled { get; }
+        void Cancel();
+
         /// <summary>
         /// Moves to the next entry by reading more data from the underlying stream.  This skips if data has not been read.
         /// </summary>

--- a/SharpCompress/Reader/Rar/RarReader.cs
+++ b/SharpCompress/Reader/Rar/RarReader.cs
@@ -73,7 +73,7 @@ namespace SharpCompress.Reader.Rar
 
         protected override EntryStream GetEntryStream()
         {
-            return new EntryStream(new RarStream(pack, Entry.FileHeader,
+            return CreateEntryStream(new RarStream(pack, Entry.FileHeader,
                                                  new MultiVolumeReadOnlyStream(
                                                      CreateFilePartEnumerableForCurrentEntry().Cast<RarFilePart>(), this)));
         }


### PR DESCRIPTION
Until now the caller had to completely consume each entry stream, or call SkipEntry(), before disposing the stream. If not, exception was thrown: "EntryStream has not been fully consumed". Hugely inconvenient; a user-thrown exception inside a "using (EntryStream)" block would be discarded.

Now automatically skips the entry on dispose.

Added method EntryStream.Cancel(). Call this if entry stream is unfinished, and no further entries are required. Helps with efficiency, as it avoids reading data that is not needed.