### PR TITLE
Add password when opening RarReader

### DIFF
--- a/SharpCompress/Archive/Rar/RarArchive.cs
+++ b/SharpCompress/Archive/Rar/RarArchive.cs
@@ -64,7 +64,7 @@ namespace SharpCompress.Archive.Rar
         {
             var stream = Volumes.First().Stream;
             stream.Position = 0;
-            return RarReader.Open(stream);
+            return RarReader.Open(stream, Password);
         }
 
         public override bool IsSolid


### PR DESCRIPTION
When using the following code the program will crash because there is no password specified

```c#
var archive = RarArchive.Open(***);
var entries = archive.ExtractAllEntries();
while(entries.MoveToNextEntry()) { // cryptographic exception here
   // do something with entries
}
```

This pull requests passes the password to the `RarReader`