### PR TITLE
Move closing parentheses to where they should be, so build does not b…

### DIFF
--- a/SharpCompress/Common/SevenZip/ArchiveReader.cs
+++ b/SharpCompress/Common/SevenZip/ArchiveReader.cs
@@ -241,9 +241,8 @@ namespace SharpCompress.Common.SevenZip
                             coder.NumInStreams = ReadNum();
                             coder.NumOutStreams = ReadNum();
 #if DEBUG
-                            Log.WriteLine("Complex Stream (In: " + coder.NumInStreams + " - Out: " + coder.NumOutStreams +
+                            Log.WriteLine("Complex Stream (In: " + coder.NumInStreams + " - Out: " + coder.NumOutStreams + ")");
 #endif
- ")");
                         }
                         else
                         {


### PR DESCRIPTION
…reak for non-DEBUG configurations.