### PR TITLE
Fix various warnings

### DIFF
--- a/SharpCompress/Archive/Rar/FileInfoRarFilePart.cs
+++ b/SharpCompress/Archive/Rar/FileInfoRarFilePart.cs
@@ -6,12 +6,12 @@ namespace SharpCompress.Archive.Rar
 {
     internal class FileInfoRarFilePart : SeekableFilePart
     {
-        private readonly FileInfoRarArchiveVolume volume;
+        //private readonly FileInfoRarArchiveVolume volume;
 
         internal FileInfoRarFilePart(FileInfoRarArchiveVolume volume, MarkHeader mh, FileHeader fh, FileInfo fi)
             : base(mh, fh, volume.Stream, volume.Password)
         {
-            this.volume = volume;
+            //this.volume = volume;
             FileInfo = fi;
         }
 

--- a/SharpCompress/Archive/Rar/FileInfoRarFilePart.cs
+++ b/SharpCompress/Archive/Rar/FileInfoRarFilePart.cs
@@ -6,12 +6,9 @@ namespace SharpCompress.Archive.Rar
 {
     internal class FileInfoRarFilePart : SeekableFilePart
     {
-        //private readonly FileInfoRarArchiveVolume volume;
-
         internal FileInfoRarFilePart(FileInfoRarArchiveVolume volume, MarkHeader mh, FileHeader fh, FileInfo fi)
             : base(mh, fh, volume.Stream, volume.Password)
         {
-            //this.volume = volume;
             FileInfo = fi;
         }
 

--- a/SharpCompress/Common/GZip/GZipVolume.cs
+++ b/SharpCompress/Common/GZip/GZipVolume.cs
@@ -4,10 +4,6 @@ namespace SharpCompress.Common.GZip
 {
     public class GZipVolume : Volume
     {
-#if !PORTABLE && !NETFX_CORE
-        //private readonly FileInfo fileInfo;
-#endif
-
         public GZipVolume(Stream stream, Options options)
             : base(stream, options)
         {
@@ -17,7 +13,6 @@ namespace SharpCompress.Common.GZip
         public GZipVolume(FileInfo fileInfo, Options options)
             : base(fileInfo.OpenRead(), options)
         {
-            //this.fileInfo = fileInfo;
         }
 #endif
 

--- a/SharpCompress/Common/GZip/GZipVolume.cs
+++ b/SharpCompress/Common/GZip/GZipVolume.cs
@@ -5,7 +5,7 @@ namespace SharpCompress.Common.GZip
     public class GZipVolume : Volume
     {
 #if !PORTABLE && !NETFX_CORE
-        private readonly FileInfo fileInfo;
+        //private readonly FileInfo fileInfo;
 #endif
 
         public GZipVolume(Stream stream, Options options)
@@ -17,7 +17,7 @@ namespace SharpCompress.Common.GZip
         public GZipVolume(FileInfo fileInfo, Options options)
             : base(fileInfo.OpenRead(), options)
         {
-            this.fileInfo = fileInfo;
+            //this.fileInfo = fileInfo;
         }
 #endif
 

--- a/SharpCompress/Common/SevenZip/ArchiveReader.cs
+++ b/SharpCompress/Common/SevenZip/ArchiveReader.cs
@@ -1198,14 +1198,12 @@ namespace SharpCompress.Common.SevenZip
         private class FolderUnpackStream : Stream
         {
             private ArchiveDatabase _db;
-            //private int _otherIndex;
             private int _startIndex;
             private List<bool> _extractStatuses;
 
             public FolderUnpackStream(ArchiveDatabase db, int p, int startIndex, List<bool> list)
             {
                 this._db = db;
-                //this._otherIndex = p;
                 this._startIndex = startIndex;
                 this._extractStatuses = list;
             }
@@ -1277,7 +1275,6 @@ namespace SharpCompress.Common.SevenZip
             {
                 //bool skip = !_extractStatuses[_currentIndex];
                 int index = _startIndex + _currentIndex;
-                //int realIndex = _otherIndex + index;
                 //string filename = @"D:\_testdump\" + _db.Files[index].Name;
                 //Directory.CreateDirectory(Path.GetDirectoryName(filename));
                 //_stream = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Delete);

--- a/SharpCompress/Common/SevenZip/ArchiveReader.cs
+++ b/SharpCompress/Common/SevenZip/ArchiveReader.cs
@@ -1198,14 +1198,14 @@ namespace SharpCompress.Common.SevenZip
         private class FolderUnpackStream : Stream
         {
             private ArchiveDatabase _db;
-            private int _otherIndex;
+            //private int _otherIndex;
             private int _startIndex;
             private List<bool> _extractStatuses;
 
             public FolderUnpackStream(ArchiveDatabase db, int p, int startIndex, List<bool> list)
             {
                 this._db = db;
-                this._otherIndex = p;
+                //this._otherIndex = p;
                 this._startIndex = startIndex;
                 this._extractStatuses = list;
             }
@@ -1275,9 +1275,9 @@ namespace SharpCompress.Common.SevenZip
 
             private void OpenFile()
             {
-                bool skip = !_extractStatuses[_currentIndex];
+                //bool skip = !_extractStatuses[_currentIndex];
                 int index = _startIndex + _currentIndex;
-                int realIndex = _otherIndex + index;
+                //int realIndex = _otherIndex + index;
                 //string filename = @"D:\_testdump\" + _db.Files[index].Name;
                 //Directory.CreateDirectory(Path.GetDirectoryName(filename));
                 //_stream = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Delete);

--- a/SharpCompress/Common/SevenZip/ArchiveReader.cs
+++ b/SharpCompress/Common/SevenZip/ArchiveReader.cs
@@ -1273,11 +1273,7 @@ namespace SharpCompress.Common.SevenZip
 
             private void OpenFile()
             {
-                //bool skip = !_extractStatuses[_currentIndex];
                 int index = _startIndex + _currentIndex;
-                //string filename = @"D:\_testdump\" + _db.Files[index].Name;
-                //Directory.CreateDirectory(Path.GetDirectoryName(filename));
-                //_stream = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.Delete);
 #if DEBUG
                 Log.WriteLine(_db.Files[index].Name);
 #endif

--- a/SharpCompress/Common/SevenZip/DataReader.cs
+++ b/SharpCompress/Common/SevenZip/DataReader.cs
@@ -34,7 +34,7 @@ namespace SharpCompress.Common.SevenZip
         #region Variables
 
         private byte[] _buffer;
-        private int _origin;
+        //private int _origin;
         private int _offset;
         private int _ending;
 
@@ -45,7 +45,7 @@ namespace SharpCompress.Common.SevenZip
         public DataReader(byte[] buffer, int offset, int length)
         {
             _buffer = buffer;
-            _origin = offset;
+            //_origin = offset;
             _offset = offset;
             _ending = offset + length;
         }

--- a/SharpCompress/Common/SevenZip/DataReader.cs
+++ b/SharpCompress/Common/SevenZip/DataReader.cs
@@ -34,7 +34,6 @@ namespace SharpCompress.Common.SevenZip
         #region Variables
 
         private byte[] _buffer;
-        //private int _origin;
         private int _offset;
         private int _ending;
 
@@ -45,7 +44,6 @@ namespace SharpCompress.Common.SevenZip
         public DataReader(byte[] buffer, int offset, int length)
         {
             _buffer = buffer;
-            //_origin = offset;
             _offset = offset;
             _ending = offset + length;
         }

--- a/SharpCompress/Compressor/LZMA/Bcj2DecoderStream.cs
+++ b/SharpCompress/Compressor/LZMA/Bcj2DecoderStream.cs
@@ -99,7 +99,6 @@ namespace SharpCompress.Compressor.LZMA
         private RangeDecoder mRangeDecoder;
         private StatusDecoder[] mStatusDecoder;
         private long mWritten;
-        //private long mLimit;
         private IEnumerator<byte> mIter;
         private bool mFinished;
         private bool isDisposed;
@@ -112,7 +111,6 @@ namespace SharpCompress.Compressor.LZMA
             if (streams.Length != 4)
                 throw new NotSupportedException();
 
-            //mLimit = limit;
             mMainStream = streams[0];
             mCallStream = streams[1];
             mJumpStream = streams[2];

--- a/SharpCompress/Compressor/LZMA/Bcj2DecoderStream.cs
+++ b/SharpCompress/Compressor/LZMA/Bcj2DecoderStream.cs
@@ -99,7 +99,7 @@ namespace SharpCompress.Compressor.LZMA
         private RangeDecoder mRangeDecoder;
         private StatusDecoder[] mStatusDecoder;
         private long mWritten;
-        private long mLimit;
+        //private long mLimit;
         private IEnumerator<byte> mIter;
         private bool mFinished;
         private bool isDisposed;
@@ -112,7 +112,7 @@ namespace SharpCompress.Compressor.LZMA
             if (streams.Length != 4)
                 throw new NotSupportedException();
 
-            mLimit = limit;
+            //mLimit = limit;
             mMainStream = streams[0];
             mCallStream = streams[1];
             mJumpStream = streams[2];


### PR DESCRIPTION
When building the solution with Xamarin Studio on OSX, it complains about a number of unused fields and variables.

Commenting these out has no ill effect. I can make an update with the fields deleted if you like.