### PR TITLE
Utility.Skip uses seek

### DIFF
--- a/src/SharpCompress/Utility.cs
+++ b/src/SharpCompress/Utility.cs
@@ -141,6 +141,12 @@ namespace SharpCompress
 
         public static void Skip(this Stream source, long advanceAmount)
         {
+            if (source.CanSeek)
+            {
+                source.Position += advanceAmount;
+                return;
+            }
+
             byte[] buffer = GetTransferByteArray();
             try
             {


### PR DESCRIPTION
Hello.
I have a large zip file.(~100GB 871kEntries)
I tried below code.

```csharp
var sw = Stopwatch.StartNew();
using (var stream = new FileStream(@"large.zip", FileMode.Open, FileAccess.Read, FileShare.Read))
using (var reader = ZipReader.Open(stream, new SharpCompress.Readers.ReaderOptions { LeaveStreamOpen = true }))
{
    while (reader.MoveToNextEntry())
    {
        //Console.WriteLine(reader.Entry.Key);
    }
}
Console.WriteLine(sw.Elapsed);
```

It took about 13 minutes in my machine.
However, when this PR is applied, it was shortened to 10 seconds.
Does this cause problems?

I'm sorry for my poor English.
Thank you for reading.