### PR TITLE
Support tars with global extended headers

### DIFF
--- a/SharpCompress/Common/Tar/Headers/TarHeader.cs
+++ b/SharpCompress/Common/Tar/Headers/TarHeader.cs
@@ -22,6 +22,7 @@ namespace SharpCompress.Common.Tar.Headers
         LongName = (byte) 'L',
         SparseFile = (byte) 'S',
         VolumeHeader = (byte) 'V',
+        GlobalExtendedHeader = (byte) 'g',
     }
 
     internal class TarHeader


### PR DESCRIPTION
Fixes https://github.com/adamhathcock/sharpcompress/issues/128