### PR TITLE
Fix invalid headers

### DIFF
--- a/src/SharpCompress/Common/Zip/Headers/DirectoryEntryHeader.cs
+++ b/src/SharpCompress/Common/Zip/Headers/DirectoryEntryHeader.cs
@@ -70,7 +70,7 @@ namespace SharpCompress.Common.Zip.Headers
             writer.Write(LastModifiedTime);
             writer.Write(LastModifiedDate);
             writer.Write(Crc);
-			writer.Write((uint)CompressedSize);
+            writer.Write((uint)CompressedSize);
             writer.Write((uint)UncompressedSize);
 
             byte[] nameBytes = EncodeString(Name);

--- a/src/SharpCompress/Common/Zip/Headers/DirectoryEntryHeader.cs
+++ b/src/SharpCompress/Common/Zip/Headers/DirectoryEntryHeader.cs
@@ -70,8 +70,8 @@ namespace SharpCompress.Common.Zip.Headers
             writer.Write(LastModifiedTime);
             writer.Write(LastModifiedDate);
             writer.Write(Crc);
-            writer.Write(CompressedSize);
-            writer.Write(UncompressedSize);
+			writer.Write((uint)CompressedSize);
+            writer.Write((uint)UncompressedSize);
 
             byte[] nameBytes = EncodeString(Name);
             writer.Write((ushort)nameBytes.Length);

--- a/src/SharpCompress/Common/Zip/Headers/LocalEntryHeader.cs
+++ b/src/SharpCompress/Common/Zip/Headers/LocalEntryHeader.cs
@@ -55,8 +55,8 @@ namespace SharpCompress.Common.Zip.Headers
             writer.Write(LastModifiedTime);
             writer.Write(LastModifiedDate);
             writer.Write(Crc);
-            writer.Write(CompressedSize);
-            writer.Write(UncompressedSize);
+			writer.Write((uint)CompressedSize);
+			writer.Write((uint)UncompressedSize);
 
             byte[] nameBytes = EncodeString(Name);
 

--- a/src/SharpCompress/Common/Zip/Headers/LocalEntryHeader.cs
+++ b/src/SharpCompress/Common/Zip/Headers/LocalEntryHeader.cs
@@ -55,8 +55,8 @@ namespace SharpCompress.Common.Zip.Headers
             writer.Write(LastModifiedTime);
             writer.Write(LastModifiedDate);
             writer.Write(Crc);
-			writer.Write((uint)CompressedSize);
-			writer.Write((uint)UncompressedSize);
+            writer.Write((uint)CompressedSize);
+            writer.Write((uint)UncompressedSize);
 
             byte[] nameBytes = EncodeString(Name);
 


### PR DESCRIPTION
This fixes a bug introduced with 6be6ef0b5c3ed6a4d40d00c8fb133518e75e4a6f.

Bad news is that all zip files written with 0.15.1 are semi-broken.
That is, their filenames are garbled, but content is recoverable.