### PR TITLE
verify RAR crc on header and file data

### DIFF
--- a/src/SharpCompress/Common/Rar/Headers/RarHeaderFactory.cs
+++ b/src/SharpCompress/Common/Rar/Headers/RarHeaderFactory.cs
@@ -129,7 +129,7 @@ namespace SharpCompress.Common.Rar.Headers
                 reader.InitializeAes(salt);
             }
 #else
-            var reader = new MarkingBinaryReader(stream);
+            var reader = new RarCrcBinaryReader(stream);
 
 #endif
 

--- a/src/SharpCompress/Common/Rar/RarCrcBinaryReader.cs
+++ b/src/SharpCompress/Common/Rar/RarCrcBinaryReader.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using SharpCompress.Compressors.Rar;
+using SharpCompress.IO;
+
+namespace SharpCompress.Common.Rar {
+    internal class RarCrcBinaryReader : MarkingBinaryReader {
+        private uint currentCrc;
+
+        public RarCrcBinaryReader(Stream stream) : base(stream)
+        {
+        }
+
+        public ushort GetCrc() 
+        {
+            return (ushort)~this.currentCrc;
+        }
+
+        public void ResetCrc()
+        {
+            this.currentCrc = 0xffffffff;
+        }
+
+        protected void UpdateCrc(byte b) 
+        {
+            this.currentCrc = RarCRC.CheckCrc(this.currentCrc, b);
+        }
+
+        protected byte[] ReadBytesNoCrc(int count)
+        {
+            return base.ReadBytes(count);
+        }
+
+        public override byte[] ReadBytes(int count)
+        {
+            var result = base.ReadBytes(count);
+            this.currentCrc = RarCRC.CheckCrc(this.currentCrc, result, 0, result.Length);
+            return result;
+        }
+    }
+}

--- a/src/SharpCompress/Compressors/Rar/MultiVolumeReadOnlyStream.cs
+++ b/src/SharpCompress/Compressors/Rar/MultiVolumeReadOnlyStream.cs
@@ -19,6 +19,7 @@ namespace SharpCompress.Compressors.Rar
 
         private long currentPartTotalReadBytes;
         private long currentEntryTotalReadBytes;
+        private uint currentCrc;
 
         internal MultiVolumeReadOnlyStream(IEnumerable<RarFilePart> parts, IExtractionListener streamListener)
         {
@@ -58,6 +59,8 @@ namespace SharpCompress.Compressors.Rar
             currentStream = filePartEnumerator.Current.GetCompressedStream();
 
             currentPartTotalReadBytes = 0;
+
+            currentCrc = filePartEnumerator.Current.FileHeader.FileCRC;
 
             streamListener.FireFilePartExtractionBegin(filePartEnumerator.Current.FilePartName,
                                                        filePartEnumerator.Current.FileHeader.CompressedSize,
@@ -118,6 +121,8 @@ namespace SharpCompress.Compressors.Rar
         public override bool CanSeek { get { return false; } }
 
         public override bool CanWrite { get { return false; } }
+
+        public uint CurrentCrc { get { return this.currentCrc; } }
 
         public override void Flush()
         {

--- a/src/SharpCompress/Compressors/Rar/RarCRC.cs
+++ b/src/SharpCompress/Compressors/Rar/RarCRC.cs
@@ -6,6 +6,10 @@ namespace SharpCompress.Compressors.Rar
     {
         private static readonly uint[] crcTab;
 
+        public static uint CheckCrc(uint startCrc, byte b) {
+                return (crcTab[((int) ((int) startCrc ^ (int) b)) & 0xff] ^ (startCrc >> 8));
+        }
+
         public static uint CheckCrc(uint startCrc, byte[] data, int offset, int count)
         {
             int size = Math.Min(data.Length - offset, count);

--- a/src/SharpCompress/Compressors/Rar/RarCrcStream.cs
+++ b/src/SharpCompress/Compressors/Rar/RarCrcStream.cs
@@ -1,0 +1,42 @@
+using System.IO;
+using SharpCompress.Common;
+using SharpCompress.Common.Rar.Headers;
+
+namespace SharpCompress.Compressors.Rar {
+    internal class RarCrcStream : RarStream {
+        private readonly MultiVolumeReadOnlyStream readStream;
+        private uint currentCrc;
+
+        public RarCrcStream(Unpack unpack, FileHeader fileHeader, MultiVolumeReadOnlyStream readStream) : base(unpack, fileHeader, readStream)
+        {
+            this.readStream = readStream;
+            ResetCrc();
+        }
+
+        public uint GetCrc()
+        {
+            return ~this.currentCrc;
+        }
+
+        public void ResetCrc()
+        {
+            this.currentCrc = 0xffffffff;
+        }
+
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var result = base.Read(buffer, offset, count);
+            if (result != 0) 
+            {
+                this.currentCrc = RarCRC.CheckCrc(this.currentCrc, buffer, offset, result);
+            } 
+            else if (GetCrc() != this.readStream.CurrentCrc)
+            {
+                // NOTE: we use the last FileHeader in a multipart volume to check CRC
+                throw new InvalidFormatException("file crc mismatch");
+            }
+            return result;
+        }
+    }
+}

--- a/src/SharpCompress/IO/MarkingBinaryReader.cs
+++ b/src/SharpCompress/IO/MarkingBinaryReader.cs
@@ -12,9 +12,9 @@ namespace SharpCompress.IO
         {
         }
 
-        public long CurrentReadByteCount { get; private set; }
+        public virtual long CurrentReadByteCount { get; protected set; }
 
-        public void Mark()
+        public virtual void Mark()
         {
             CurrentReadByteCount = 0;
         }

--- a/src/SharpCompress/Readers/Rar/RarReader.cs
+++ b/src/SharpCompress/Readers/Rar/RarReader.cs
@@ -69,7 +69,7 @@ namespace SharpCompress.Readers.Rar
 
         protected override EntryStream GetEntryStream()
         {
-            return CreateEntryStream(new RarStream(pack, Entry.FileHeader,
+            return CreateEntryStream(new RarCrcStream(pack, Entry.FileHeader,
                                                    new MultiVolumeReadOnlyStream(
                                                                                  CreateFilePartEnumerableForCurrentEntry().Cast<RarFilePart>(), this)));
         }


### PR DESCRIPTION
verify rar file crc checksums:
- header records
- decompressed file payload

tested and works with:
- typical rar files
- rar files with encrypted headers
- multipart rar files