### PR TITLE
Implement Entry.ToString()

### DIFF
--- a/src/SharpCompress/Common/Entry.cs
+++ b/src/SharpCompress/Common/Entry.cs
@@ -65,6 +65,12 @@ namespace SharpCompress.Common
         /// </summary>
         public abstract bool IsSplit { get; }
 
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Key;
+        }
+
         internal abstract IEnumerable<FilePart> Parts { get; }
         internal bool IsSolid { get; set; }
 


### PR DESCRIPTION
When inspecting a `TarArchive` under the debugger, I found that all entries are listed as `{SharpCompress.Archives.Tar.TarArchiveEntry}`.

This PR implements `Entry.ToString()` by returning `Entry.Key`, so that each entry now shows up with its actual file name.

Could be useful for logging/monitoring scenarios as well.