### PR TITLE
Make PpmdProperties lazy to avoid unnecessary allocations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The major feature is support for non-seekable streams so large files can be proc
 ## Need Help?
 Post Issues on Github!
 
-Check the [Supported Formats](FORMATS.md) and [basic usage.](USAGE.md)
+Check the [Supported Formats](FORMATS.md) and [Basic Usage.](USAGE.md)
 
 ## A Simple Request
 

--- a/src/SharpCompress/Compressors/PPMd/PpmdProperties.cs
+++ b/src/SharpCompress/Compressors/PPMd/PpmdProperties.cs
@@ -3,13 +3,6 @@ using SharpCompress.Converters;
 
 namespace SharpCompress.Compressors.PPMd
 {
-    public enum PpmdVersion
-    {
-        H,
-        H7z,
-        I1
-    }
-
     public class PpmdProperties
     {
         public PpmdVersion Version = PpmdVersion.I1;

--- a/src/SharpCompress/Compressors/PPMd/PpmdVersion.cs
+++ b/src/SharpCompress/Compressors/PPMd/PpmdVersion.cs
@@ -1,0 +1,9 @@
+﻿namespace SharpCompress.Compressors.PPMd
+{
+    public enum PpmdVersion
+    {
+        H,
+        H7z,
+        I1
+    }
+}

--- a/src/SharpCompress/Writers/Zip/ZipWriter.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriter.cs
@@ -19,7 +19,7 @@ namespace SharpCompress.Writers.Zip
     {
         private readonly CompressionType compressionType;
         private readonly CompressionLevel compressionLevel;
-        private readonly PpmdProperties ppmdProperties = new PpmdProperties(); // Caching properties to speed up PPMd
+        private readonly Lazy<PpmdProperties> ppmdProperties = new Lazy<PpmdProperties>(() => new PpmdProperties()); // Caching properties to speed up PPMd
         private readonly List<ZipCentralDirectoryEntry> entries = new List<ZipCentralDirectoryEntry>();
         private readonly string zipComment;
         private long streamPosition;
@@ -252,8 +252,8 @@ namespace SharpCompress.Writers.Zip
                     }
                     case ZipCompressionMethod.PPMd:
                     {
-                        counting.Write(writer.ppmdProperties.Properties, 0, 2);
-                        return new PpmdStream(writer.ppmdProperties, counting, true);
+                        counting.Write(writer.ppmdProperties.Value.Properties, 0, 2);
+                        return new PpmdStream(writer.ppmdProperties.Value, counting, true);
                     }
                     default:
                     {

--- a/src/SharpCompress/Writers/Zip/ZipWriter.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriter.cs
@@ -19,10 +19,10 @@ namespace SharpCompress.Writers.Zip
     {
         private readonly CompressionType compressionType;
         private readonly CompressionLevel compressionLevel;
-        private readonly Lazy<PpmdProperties> ppmdProperties = new Lazy<PpmdProperties>(() => new PpmdProperties()); // Caching properties to speed up PPMd
         private readonly List<ZipCentralDirectoryEntry> entries = new List<ZipCentralDirectoryEntry>();
         private readonly string zipComment;
         private long streamPosition;
+        private PpmdProperties ppmdProps;
 
         public ZipWriter(Stream destination, ZipWriterOptions zipWriterOptions)
             : base(ArchiveType.Zip)
@@ -32,6 +32,18 @@ namespace SharpCompress.Writers.Zip
             compressionType = zipWriterOptions.CompressionType;
             compressionLevel = zipWriterOptions.DeflateCompressionLevel;
             InitalizeStream(destination, !zipWriterOptions.LeaveStreamOpen);
+        }
+
+        private PpmdProperties PpmdProperties
+        {
+            get
+            {
+                if (ppmdProps == null)
+                {
+                    ppmdProps = new PpmdProperties();
+                }
+                return ppmdProps;
+            }
         }
 
         protected override void Dispose(bool isDisposing)
@@ -252,8 +264,8 @@ namespace SharpCompress.Writers.Zip
                     }
                     case ZipCompressionMethod.PPMd:
                     {
-                        counting.Write(writer.ppmdProperties.Value.Properties, 0, 2);
-                        return new PpmdStream(writer.ppmdProperties.Value, counting, true);
+                        counting.Write(writer.PpmdProperties.Properties, 0, 2);
+                        return new PpmdStream(writer.PpmdProperties, counting, true);
                     }
                     default:
                     {


### PR DESCRIPTION
Fixes https://github.com/adamhathcock/sharpcompress/issues/182