### PR TITLE
Fix IsRarFile() StreamingMode

### DIFF
--- a/SharpCompress/Archive/ArchiveFactory.cs
+++ b/SharpCompress/Archive/ArchiveFactory.cs
@@ -6,6 +6,7 @@ using SharpCompress.Archive.SevenZip;
 using SharpCompress.Archive.Tar;
 using SharpCompress.Archive.Zip;
 using SharpCompress.Common;
+using SharpCompress.IO;
 
 namespace SharpCompress.Archive
 {
@@ -43,7 +44,7 @@ namespace SharpCompress.Archive
                 return GZipArchive.Open(stream, options);
             }
             stream.Seek(0, SeekOrigin.Begin);
-            if (RarArchive.IsRarFile(stream, options))
+            if (RarArchive.IsRarFile(stream, StreamingMode.Seekable, options))
             {
                stream.Seek(0, SeekOrigin.Begin);
                return RarArchive.Open(stream, options);
@@ -138,7 +139,7 @@ namespace SharpCompress.Archive
                     return GZipArchive.Open(fileInfo, options);
                 }
                 stream.Seek(0, SeekOrigin.Begin);
-                if (RarArchive.IsRarFile(stream, options))
+                if (RarArchive.IsRarFile(stream, StreamingMode.Seekable, options))
                 {
                    stream.Dispose();
                    return RarArchive.Open(fileInfo, options);

--- a/SharpCompress/Archive/Rar/RarArchive.cs
+++ b/SharpCompress/Archive/Rar/RarArchive.cs
@@ -149,9 +149,14 @@ namespace SharpCompress.Archive.Rar
 
         public static bool IsRarFile(Stream stream, Options options)
         {
+            return IsRarFile(stream, StreamingMode.Seekable, options);
+        }
+
+        public static bool IsRarFile(Stream stream, StreamingMode streamingMode, Options options)
+        {
             try
             {
-                var headerFactory = new RarHeaderFactory(StreamingMode.Seekable, options);
+                var headerFactory = new RarHeaderFactory(streamingMode, options);
                 var markHeader = headerFactory.ReadHeaders(stream).FirstOrDefault() as MarkHeader;
                 return markHeader != null && markHeader.IsValid();
             }

--- a/SharpCompress/IO/StreamingMode.cs
+++ b/SharpCompress/IO/StreamingMode.cs
@@ -1,6 +1,6 @@
 ﻿namespace SharpCompress.IO
 {
-    internal enum StreamingMode
+    public enum StreamingMode
     {
         Streaming,
         Seekable,

--- a/SharpCompress/Reader/ReaderFactory.cs
+++ b/SharpCompress/Reader/ReaderFactory.cs
@@ -62,7 +62,7 @@ namespace SharpCompress.Reader
             }
 
             rewindableStream.Rewind(false);
-            if (RarArchive.IsRarFile(rewindableStream, options))
+            if (RarArchive.IsRarFile(rewindableStream, StreamingMode.Streaming, options))
             {
                 rewindableStream.Rewind(true);
                 return RarReader.Open(rewindableStream, options);


### PR DESCRIPTION
IsRarFile() no longer assumes seekable stream. This caused IsRarFile()
to break RewindableStreams when testing certain files, causing
ReaderFactory to fail to open certain tars.

Fixes https://github.com/adamhathcock/sharpcompress/issues/130