### PR TITLE
Fix VS2013 compiler warnings (errors)

### DIFF
--- a/SharpCompress/Compressor/Deflate/DeflateManager.cs
+++ b/SharpCompress/Compressor/Deflate/DeflateManager.cs
@@ -670,6 +670,7 @@ namespace SharpCompress.Compressor.Deflate
             send_bits((tree[c2] & 0xffff), (tree[c2 + 1] & 0xffff));
         }
 
+#pragma warning disable 675 // workaround for Visual Studio 2015 compiler bug: https://github.com/dotnet/roslyn/issues/4027
         internal void send_bits(int value, int length)
         {
             int len = length;
@@ -677,10 +678,10 @@ namespace SharpCompress.Compressor.Deflate
             {
                 if (bi_valid > (int) Buf_size - len)
                 {
+                    //int val = value;
                     //      bi_buf |= (val << bi_valid);
-                    int x = (value << bi_valid) & 0xffff;
-                    bi_buf = (short)((int)bi_buf | x);
 
+                    bi_buf |= (short)((value << bi_valid) & 0xffff);
                     //put_short(bi_buf);
                     pending[pendingCount++] = (byte) bi_buf;
                     pending[pendingCount++] = (byte) (bi_buf >> 8);
@@ -691,14 +692,13 @@ namespace SharpCompress.Compressor.Deflate
                 }
                 else
                 {
-                    //      bi_buf |= (val << bi_valid);
-                    int x = (value << bi_valid) & 0xffff;
-                    bi_buf = (short)((int)bi_buf | x);
-
+                    //      bi_buf |= (value) << bi_valid;
+                    bi_buf |= (short)((value << bi_valid) & 0xffff);
                     bi_valid += len;
                 }
             }
         }
+#pragma warning restore 675
 
         // Send one empty static block to give enough lookahead for inflate.
         // This takes 10 bits, of which 7 may remain in the bit buffer.


### PR DESCRIPTION
Fixes broken build in VS2013 introduced by
18bd8102281c04c7eb09ecfdd984d7382b629f2c. That commit attempted to fix a
compiler warning from VS2015, but this turns out to be a compiler bug:
https://github.com/dotnet/roslyn/issues/4027 . That commit added code
which VS2013 correctly treats as a compiler warning, breaking the VS2013
build.
I have reverted this unnecessary change to the deflate code, fixing the
VS2013 build, and disabled warning CS0675 on send_bits() which will
satisfy VS2015.

Fixes https://github.com/adamhathcock/sharpcompress/issues/79