### PR TITLE
Zip entry header version for Deflate compression set to 20

### DIFF
--- a/SharpCompress/Writer/Zip/ZipWriter.cs
+++ b/SharpCompress/Writer/Zip/ZipWriter.cs
@@ -94,7 +94,14 @@ namespace SharpCompress.Writer.Zip
             byte[] encodedFilename = ArchiveEncoding.Default.GetBytes(filename);
 
             OutputStream.Write(BitConverter.GetBytes(ZipHeaderFactory.ENTRY_HEADER_BYTES), 0, 4);
-            OutputStream.Write(new byte[] {63, 0}, 0, 2); //version
+				if(explicitZipCompressionInfo.Compression == ZipCompressionMethod.Deflate)
+				{
+					OutputStream.Write(new byte[] {20, 0}, 0, 2); //version
+				}
+				else
+				{
+					OutputStream.Write(new byte[] {63, 0}, 0, 2); //version
+				}            
             HeaderFlags flags = ArchiveEncoding.Default == Encoding.UTF8 ? HeaderFlags.UTF8 : (HeaderFlags)0;
             if (!OutputStream.CanSeek)
             {


### PR DESCRIPTION
The java runtime on Android cannot process file entries with the fixed
version 63 - it can only process entries up to version 20, which should
be fine if the entry was compressed using deflate.