### PR TITLE
Fixed bug: Passing default ReaderOptions when creating ZipReader for solid extraction

### DIFF
--- a/src/SharpCompress/Archives/Zip/ZipArchive.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.cs
@@ -208,7 +208,7 @@ namespace SharpCompress.Archives.Zip
         {
             var stream = Volumes.Single().Stream;
             stream.Position = 0;
-            return ZipReader.Open(stream);
+            return ZipReader.Open(stream, ReaderOptions);
         }
     }
 }


### PR DESCRIPTION
This bug causes entry keys in wrong encoding when using ExtractAllEntries/MoveToNextEntry if non-UTF8 encoding specified at ZipArchive.Open