### PR TITLE
Zip64 extending information and ZipReader

### DIFF
--- a/src/SharpCompress/Common/Zip/Headers/DirectoryEntryHeader.cs
+++ b/src/SharpCompress/Common/Zip/Headers/DirectoryEntryHeader.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 
 namespace SharpCompress.Common.Zip.Headers
@@ -41,6 +42,23 @@ namespace SharpCompress.Common.Zip.Headers
             {
                 Name = ((ExtraUnicodePathExtraField)unicodePathExtra).UnicodeName;
             }
+
+            var zip64ExtraData = Extra.OfType<Zip64ExtendedInformationExtraField>().FirstOrDefault();
+            if (zip64ExtraData != null)
+            {
+                if (CompressedSize == uint.MaxValue)
+                {
+                    CompressedSize = zip64ExtraData.CompressedSize;
+                }
+                if (UncompressedSize == uint.MaxValue)
+                {
+                    UncompressedSize = zip64ExtraData.UncompressedSize;
+                }
+                if (RelativeOffsetOfEntryHeader == uint.MaxValue)
+                {
+                    RelativeOffsetOfEntryHeader = zip64ExtraData.RelativeOffsetOfEntryHeader;
+                }
+            }
         }
 
         internal override void Write(BinaryWriter writer)
@@ -77,7 +95,7 @@ namespace SharpCompress.Common.Zip.Headers
 
         public ushort VersionNeededToExtract { get; set; }
 
-        public uint RelativeOffsetOfEntryHeader { get; set; }
+        public long RelativeOffsetOfEntryHeader { get; set; }
 
         public uint ExternalFileAttributes { get; set; }
 

--- a/src/SharpCompress/Common/Zip/Headers/LocalEntryHeader.cs
+++ b/src/SharpCompress/Common/Zip/Headers/LocalEntryHeader.cs
@@ -32,6 +32,19 @@ namespace SharpCompress.Common.Zip.Headers
             {
                 Name = ((ExtraUnicodePathExtraField)unicodePathExtra).UnicodeName;
             }
+
+            var zip64ExtraData = Extra.OfType<Zip64ExtendedInformationExtraField>().FirstOrDefault();
+            if (zip64ExtraData != null)
+            {
+                if (CompressedSize == uint.MaxValue)
+                {
+                    CompressedSize = zip64ExtraData.CompressedSize;
+                }
+                if (UncompressedSize == uint.MaxValue)
+                {
+                    UncompressedSize = zip64ExtraData.UncompressedSize;
+                }
+            }
         }
 
         internal override void Write(BinaryWriter writer)

--- a/src/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
@@ -28,7 +28,7 @@ namespace SharpCompress.Common.Zip
                 ZipHeader header = null;
                 BinaryReader reader = new BinaryReader(rewindableStream);
                 if (lastEntryHeader != null &&
-                    FlagUtility.HasFlag(lastEntryHeader.Flags, HeaderFlags.UsePostDataDescriptor))
+                    (FlagUtility.HasFlag(lastEntryHeader.Flags, HeaderFlags.UsePostDataDescriptor) || lastEntryHeader.IsZip64))
                 {
                     reader = (lastEntryHeader.Part as StreamingZipFilePart).FixStreamedFileLocation(ref rewindableStream);
                     long? pos = rewindableStream.CanSeek ? (long?)rewindableStream.Position : null;

--- a/src/SharpCompress/Common/Zip/ZipFilePart.cs
+++ b/src/SharpCompress/Common/Zip/ZipFilePart.cs
@@ -51,7 +51,7 @@ namespace SharpCompress.Common.Zip
 
         protected abstract Stream CreateBaseStream();
 
-        protected bool LeaveStreamOpen { get { return FlagUtility.HasFlag(Header.Flags, HeaderFlags.UsePostDataDescriptor); } }
+        protected bool LeaveStreamOpen { get { return FlagUtility.HasFlag(Header.Flags, HeaderFlags.UsePostDataDescriptor) || Header.IsZip64; } }
 
         protected Stream CreateDecompressionStream(Stream stream)
         {

--- a/test/SharpCompress.Test/Zip/ZipReaderTests.cs
+++ b/test/SharpCompress.Test/Zip/ZipReaderTests.cs
@@ -14,6 +14,13 @@ namespace SharpCompress.Test
         {
             UseExtensionInsteadOfNameToVerify = true;
         }
+
+        [Fact]
+        public void Zip_Zip64_Streamed_Read()
+        {
+            Read("Zip.Zip64.zip", CompressionType.Deflate);
+        }
+
         [Fact]
         public void Zip_ZipX_Streamed_Read()
         {


### PR DESCRIPTION
This PR adds support for reading the zip64 extended information field, which wasn't required for my previous test files, but probably is required in general for zip64 archives (the tripping point in my testing was new files starting beyond the 4Gb point of my archive).

Adding this support also instantly fixed the trouble I was having with ZipReader support, so that has been included.