### PR TITLE
	Bugfix for inflate algorithm cutting of the end of certain blocks

### DIFF
--- a/SharpCompress/Compressor/Deflate/Inflate.cs
+++ b/SharpCompress/Compressor/Deflate/Inflate.cs
@@ -895,11 +895,11 @@ namespace SharpCompress.Compressor.Deflate
                                 r = ZlibConstants.Z_OK;
                             else
                             {
-								// Handling missing trailing bit(s)
-								var tmp_tindex = (tree_index + (b & InternalInflateConstants.InflateMask[k]))*3;
-								if (k >= tree[tmp_tindex + 1])
-									break;
-								
+                                // Handling missing trailing bit(s)
+                                var tmp_tindex = (tree_index + (b & InternalInflateConstants.InflateMask[k]))*3;
+                                if (k >= tree[tmp_tindex + 1])
+                                    break;
+                                
                                 blocks.bitb = b;
                                 blocks.bitk = k;
                                 z.AvailableBytesIn = n;
@@ -1003,10 +1003,10 @@ namespace SharpCompress.Compressor.Deflate
                                 r = ZlibConstants.Z_OK;
                             else
                             {
-								// Handling missing trailing bit(s)
-								var tmp_tindex = (tree_index + (b & InternalInflateConstants.InflateMask[k]))*3;
-								if (k >= tree[tmp_tindex + 1])
-									break;
+                                // Handling missing trailing bit(s)
+                                var tmp_tindex = (tree_index + (b & InternalInflateConstants.InflateMask[k]))*3;
+                                if (k >= tree[tmp_tindex + 1])
+                                    break;
 
                                 blocks.bitb = b;
                                 blocks.bitk = k;

--- a/SharpCompress/Compressor/Deflate/Inflate.cs
+++ b/SharpCompress/Compressor/Deflate/Inflate.cs
@@ -895,6 +895,11 @@ namespace SharpCompress.Compressor.Deflate
                                 r = ZlibConstants.Z_OK;
                             else
                             {
+								// Handling missing trailing bit(s)
+								var tmp_tindex = (tree_index + (b & InternalInflateConstants.InflateMask[k]))*3;
+								if (k >= tree[tmp_tindex + 1])
+									break;
+								
                                 blocks.bitb = b;
                                 blocks.bitk = k;
                                 z.AvailableBytesIn = n;
@@ -998,6 +1003,11 @@ namespace SharpCompress.Compressor.Deflate
                                 r = ZlibConstants.Z_OK;
                             else
                             {
+								// Handling missing trailing bit(s)
+								var tmp_tindex = (tree_index + (b & InternalInflateConstants.InflateMask[k]))*3;
+								if (k >= tree[tmp_tindex + 1])
+									break;
+
                                 blocks.bitb = b;
                                 blocks.bitk = k;
                                 z.AvailableBytesIn = n;


### PR DESCRIPTION
After tracking down a case of a corrupt file being extracted, I was able to isolate the issue to a single 100kb file. If I compress this file with the maximum compression, and decompress it, I the loose the trailing 109 bytes.

I have finally tracked down the issue and made this patch. The problem is that the number of bits requested is larger than the number of bits required. For the `LEN` and `DIST` case, the number of required bits `k`  is set to `lbits` and `dbits` respectively. But if you look in the code below, you can see that they "consume" a variable number of bits, which in this case is less than `k`.

For most cases this is not a problem, but when the last code to be processed hits this case, the decompression stops prematurely and this cuts of a number of bytes. Other zip implementations (unarchiver, 7zip, etc) handles this correctly. This bug is also present in jzlib and the DotNetZip libraries, but not in the SharpZipLib/ICSharp.ZipLib.

If have a file that can reproduce this, but I am awaiting clarification to see if I can provide publicly it.

As a side note, the inflater file contains some of the worst code I have seen. It is a mix of states stored in objects and scope, copied around. There are almost no comments, tens of single digit variables, and the control flow is ridiculously hard to follow. In many places the same code is simply copy-pasted rather than being encapsulated, which is why there are two changes to the source code. In other words: if you have another zip implementation, I suggest you go with that :).