### PR TITLE
Added ability to leave tar archive open after stream is closed

### DIFF
--- a/src/SharpCompress/Archives/Tar/TarArchive.cs
+++ b/src/SharpCompress/Archives/Tar/TarArchive.cs
@@ -182,7 +182,7 @@ namespace SharpCompress.Archives.Tar
                                        IEnumerable<TarArchiveEntry> oldEntries,
                                        IEnumerable<TarArchiveEntry> newEntries)
         {
-            using (var writer = new TarWriter(stream, options))
+            using (var writer = new TarWriter(stream, new TarWriterOptions(options)))
             {
                 foreach (var entry in oldEntries.Concat(newEntries)
                                                 .Where(x => !x.IsDirectory))

--- a/src/SharpCompress/Writers/Tar/TarWriter.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriter.cs
@@ -11,9 +11,13 @@ namespace SharpCompress.Writers.Tar
 {
     public class TarWriter : AbstractWriter
     {
-        public TarWriter(Stream destination, WriterOptions options)
+        private readonly bool finalizeArchiveOnClose;
+
+        public TarWriter(Stream destination, WriterOptions options, bool finalizeArchiveOnClose = true)
             : base(ArchiveType.Tar, options)
         {
+            this.finalizeArchiveOnClose = finalizeArchiveOnClose;
+
             if (!destination.CanWrite)
             {
                 throw new ArgumentException("Tars require writable streams.");
@@ -97,8 +101,10 @@ namespace SharpCompress.Writers.Tar
         {
             if (isDisposing)
             {
-                PadTo512(0, true);
-                PadTo512(0, true);
+                if (finalizeArchiveOnClose){
+                    PadTo512(0, true);
+                    PadTo512(0, true);
+                }
                 switch (OutputStream)
                 {
                     case BZip2Stream b:

--- a/src/SharpCompress/Writers/Tar/TarWriter.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriter.cs
@@ -11,9 +11,13 @@ namespace SharpCompress.Writers.Tar
 {
     public class TarWriter : AbstractWriter
     {
-        public TarWriter(Stream destination, WriterOptions options)
+        private bool finalizeArchiveOnClose;
+
+        public TarWriter(Stream destination, TarWriterOptions options)
             : base(ArchiveType.Tar, options)
         {
+            finalizeArchiveOnClose = options.FinalizeArchiveOnClose;
+
             if (!destination.CanWrite)
             {
                 throw new ArgumentException("Tars require writable streams.");
@@ -97,8 +101,10 @@ namespace SharpCompress.Writers.Tar
         {
             if (isDisposing)
             {
-                PadTo512(0, true);
-                PadTo512(0, true);
+                if (finalizeArchiveOnClose) {
+                    PadTo512(0, true);
+                    PadTo512(0, true);
+                }
                 switch (OutputStream)
                 {
                     case BZip2Stream b:

--- a/src/SharpCompress/Writers/Tar/TarWriter.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriter.cs
@@ -11,13 +11,9 @@ namespace SharpCompress.Writers.Tar
 {
     public class TarWriter : AbstractWriter
     {
-        private readonly bool finalizeArchiveOnClose;
-
-        public TarWriter(Stream destination, WriterOptions options, bool finalizeArchiveOnClose = true)
+        public TarWriter(Stream destination, WriterOptions options)
             : base(ArchiveType.Tar, options)
         {
-            this.finalizeArchiveOnClose = finalizeArchiveOnClose;
-
             if (!destination.CanWrite)
             {
                 throw new ArgumentException("Tars require writable streams.");
@@ -101,10 +97,8 @@ namespace SharpCompress.Writers.Tar
         {
             if (isDisposing)
             {
-                if (finalizeArchiveOnClose){
-                    PadTo512(0, true);
-                    PadTo512(0, true);
-                }
+                PadTo512(0, true);
+                PadTo512(0, true);
                 switch (OutputStream)
                 {
                     case BZip2Stream b:

--- a/src/SharpCompress/Writers/Tar/TarWriterOptions.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriterOptions.cs
@@ -1,0 +1,23 @@
+using SharpCompress.Archives;
+using SharpCompress.Common;
+
+namespace SharpCompress.Writers.Tar
+{
+    public class TarWriterOptions : WriterOptions
+    {
+        /// <summary>
+        /// Indicates if archive should be finalized (by 2 empty blocks) on close.
+        /// </summary>
+        public bool FinalizeArchiveOnClose { get; }
+
+        public TarWriterOptions(CompressionType compressionType, bool finalizeArchiveOnClose)
+            : base(compressionType)
+        {
+            FinalizeArchiveOnClose = finalizeArchiveOnClose;
+        }
+
+        internal TarWriterOptions(WriterOptions options) : this(options.CompressionType, true)
+        {
+        }
+    }
+}

--- a/src/SharpCompress/Writers/WriterFactory.cs
+++ b/src/SharpCompress/Writers/WriterFactory.cs
@@ -27,7 +27,7 @@ namespace SharpCompress.Writers
                 }
                 case ArchiveType.Tar:
                 {
-                    return new TarWriter(stream, writerOptions);
+                    return new TarWriter(stream, new TarWriterOptions(writerOptions));
                 }
                 default:
                 {

--- a/tests/SharpCompress.Test/Tar/TarWriterTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarWriterTests.cs
@@ -1,4 +1,6 @@
-﻿using SharpCompress.Common;
+﻿using System.IO;
+using SharpCompress.Common;
+using SharpCompress.Writers.Tar;
 using Xunit;
 
 namespace SharpCompress.Test.Tar
@@ -33,6 +35,23 @@ namespace SharpCompress.Test.Tar
         public void Tar_Rar_Write()
         {
             Assert.Throws<InvalidFormatException>(() => Write(CompressionType.Rar, "Zip.ppmd.noEmptyDirs.zip", "Zip.ppmd.noEmptyDirs.zip"));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Tar_Finalize_Archive(bool finalizeArchive)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            using (Stream content = File.OpenRead(Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg"))) {
+                using (TarWriter writer = new TarWriter(stream, new TarWriterOptions(CompressionType.None, finalizeArchive)))             {
+                    writer.Write("doesn't matter", content, null);
+                }
+
+                var paddedContentWithHeader = content.Length / 512 * 512 + 512 + 512;
+                var expectedStreamLength = finalizeArchive ? paddedContentWithHeader + 512 * 2 : paddedContentWithHeader;
+                Assert.Equal(expectedStreamLength, stream.Length);
+            }
         }
     }
 }


### PR DESCRIPTION
I'm not sure if this flag should be included in WriterOptions since no other archives could support it. Moreover zip archive also has finalization logic but there is no sense to leave it open since it is not possible to resume zip archive writing (correct me if I'm wrong and I'll move this flag to WriterOptions).

If there are no objections with this approach - I'll add tests for these changes.
Related to #323 