### PR TITLE
Fix for Issue #250: remove extra build flags for .NET 3.5

### DIFF
--- a/src/SharpCompress/SharpCompress.csproj
+++ b/src/SharpCompress/SharpCompress.csproj
@@ -28,8 +28,4 @@
     <DefineConstants>$(DefineConstants);NO_FILE;NO_CRYPTO;SILVERLIGHT</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net35'">
-    <DefineConstants>$(DefineConstants);NO_FILE;NO_CRYPTO;SILVERLIGHT</DefineConstants>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
This re-enables WinZipAes support for .NET 3.5.