### PR TITLE
Preserve File Timestamps with IReader

### DIFF
--- a/SharpCompress/Common/IEntry.Extensions.cs
+++ b/SharpCompress/Common/IEntry.Extensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+
+namespace SharpCompress.Common
+{
+    internal static class IEntryExtensions
+    {
+        internal static void PreserveExtractionOptions(this IEntry entry, string destinationFileName,
+                                                        ExtractOptions options)
+        {
+            if (options.HasFlag(ExtractOptions.PreserveFileTime) || options.HasFlag(ExtractOptions.PreserveAttributes))
+            {
+                FileInfo nf = new FileInfo(destinationFileName);
+                if (!nf.Exists)
+                {
+                    return;
+                }
+
+                // update file time to original packed time
+                if (options.HasFlag(ExtractOptions.PreserveFileTime))
+                {
+                    if (entry.CreatedTime.HasValue)
+                    {
+                        nf.CreationTime = entry.CreatedTime.Value;
+                    }
+
+                    if (entry.LastModifiedTime.HasValue)
+                    {
+                        nf.LastWriteTime = entry.LastModifiedTime.Value;
+                    }
+
+                    if (entry.LastAccessedTime.HasValue)
+                    {
+                        nf.LastAccessTime = entry.LastAccessedTime.Value;
+                    }
+                }
+
+                if (options.HasFlag(ExtractOptions.PreserveAttributes))
+                {
+                    if (entry.Attrib.HasValue)
+                    {
+                        nf.Attributes = (FileAttributes)System.Enum.ToObject(typeof(FileAttributes), entry.Attrib.Value);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SharpCompress/Reader/IReader.Extensions.cs
+++ b/SharpCompress/Reader/IReader.Extensions.cs
@@ -89,6 +89,7 @@ namespace SharpCompress.Reader
                 //    s.TransferTo(fs);
                 //}
             }
+            reader.Entry.PreserveExtractionOptions(destinationFileName, options);
         }
 #endif
     }

--- a/SharpCompress/SharpCompress.PortableTest.csproj
+++ b/SharpCompress/SharpCompress.PortableTest.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Common\FilePart.cs" />
     <Compile Include="Common\Entry.cs" />
     <Compile Include="Common\IEntry.cs" />
+	<Compile Include="Common\IEntry.Extensions.cs" />
     <Compile Include="Common\IVolume.cs" />
     <Compile Include="Common\Rar\RarCryptoWrapper.cs" />
     <Compile Include="Common\Rar\RarRijndael.Portable.cs" />

--- a/SharpCompress/SharpCompress.Unsigned.csproj
+++ b/SharpCompress/SharpCompress.Unsigned.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Common\FilePart.cs" />
     <Compile Include="Common\Entry.cs" />
     <Compile Include="Common\IEntry.cs" />
+	<Compile Include="Common\IEntry.Extensions.cs" />
     <Compile Include="Common\IVolume.cs" />
     <Compile Include="Common\Rar\RarCryptoWrapper.cs" />
     <Compile Include="Common\Rar\RarRijndael.cs" />

--- a/SharpCompress/SharpCompress.csproj
+++ b/SharpCompress/SharpCompress.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Common\FilePart.cs" />
     <Compile Include="Common\Entry.cs" />
     <Compile Include="Common\IEntry.cs" />
+	<Compile Include="Common\IEntry.Extensions.cs" />
     <Compile Include="Common\IVolume.cs" />
     <Compile Include="Common\Rar\RarCryptoWrapper.cs" />
     <Compile Include="Common\Rar\RarRijndael.cs" />


### PR DESCRIPTION
Previously only `IArchive` would use the `ExtractionOptions` enum to set the timestamps & attributes on extracted files. With this change the common logic is extracted out and used during both `IReader` and `IArchive` extraction.