### PR TITLE
Fixed serious performance regression (revert 0f12a073af4486509dfd777da1854efb5dc571ee)

### DIFF
--- a/SharpCompress/Archive/Zip/ZipArchive.cs
+++ b/SharpCompress/Archive/Zip/ZipArchive.cs
@@ -116,7 +116,7 @@ namespace SharpCompress.Archive.Zip
             try
             {
                 ZipHeader header =
-                    headerFactory.ReadStreamHeader(stream).FirstOrDefault(x => x != null && x.ZipHeaderType != ZipHeaderType.Split);
+                    headerFactory.ReadStreamHeader(stream).FirstOrDefault(x => x.ZipHeaderType != ZipHeaderType.Split);
                 if (header == null)
                 {
                     return false;

--- a/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
+++ b/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
@@ -45,17 +45,18 @@ namespace SharpCompress.Common.Zip
                 lastEntryHeader = null;
                 uint headerBytes = reader.ReadUInt32();
                 header = ReadHeader(headerBytes, reader);
-                if (header != null) {
-                    // entry could be zero bytes so we need to know that.
-                    if(header.ZipHeaderType == ZipHeaderType.LocalEntry) {
-                        bool isRecording = rewindableStream.IsRecording;
-                        if (!isRecording) {
-                            rewindableStream.StartRecording();
-                        }
-                        uint nextHeaderBytes = reader.ReadUInt32();
-                        header.HasData = !IsHeader(nextHeaderBytes);
-                        rewindableStream.Rewind(!isRecording);
+
+                //entry could be zero bytes so we need to know that.
+                if (header.ZipHeaderType == ZipHeaderType.LocalEntry)
+                {
+                    bool isRecording = rewindableStream.IsRecording;
+                    if (!isRecording)
+                    {
+                        rewindableStream.StartRecording();
                     }
+                    uint nextHeaderBytes = reader.ReadUInt32();
+                    header.HasData = !IsHeader(nextHeaderBytes);
+                    rewindableStream.Rewind(!isRecording);
                 }
                 yield return header;
             }

--- a/SharpCompress/Common/Zip/ZipHeaderFactory.cs
+++ b/SharpCompress/Common/Zip/ZipHeaderFactory.cs
@@ -87,7 +87,7 @@ namespace SharpCompress.Common.Zip
                         return entry;
                     }
                 default:
-                    return null;
+                    throw new NotSupportedException("Unknown header: " + headerBytes);
             }
         }
 


### PR DESCRIPTION
Revert commit that caused all non-zip files to be read entirely upon opening.
IsZipArchive() would read and process the entire file looking for a zip header.