### PR TITLE
Extract Options And Total Sizes

### DIFF
--- a/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
+++ b/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
@@ -61,6 +61,11 @@ namespace SharpCompress.Test
             ArchiveFileRead("7Zip.BZip2.7z");
         }
 
+        [TestMethod]
+        public void SevenZipArchive_LZMA_Time_Attributes_PathRead()
+        {
+            ArchiveFileReadEx("7Zip.LZMA.7z");
+        }
 
         [TestMethod]
         [ExpectedException(typeof(IndexOutOfRangeException))]

--- a/SharpCompress.Test/TestBase.cs
+++ b/SharpCompress.Test/TestBase.cs
@@ -78,6 +78,21 @@ namespace SharpCompress.Test
             }
         }
 
+        /// <summary>
+        /// Verifies the files also check modified time and attributes.
+        /// </summary>
+        public void VerifyFilesEx()
+        {
+            if (UseExtensionInsteadOfNameToVerify)
+            {
+                VerifyFilesByExtensionEx();
+            }
+            else
+            {
+                VerifyFilesByNameEx();
+            }
+        }
+
         protected void VerifyFilesByName()
         {
             var extracted =
@@ -94,6 +109,52 @@ namespace SharpCompress.Test
                 Assert.IsTrue(extracted.Contains(orig.Key));
 
                 CompareFilesByPath(orig.Single(), extracted[orig.Key].Single());
+            }
+        }
+
+        /// <summary>
+        /// Verifies the files by name also check modified time and attributes.
+        /// </summary>
+        protected void VerifyFilesByNameEx()
+        {
+            var extracted =
+                Directory.EnumerateFiles(SCRATCH_FILES_PATH, "*.*", SearchOption.AllDirectories)
+                .ToLookup(path => path.Substring(SCRATCH_FILES_PATH.Length));
+            var original =
+                Directory.EnumerateFiles(ORIGINAL_FILES_PATH, "*.*", SearchOption.AllDirectories)
+                .ToLookup(path => path.Substring(ORIGINAL_FILES_PATH.Length));
+
+            Assert.AreEqual(extracted.Count, original.Count);
+
+            foreach (var orig in original)
+            {
+                Assert.IsTrue(extracted.Contains(orig.Key));
+
+                CompareFilesByPath(orig.Single(), extracted[orig.Key].Single());
+                CompareFilesByTimeAndAttribut(orig.Single(), extracted[orig.Key].Single());
+            }
+        }
+
+        /// <summary>
+        /// Verifies the files by extension also check modified time and attributes.
+        /// </summary>
+        protected void VerifyFilesByExtensionEx()
+        {
+            var extracted =
+                Directory.EnumerateFiles(SCRATCH_FILES_PATH, "*.*", SearchOption.AllDirectories)
+                .ToLookup(path => Path.GetExtension(path));
+            var original =
+                Directory.EnumerateFiles(ORIGINAL_FILES_PATH, "*.*", SearchOption.AllDirectories)
+                .ToLookup(path => Path.GetExtension(path));
+
+            Assert.AreEqual(extracted.Count, original.Count);
+
+            foreach (var orig in original)
+            {
+                Assert.IsTrue(extracted.Contains(orig.Key));
+
+                CompareFilesByPath(orig.Single(), extracted[orig.Key].Single());
+                CompareFilesByTimeAndAttribut(orig.Single(), extracted[orig.Key].Single());
             }
         }
 
@@ -135,6 +196,14 @@ namespace SharpCompress.Test
                             counter, file1, file2));
                 }
             }
+        }
+
+        protected void CompareFilesByTimeAndAttribut(string file1, string file2)
+        {
+            FileInfo fi1 = new FileInfo(file1);
+            FileInfo fi2 = new FileInfo(file2);
+            Assert.AreEqual(fi1.LastWriteTime, fi2.LastWriteTime);
+            Assert.AreEqual(fi1.Attributes, fi2.Attributes);
         }
 
         protected void CompareArchivesByPath(string file1, string file2)

--- a/SharpCompress/Archive/AbstractArchive.cs
+++ b/SharpCompress/Archive/AbstractArchive.cs
@@ -84,7 +84,6 @@ namespace SharpCompress.Archive
         /// <summary>
         /// Returns an ReadOnlyCollection of all the RarArchiveEntries across the one or many parts of the RarArchive.
         /// </summary>
-        /// <returns></returns>
         public virtual ICollection<TEntry> Entries
         {
             get { return lazyEntries; }
@@ -93,7 +92,6 @@ namespace SharpCompress.Archive
         /// <summary>
         /// Returns an ReadOnlyCollection of all the RarArchiveVolumes across the one or many parts of the RarArchive.
         /// </summary>
-        /// <returns></returns>
         public ICollection<TVolume> Volumes
         {
             get { return lazyVolumes; }
@@ -102,9 +100,17 @@ namespace SharpCompress.Archive
         /// <summary>
         /// The total size of the files compressed in the archive.
         /// </summary>
-        public long TotalSize
+        public virtual long TotalSize
         {
             get { return Entries.Aggregate(0L, (total, cf) => total + cf.CompressedSize); }
+        }
+
+        /// <summary>
+        /// The total size of the files as uncompressed in the archive.
+        /// </summary>
+        public virtual long TotalUncompressSize
+        {
+            get { return Entries.Aggregate(0L, (total, cf) => total + cf.Size); }
         }
 
         protected abstract IEnumerable<TVolume> LoadVolumes(IEnumerable<Stream> streams, Options options);

--- a/SharpCompress/Archive/IArchive.cs
+++ b/SharpCompress/Archive/IArchive.cs
@@ -14,7 +14,6 @@ namespace SharpCompress.Archive
         event EventHandler<FilePartExtractionBeginEventArgs> FilePartExtractionBegin;
 
         IEnumerable<IArchiveEntry> Entries { get; }
-        long TotalSize { get; }
         IEnumerable<IVolume> Volumes { get; }
 
         ArchiveType Type { get; }
@@ -24,7 +23,6 @@ namespace SharpCompress.Archive
         /// This is primarily for SOLID Rar Archives or 7Zip Archives as they need to be 
         /// extracted sequentially for the best performance.
         /// </summary>
-        /// <returns></returns>
         IReader ExtractAllEntries();
 
         /// <summary>
@@ -37,5 +35,15 @@ namespace SharpCompress.Archive
         /// This checks to see if all the known entries have IsComplete = true
         /// </summary>
         bool IsComplete { get; }
+
+        /// <summary>
+        /// The total size of the files compressed in the archive.
+        /// </summary>
+        long TotalSize { get; }
+
+        /// <summary>
+        /// The total size of the files as uncompressed in the archive.
+        /// </summary>
+        long TotalUncompressSize { get; }
     }
 }

--- a/SharpCompress/Archive/IArchiveEntry.Extensions.cs
+++ b/SharpCompress/Archive/IArchiveEntry.Extensions.cs
@@ -83,6 +83,40 @@ namespace SharpCompress.Archive
             {
                 entry.WriteTo(fs);
             }
+
+            if (options.HasFlag(ExtractOptions.PreserveFileTime) || options.HasFlag(ExtractOptions.PreserveAttributes))
+            {
+                // update file time to original packed time
+                FileInfo nf = new FileInfo(destinationFileName);
+                if (nf.Exists)
+                {
+                    if (options.HasFlag(ExtractOptions.PreserveAttributes))
+                    {
+                        if (entry.CreatedTime.HasValue)
+                        {
+                            nf.CreationTime = entry.CreatedTime.Value;
+                        }
+
+                        if (entry.LastModifiedTime.HasValue)
+                        {
+                            nf.LastWriteTime = entry.LastModifiedTime.Value;
+                        }
+
+                        if (entry.LastAccessedTime.HasValue)
+                        {
+                            nf.LastAccessTime = entry.CreatedTime.Value;
+                        }
+                    }
+
+                    if (options.HasFlag(ExtractOptions.PreserveAttributes))
+                    {
+                        if (entry.Attrib.HasValue)
+                        {
+                            nf.Attributes = (FileAttributes)System.Enum.ToObject(typeof(FileAttributes), entry.Attrib.Value);
+                        }
+                    }
+                }
+            }
         }
 #endif
     }

--- a/SharpCompress/Archive/SevenZip/SevenZipArchive.cs
+++ b/SharpCompress/Archive/SevenZip/SevenZipArchive.cs
@@ -188,6 +188,15 @@ namespace SharpCompress.Archive.SevenZip
             get { return Entries.Where(x => !x.IsDirectory).GroupBy(x => x.FilePart.Folder).Count() > 1; }
         }
 
+        public override long TotalSize
+        {
+            get
+            {
+                int i = Entries.Count;
+                return database.PackSizes.Aggregate(0L, (total, packSize) => total + packSize);
+            }
+        }
+
         private class SevenZipReader : AbstractReader<SevenZipEntry, SevenZipVolume>
         {
             private readonly SevenZipArchive archive;

--- a/SharpCompress/Common/Entry.cs
+++ b/SharpCompress/Common/Entry.cs
@@ -46,7 +46,7 @@ namespace SharpCompress.Common
         public abstract DateTime? LastAccessedTime { get; }
 
         /// <summary>
-        /// The entry time whend archived, if recorded
+        /// The entry time when archived, if recorded
         /// </summary>
         public abstract DateTime? ArchivedTime { get; }
 
@@ -70,7 +70,16 @@ namespace SharpCompress.Common
 
         internal virtual void Close()
         {
-            
+
         }
+
+        /// <summary>
+        /// Entry file attribute.
+        /// </summary>
+        public virtual int? Attrib
+        {
+            get { throw new NotImplementedException(); }
+        }
+
     }
 }

--- a/SharpCompress/Common/ExtractOptions.cs
+++ b/SharpCompress/Common/ExtractOptions.cs
@@ -16,5 +16,15 @@ namespace SharpCompress.Common
         /// extract with internal directory structure
         /// </summary>
         ExtractFullPath,
+
+        /// <summary>
+        /// preserve file time
+        /// </summary>
+        PreserveFileTime,
+
+        /// <summary>
+        /// preserve windows file attributes
+        /// </summary>
+        PreserveAttributes,
     }
 }

--- a/SharpCompress/Common/IEntry.cs
+++ b/SharpCompress/Common/IEntry.cs
@@ -16,5 +16,6 @@ namespace SharpCompress.Common
         DateTime? LastAccessedTime { get; }
         DateTime? LastModifiedTime { get; }
         long Size { get; }
+        int? Attrib { get; }
     }
 }

--- a/SharpCompress/Common/SevenZip/CStreamSwitch.cs
+++ b/SharpCompress/Common/SevenZip/CStreamSwitch.cs
@@ -16,7 +16,9 @@ namespace SharpCompress.Common.SevenZip
             if (_active)
             {
                 _active = false;
+#if DEBUG
                 Log.WriteLine("[end of switch]");
+#endif
             }
 
             if (_needRemove)
@@ -47,7 +49,9 @@ namespace SharpCompress.Common.SevenZip
                 if (dataIndex < 0 || dataIndex >= dataVector.Count)
                     throw new InvalidOperationException();
 
+#if DEBUG
                 Log.WriteLine("[switch to stream {0}]", dataIndex);
+#endif
                 _archive = archive;
                 _archive.AddByteStream(dataVector[dataIndex], 0, dataVector[dataIndex].Length);
                 _needRemove = true;
@@ -55,7 +59,9 @@ namespace SharpCompress.Common.SevenZip
             }
             else
             {
+#if DEBUG
                 Log.WriteLine("[inline data]");
+#endif
             }
         }
     }

--- a/SharpCompress/Common/SevenZip/DataReader.cs
+++ b/SharpCompress/Common/SevenZip/DataReader.cs
@@ -78,7 +78,9 @@ namespace SharpCompress.Common.SevenZip
                 throw new EndOfStreamException();
 
             _offset += (int) size;
+#if DEBUG
             Log.WriteLine("SkipData {0}", size);
+#endif
         }
 
         public void SkipData()

--- a/SharpCompress/Common/SevenZip/SevenZipEntry.cs
+++ b/SharpCompress/Common/SevenZip/SevenZipEntry.cs
@@ -72,6 +72,11 @@ namespace SharpCompress.Common.SevenZip
             get { return false; }
         }
 
+        public override int? Attrib
+        {
+            get { return (int) FilePart.Header.Attrib; }
+        }
+
         internal override IEnumerable<FilePart> Parts
         {
             get { return FilePart.AsEnumerable<FilePart>(); }


### PR DESCRIPTION
Fixed TotalSize For 7z
added TotalUncompressSize Tested for 7z
this enables to show progress for the entire archive
Added 2 Extract Options: PreserveFileTime And PreserveAttributes.
Put All the Log Command under DEBUG Condition.