### PR TITLE
Implemented ReadByte/WriteByte on streams to improve performance

### DIFF
--- a/src/SharpCompress/Common/EntryStream.cs
+++ b/src/SharpCompress/Common/EntryStream.cs
@@ -66,6 +66,16 @@ namespace SharpCompress.Common
             return read;
         }
 
+        public override int ReadByte()
+        {
+            int value = _stream.ReadByte();
+            if (value == -1)
+            {
+                _completed = true;
+            }
+            return value;
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             throw new NotSupportedException();

--- a/src/SharpCompress/Common/Tar/TarReadOnlySubStream.cs
+++ b/src/SharpCompress/Common/Tar/TarReadOnlySubStream.cs
@@ -72,6 +72,22 @@ namespace SharpCompress.Common.Tar
             return read;
         }
 
+        public override int ReadByte()
+        {
+            if (BytesLeftToRead <= 0)
+            {
+                return -1;
+            }
+            int value = Stream.ReadByte();
+            if (value != -1)
+            {
+                --BytesLeftToRead;
+                ++_amountRead;
+            }
+            return value;
+
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             throw new NotSupportedException();

--- a/src/SharpCompress/Compressors/BZip2/BZip2Stream.cs
+++ b/src/SharpCompress/Compressors/BZip2/BZip2Stream.cs
@@ -67,6 +67,11 @@ namespace SharpCompress.Compressors.BZip2
             return stream.Read(buffer, offset, count);
         }
 
+        public override int ReadByte()
+        {
+            return stream.ReadByte();
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             return stream.Seek(offset, origin);
@@ -80,6 +85,11 @@ namespace SharpCompress.Compressors.BZip2
         public override void Write(byte[] buffer, int offset, int count)
         {
             stream.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            stream.WriteByte(value);
         }
 
         /// <summary>

--- a/src/SharpCompress/Compressors/BZip2/CBZip2InputStream.cs
+++ b/src/SharpCompress/Compressors/BZip2/CBZip2InputStream.cs
@@ -1077,6 +1077,10 @@ namespace SharpCompress.Compressors.BZip2
         {
         }
 
+        public override void WriteByte(byte value)
+        {
+        }
+
         public override bool CanRead => true;
 
         public override bool CanSeek => false;

--- a/src/SharpCompress/Compressors/BZip2/CBZip2OutputStream.cs
+++ b/src/SharpCompress/Compressors/BZip2/CBZip2OutputStream.cs
@@ -1929,6 +1929,11 @@ namespace SharpCompress.Compressors.BZip2
             return 0;
         }
 
+        public override int ReadByte()
+        {
+            return -1;
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             return 0;

--- a/src/SharpCompress/Compressors/Deflate/DeflateStream.cs
+++ b/src/SharpCompress/Compressors/Deflate/DeflateStream.cs
@@ -282,6 +282,15 @@ namespace SharpCompress.Compressors.Deflate
             return _baseStream.Read(buffer, offset, count);
         }
 
+        public override int ReadByte()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException("DeflateStream");
+            }
+            return _baseStream.ReadByte();
+        }
+
         /// <summary>
         /// Calling this method always throws a <see cref="NotImplementedException"/>.
         /// </summary>
@@ -338,6 +347,15 @@ namespace SharpCompress.Compressors.Deflate
                 throw new ObjectDisposedException("DeflateStream");
             }
             _baseStream.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException("DeflateStream");
+            }
+            _baseStream.WriteByte(value);
         }
 
         #endregion

--- a/src/SharpCompress/Compressors/Deflate/ZlibStream.cs
+++ b/src/SharpCompress/Compressors/Deflate/ZlibStream.cs
@@ -270,6 +270,15 @@ namespace SharpCompress.Compressors.Deflate
             return _baseStream.Read(buffer, offset, count);
         }
 
+        public override int ReadByte()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException("ZlibStream");
+            }
+            return _baseStream.ReadByte();
+        }
+
         /// <summary>
         /// Calling this method always throws a <see cref="NotImplementedException"/>.
         /// </summary>
@@ -319,6 +328,15 @@ namespace SharpCompress.Compressors.Deflate
                 throw new ObjectDisposedException("ZlibStream");
             }
             _baseStream.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException("ZlibStream");
+            }
+            _baseStream.WriteByte(value);
         }
 
         #endregion System.IO.Stream methods

--- a/src/SharpCompress/Compressors/LZMA/Bcj2DecoderStream.cs
+++ b/src/SharpCompress/Compressors/LZMA/Bcj2DecoderStream.cs
@@ -193,6 +193,22 @@ namespace SharpCompress.Compressors.LZMA
             return count;
         }
 
+        public override int ReadByte()
+        {
+            if (_mFinished)
+            {
+                return -1;
+            }
+
+            if (!_mIter.MoveNext())
+            {
+                _mFinished = true;
+                return -1;
+            }
+
+            return _mIter.Current;
+        }
+
         public IEnumerable<byte> Run()
         {
             const uint kBurstSize = (1u << 18);

--- a/src/SharpCompress/Compressors/LZMA/LZipStream.cs
+++ b/src/SharpCompress/Compressors/LZMA/LZipStream.cs
@@ -110,6 +110,8 @@ namespace SharpCompress.Compressors.LZMA
 
         public override int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
 
+        public override int ReadByte() => _stream.ReadByte();
+
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
         public override void SetLength(long value) => throw new NotImplementedException();
@@ -118,6 +120,12 @@ namespace SharpCompress.Compressors.LZMA
         {
             _stream.Write(buffer, offset, count);
             _writeCount += count;
+        }
+
+        public override void WriteByte(byte value)
+        {
+            _stream.WriteByte(value);
+            ++_writeCount;
         }
 
         #endregion

--- a/src/SharpCompress/Compressors/Xz/Filters/Lzma2Filter.cs
+++ b/src/SharpCompress/Compressors/Xz/Filters/Lzma2Filter.cs
@@ -51,5 +51,10 @@ namespace SharpCompress.Compressors.Xz.Filters
         {
             return BaseStream.Read(buffer, offset, count);
         }
+
+        public override int ReadByte()
+        {
+            return BaseStream.ReadByte();
+        }
     }
 }

--- a/src/SharpCompress/Crypto/Crc32Stream.cs
+++ b/src/SharpCompress/Crypto/Crc32Stream.cs
@@ -47,6 +47,12 @@ namespace SharpCompress.Crypto
             hash = CalculateCrc(table, hash, buffer, offset, count);
         }
 
+        public override void WriteByte(byte value)
+        {
+            stream.WriteByte(value);
+            hash = CalculateCrc(table, hash, value);
+        }
+
         public override bool CanRead => stream.CanRead;
         public override bool CanSeek => false;
         public override bool CanWrite => stream.CanWrite;
@@ -98,9 +104,16 @@ namespace SharpCompress.Crypto
             unchecked
             {
                 for (int i = offset, end = offset + count; i < end; i++)
-                    crc = (crc >> 8) ^ table[(crc ^ buffer[i]) & 0xFF];
+                {
+                    crc = CalculateCrc(table, crc, buffer[i]);
+                }
             }
             return crc;
+        }
+
+        private static uint CalculateCrc(uint[] table, uint crc, byte b)
+        {
+            return (crc >> 8) ^ table[(crc ^ b) & 0xFF];
         }
     }
 }

--- a/src/SharpCompress/IO/CountingWritableSubStream.cs
+++ b/src/SharpCompress/IO/CountingWritableSubStream.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace SharpCompress.IO
@@ -48,6 +48,12 @@ namespace SharpCompress.IO
         {
             writableStream.Write(buffer, offset, count);
             Count += (uint)count;
+        }
+
+        public override void WriteByte(byte value)
+        {
+            writableStream.WriteByte(value);
+            ++Count;
         }
     }
 }

--- a/src/SharpCompress/IO/ListeningStream.cs
+++ b/src/SharpCompress/IO/ListeningStream.cs
@@ -47,6 +47,19 @@ namespace SharpCompress.IO
             return read;
         }
 
+        public override int ReadByte()
+        {
+            int value = Stream.ReadByte();
+            if (value == -1)
+            {
+                return -1;
+            }
+
+            ++currentEntryTotalReadBytes;
+            listener.FireCompressedBytesRead(currentEntryTotalReadBytes, currentEntryTotalReadBytes);
+            return value;
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             return Stream.Seek(offset, origin);
@@ -60,6 +73,11 @@ namespace SharpCompress.IO
         public override void Write(byte[] buffer, int offset, int count)
         {
             Stream.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            Stream.WriteByte(value);
         }
     }
 }

--- a/src/SharpCompress/IO/NonDisposingStream.cs
+++ b/src/SharpCompress/IO/NonDisposingStream.cs
@@ -44,6 +44,11 @@ namespace SharpCompress.IO
             return Stream.Read(buffer, offset, count);
         }
 
+        public override int ReadByte()
+        {
+            return Stream.ReadByte();
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             return Stream.Seek(offset, origin);
@@ -57,6 +62,11 @@ namespace SharpCompress.IO
         public override void Write(byte[] buffer, int offset, int count)
         {
             Stream.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            Stream.WriteByte(value);
         }
     }
 }

--- a/src/SharpCompress/IO/ReadOnlySubStream.cs
+++ b/src/SharpCompress/IO/ReadOnlySubStream.cs
@@ -51,6 +51,20 @@ namespace SharpCompress.IO
             return read;
         }
 
+        public override int ReadByte()
+        {
+            if (BytesLeftToRead <= 0)
+            {
+                return -1;
+            }
+            int value = Stream.ReadByte();
+            if (value != -1)
+            {
+                --BytesLeftToRead;
+            }
+            return value;
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             throw new NotSupportedException();

--- a/tests/SharpCompress.Test/ForwardOnlyStream.cs
+++ b/tests/SharpCompress.Test/ForwardOnlyStream.cs
@@ -44,6 +44,11 @@ namespace SharpCompress.Test
             return stream.Read(buffer, offset, count);
         }
 
+        public override int ReadByte()
+        {
+            return stream.ReadByte();
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             throw new NotSupportedException();
@@ -55,7 +60,8 @@ namespace SharpCompress.Test
         }
 
         public override void Write(byte[] buffer, int offset, int count)
-        {throw new NotSupportedException();
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/tests/SharpCompress.Test/Zip/Zip64Tests.cs
+++ b/tests/SharpCompress.Test/Zip/Zip64Tests.cs
@@ -205,6 +205,9 @@ namespace SharpCompress.Test.Zip
             public override int Read(byte[] buffer, int offset, int count) 
             { return stream.Read(buffer, offset, count); }
 
+            public override int ReadByte()
+            { return stream.ReadByte(); }
+
             public override long Seek(long offset, SeekOrigin origin)
             { throw new NotImplementedException(); }
 
@@ -213,6 +216,9 @@ namespace SharpCompress.Test.Zip
 
             public override void Write(byte[] buffer, int offset, int count)
             { stream.Write(buffer, offset, count); }
+
+            public override void WriteByte(byte value)
+            { stream.WriteByte(value); }
         }
     }
 }


### PR DESCRIPTION
`NonDisposingStream` and `ReadOnlySubStream` should implement `ReadByte`: currently they don't, and [the default `Stream` implementation allocates a new one-byte buffer each time](https://source.dot.net/#System.Private.CoreLib/src/System/IO/Stream.cs,757).

`Stream.ReadByte()` is used extensively by the LZMA decoder. With this simple change, I get a ~16-17% speed improvement on my machine while extracting all files in a 43MB LZMA-compressed zip file, and total memory allocations are cut by 1GB!

In the same fashion, I've also overridden `CountingWritableSubStream.WriteByte` to improve encoding. The speed results are marginal (2-3% improvement) since the encoding algorithm takes most of the CPU time, but they exist. Additional, memory traffic is also cut by a fair margin.

I've also implemented `ReadByte`/`WriteByte` on most SharpCompress streams where it was trivial to do so.