### PR TITLE
Default zip ver to 20 (deflate/encyption), fixes #164

### DIFF
--- a/src/SharpCompress/Writers/Zip/ZipCentralDirectoryEntry.cs
+++ b/src/SharpCompress/Writers/Zip/ZipCentralDirectoryEntry.cs
@@ -30,7 +30,7 @@ namespace SharpCompress.Writers.Zip
             var decompressedvalue = zip64 ? uint.MaxValue : (uint)Decompressed;
             var headeroffsetvalue = zip64 ? uint.MaxValue : (uint)HeaderOffset;
             var extralength = zip64 ? (2 + 2 + 8 + 8 + 8 + 4) : 0;
-            var version = (byte)(zip64 ? 45 : 10);
+            var version = (byte)(zip64 ? 45 : 20); // Version 20 required for deflate/encryption
 
             HeaderFlags flags = HeaderFlags.UTF8;
             if (!outputStream.CanSeek)


### PR DESCRIPTION
Sets the default level of '20' for zip files in the ZipCentralDirectoryBlock to match '20' used in Zip Local File Headers at https://github.com/adamhathcock/sharpcompress/blob/master/src/SharpCompress/Writers/Zip/ZipWriter.cs#L162

This makes Microsoft's compression.io library used by NuGet happy (and possibly some other tools)