### PR TITLE
Use Skip and ReadFully extension methods where possible.

### DIFF
--- a/src/SharpCompress/Archives/GZip/GZipArchive.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchive.cs
@@ -106,15 +106,9 @@ namespace SharpCompress.Archives.GZip
         {
             // read the header on the first read
             byte[] header = new byte[10];
-            int n = stream.Read(header, 0, header.Length);
 
             // workitem 8501: handle edge case (decompress empty stream)
-            if (n == 0)
-            {
-                return false;
-            }
-
-            if (n != 10)
+            if (!stream.ReadFully(header))
             {
                 return false;
             }

--- a/src/SharpCompress/Common/GZip/GZipFilePart.cs
+++ b/src/SharpCompress/Common/GZip/GZipFilePart.cs
@@ -70,11 +70,12 @@ namespace SharpCompress.Common.GZip
 
                 Int16 extraLength = (Int16)(header[0] + header[1] * 256);
                 byte[] extra = new byte[extraLength];
-                n = stream.Read(extra, 0, extra.Length);
-                if (n != extraLength)
+                
+                if (!stream.ReadFully(extra))
                 {
                     throw new ZlibException("Unexpected end-of-file reading GZIP header.");
                 }
+                n = extraLength;
             }
             if ((header[3] & 0x08) == 0x08)
             {

--- a/src/SharpCompress/Common/Zip/Headers/ZipFileEntry.cs
+++ b/src/SharpCompress/Common/Zip/Headers/ZipFileEntry.cs
@@ -88,7 +88,7 @@ namespace SharpCompress.Common.Zip.Headers
             }
 
             var buffer = new byte[12];
-            archiveStream.Read(buffer, 0, 12);
+            archiveStream.ReadFully(buffer);
 
             PkwareTraditionalEncryptionData encryptionData = PkwareTraditionalEncryptionData.ForRead(Password, this, buffer);
 

--- a/src/SharpCompress/Common/Zip/StreamingZipFilePart.cs
+++ b/src/SharpCompress/Common/Zip/StreamingZipFilePart.cs
@@ -45,7 +45,7 @@ namespace SharpCompress.Common.Zip
                 {
                     decompressionStream = GetCompressedStream();
                 }
-                decompressionStream.SkipAll();
+                decompressionStream.Skip();
 
                 DeflateStream deflateStream = decompressionStream as DeflateStream;
                 if (deflateStream != null)

--- a/src/SharpCompress/Common/Zip/WinzipAesCryptoStream.cs
+++ b/src/SharpCompress/Common/Zip/WinzipAesCryptoStream.cs
@@ -78,7 +78,7 @@ namespace SharpCompress.Common.Zip
             {
                 //read out last 10 auth bytes
                 var ten = new byte[10];
-                stream.Read(ten, 0, 10);
+                stream.ReadFully(ten);
                 stream.Dispose();
             }
         }

--- a/src/SharpCompress/Common/Zip/ZipFilePart.cs
+++ b/src/SharpCompress/Common/Zip/ZipFilePart.cs
@@ -88,7 +88,7 @@ namespace SharpCompress.Common.Zip
                 case ZipCompressionMethod.PPMd:
                 {
                     var props = new byte[2];
-                    stream.Read(props, 0, props.Length);
+                    stream.ReadFully(props);
                     return new PpmdStream(new PpmdProperties(props), stream, false);
                 }
                 case ZipCompressionMethod.WinzipAes:
@@ -175,7 +175,6 @@ namespace SharpCompress.Common.Zip
 
                 }
             }
-
             return plainStream;
         }
     }

--- a/src/SharpCompress/Compressors/Xz/BinaryUtils.cs
+++ b/src/SharpCompress/Compressors/Xz/BinaryUtils.cs
@@ -18,9 +18,11 @@ namespace SharpCompress.Compressors.Xz
         public static int ReadLittleEndianInt32(this Stream stream)
         {
             byte[] bytes = new byte[4];
-            var read = stream.Read(bytes, 0, 4);
-            if (read != 4)
+            var read = stream.ReadFully(bytes);
+            if (!read)
+            {
                 throw new EndOfStreamException();
+            }
             return (bytes[0] + (bytes[1] << 8) + (bytes[2] << 16) + (bytes[3] << 24));
         }
 

--- a/src/SharpCompress/Readers/AbstractReader.cs
+++ b/src/SharpCompress/Readers/AbstractReader.cs
@@ -139,8 +139,6 @@ namespace SharpCompress.Readers
             }
         }
 
-        private readonly byte[] skipBuffer = new byte[4096];
-
         private void Skip()
         {
             if (ArchiveType != ArchiveType.Rar 
@@ -153,20 +151,14 @@ namespace SharpCompress.Readers
                 if (rawStream != null)
                 {
                     var bytesToAdvance = Entry.CompressedSize;
-                    for (var i = 0; i < bytesToAdvance / skipBuffer.Length; i++)
-                    {
-                        rawStream.Read(skipBuffer, 0, skipBuffer.Length);
-                    }
-                    rawStream.Read(skipBuffer, 0, (int)(bytesToAdvance % skipBuffer.Length));
+                    rawStream.Skip(bytesToAdvance);
                     return;
                 }
             }
             //don't know the size so we have to try to decompress to skip
             using (var s = OpenEntryStream())
             {
-                while (s.Read(skipBuffer, 0, skipBuffer.Length) > 0)
-                {
-                }
+                s.Skip();
             }
         }
 

--- a/src/SharpCompress/Utility.cs
+++ b/src/SharpCompress/Utility.cs
@@ -7,7 +7,7 @@ using SharpCompress.Readers;
 namespace SharpCompress
 {
     internal static class Utility
-    {
+    {   
         public static ReadOnlyCollection<T> ToReadOnly<T>(this IEnumerable<T> items)
         {
             return new ReadOnlyCollection<T>(items.ToList());
@@ -138,7 +138,7 @@ namespace SharpCompress
 
         public static void Skip(this Stream source, long advanceAmount)
         {
-            byte[] buffer = new byte[32 * 1024];
+            byte[] buffer = GetTransferByteArray();
             int read = 0;
             int readCount = 0;
             do
@@ -162,9 +162,9 @@ namespace SharpCompress
             while (true);
         }
 
-        public static void SkipAll(this Stream source)
+        public static void Skip(this Stream source)
         {
-            byte[] buffer = new byte[32 * 1024];
+            byte[] buffer = GetTransferByteArray();
             do
             {
             }


### PR DESCRIPTION
Fixes https://github.com/adamhathcock/sharpcompress/issues/275 with some clean up