### PR TITLE
Fix Skipping when compressed size is unknown (fallback to decompressing)

### DIFF
--- a/src/SharpCompress/Readers/AbstractReader.cs
+++ b/src/SharpCompress/Readers/AbstractReader.cs
@@ -143,8 +143,9 @@ namespace SharpCompress.Readers
 
         private void Skip()
         {
-            if (!Entry.IsSolid)
+            if (!Entry.IsSolid && Entry.CompressedSize > 0)
             {
+                //not solid and has a known compressed size then we can skip raw bytes.
                 var rawStream = Entry.Parts.First().GetRawStream();
 
                 if (rawStream != null)
@@ -155,13 +156,15 @@ namespace SharpCompress.Readers
                         rawStream.Read(skipBuffer, 0, skipBuffer.Length);
                     }
                     rawStream.Read(skipBuffer, 0, (int)(bytesToAdvance % skipBuffer.Length));
-                    return;
                 }
             }
-            using (var s = OpenEntryStream())
+            else //don't know the size so we have to try to decompress to skip
             {
-                while (s.Read(skipBuffer, 0, skipBuffer.Length) > 0)
+                using (var s = OpenEntryStream())
                 {
+                    while (s.Read(skipBuffer, 0, skipBuffer.Length) > 0)
+                    {
+                    }
                 }
             }
         }

--- a/tests/SharpCompress.Test/Zip/ZipReaderTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipReaderTests.cs
@@ -48,6 +48,32 @@ namespace SharpCompress.Test.Zip
             Read("Zip.deflate.dd.zip", CompressionType.Deflate);
         }
         [Fact]
+        public void Zip_Deflate_Streamed_Skip()
+        {
+            using (Stream stream = new ForwardOnlyStream(File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))))
+            using (IReader reader = ReaderFactory.Open(stream))
+            {
+                ResetScratch();
+                int x = 0;
+                while (reader.MoveToNextEntry())
+                {
+                    if (!reader.Entry.IsDirectory)
+                    {
+                        x++;
+                        if (x % 2 == 0)
+                        {
+                            reader.WriteEntryToDirectory(SCRATCH_FILES_PATH,
+                                                         new ExtractionOptions()
+                                                         {
+                                                             ExtractFullPath = true,
+                                                             Overwrite = true
+                                                         });
+                        }
+                    }
+                }
+            }
+        }
+        [Fact]
         public void Zip_Deflate_Read()
         {
             Read("Zip.deflate.zip", CompressionType.Deflate);


### PR DESCRIPTION
Fixes https://github.com/adamhathcock/sharpcompress/issues/162