### PR TITLE
Add explicit compressioninfo when writing file to zip

### DIFF
--- a/SharpCompress/SharpCompress.Portable.csproj
+++ b/SharpCompress/SharpCompress.Portable.csproj
@@ -321,6 +321,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/SharpCompress.PortableTest.csproj
+++ b/SharpCompress/SharpCompress.PortableTest.csproj
@@ -371,6 +371,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/SharpCompress.Unsigned.csproj
+++ b/SharpCompress/SharpCompress.Unsigned.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/SharpCompress.WindowsStore.csproj
+++ b/SharpCompress/SharpCompress.WindowsStore.csproj
@@ -306,6 +306,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/SharpCompress.csproj
+++ b/SharpCompress/SharpCompress.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Writer\Tar\TarWriter.cs" />
     <Compile Include="Writer\WriterFactory.cs" />
     <Compile Include="Writer\Zip\ZipCentralDirectoryEntry.cs" />
+    <Compile Include="Writer\Zip\ZipCompressionInfo.cs" />
     <Compile Include="Writer\Zip\ZipWriter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpCompress/Writer/Zip/ZipCompressionInfo.cs
+++ b/SharpCompress/Writer/Zip/ZipCompressionInfo.cs
@@ -1,0 +1,47 @@
+﻿using SharpCompress.Common;
+using SharpCompress.Common.Zip;
+using SharpCompress.Compressor.Deflate;
+
+namespace SharpCompress.Writer.Zip
+{
+    internal class ZipCompressionInfo
+    {
+        internal CompressionLevel DeflateCompressionLevel { get; private set; }
+        internal ZipCompressionMethod Compression { get; private set; }
+
+        public ZipCompressionInfo(CompressionInfo compressionInfo)
+        {
+            switch (compressionInfo.Type)
+            {
+                case CompressionType.None:
+                    {
+                        this.Compression = ZipCompressionMethod.None;
+                    }
+                    break;
+                case CompressionType.Deflate:
+                    {
+                        this.DeflateCompressionLevel = compressionInfo.DeflateCompressionLevel;
+                        this.Compression = ZipCompressionMethod.Deflate;
+                    }
+                    break;
+                case CompressionType.BZip2:
+                    {
+                        this.Compression = ZipCompressionMethod.BZip2;
+                    }
+                    break;
+                case CompressionType.LZMA:
+                    {
+                        this.Compression = ZipCompressionMethod.LZMA;
+                    }
+                    break;
+                case CompressionType.PPMd:
+                    {
+                        this.Compression = ZipCompressionMethod.PPMd;
+                    }
+                    break;
+                default:
+                    throw new InvalidFormatException("Invalid compression method: " + compressionInfo.Type);
+            }
+        }
+    }
+}


### PR DESCRIPTION
We use the ZipWriter to create archive with compression type deflate. But there is a problem - the default Mac UI unzipping (double click on the zip file) is throwing "Unable to expand. Error 2 No such file or directory." if there is an empty file in the archive. It only works  for archives that store the empty files and do not compress them.

As this is not a general bug, but one tool issue, the solution for me is to provide the API with option to explicitly change the compression info for specific files. This way if there are empty files or other specifics one can have different compression infos in one archive.