### PR TITLE
XZ: fix variable-length integers decoding

### DIFF
--- a/src/SharpCompress/Compressors/Xz/MultiByteIntegers.cs
+++ b/src/SharpCompress/Compressors/Xz/MultiByteIntegers.cs
@@ -18,7 +18,7 @@ namespace SharpCompress.Compressors.Xz
             int i = 0;
             while ((LastByte & 0x80) != 0)
             {
-                if (i >= MaxBytes)
+                if (++i >= MaxBytes)
                     throw new InvalidDataException();
                 LastByte = reader.ReadByte();
                 if (LastByte == 0)

--- a/tests/SharpCompress.Test/Xz/XZIndexTests.cs
+++ b/tests/SharpCompress.Test/Xz/XZIndexTests.cs
@@ -41,5 +41,14 @@ namespace SharpCompress.Test.Xz
             index.Process();
             Assert.Equal(index.NumberOfRecords, (ulong)1);
         }
+
+        [Fact]
+        public void ReadsFirstRecord()
+        {
+            BinaryReader br = new BinaryReader(CompressedStream);
+            var index = new XZIndex(br, false);
+            index.Process();
+            Assert.Equal((ulong)OriginalBytes.Length, index.Records[0].UncompressedSize);
+        }
     }
 }


### PR DESCRIPTION
The `ReadXZInteger` extension method reads VLIs in XZ streams. It reads the right number of bytes, but does not return the correct value for multi-byte VLIs (>= 128) because an increment is missing.

This PR adds the missing increment, with a unit test (based on XZIndex). The fix matches the [reference Java implementation](https://git.tukaani.org/?p=xz-java.git;a=blob;f=src/org/tukaani/xz/common/DecoderUtil.java;h=77ba4413e71ef37f73b29d8dca96231c1c75240a;hb=HEAD#l106).

I see two cases where a valid XZ file could previously not be read:
- XZ file with an index containing >= 128 records (AFAIK indexes aren't that common),
- block filter with >= 128 bytes of properties (seems unlikely).