### PR TITLE
Fix Release build of Tests

### DIFF
--- a/SharpCompress/SharpCompress.PortableTest.csproj
+++ b/SharpCompress/SharpCompress.PortableTest.csproj
@@ -63,7 +63,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;UNSIGNED</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/SharpCompress/SharpCompress.Unsigned.csproj
+++ b/SharpCompress/SharpCompress.Unsigned.csproj
@@ -65,7 +65,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;UNSIGNED</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Fixes release builds of SharpCompress.Test and SharpCompress.Test.Portable. The UNSIGNED symbol was missing from the Release configurations of SharpCompress.Unsigned and SharpCompress.PortableTest