### PR TITLE
Avoid throwing NotSupportedException in ReaderFactory hot path

### DIFF
--- a/src/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
@@ -49,6 +49,7 @@ namespace SharpCompress.Common.Zip
                 _lastEntryHeader = null;
                 uint headerBytes = reader.ReadUInt32();
                 header = ReadHeader(headerBytes, reader);
+                if (header == null) { yield break; }
 
                 //entry could be zero bytes so we need to know that.
                 if (header.ZipHeaderType == ZipHeaderType.LocalEntry)

--- a/src/SharpCompress/Common/Zip/ZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/ZipHeaderFactory.cs
@@ -91,7 +91,7 @@ namespace SharpCompress.Common.Zip
                         return entry;
                     }
                 default:
-                    throw new NotSupportedException("Unknown header: " + headerBytes);
+                    return null;
             }
         }
 


### PR DESCRIPTION
`ReaderFactory.Open()` calls `ZipArchive.IsZipFile()` to determine if the stream is a zip archive, which calls into `ZipHeaderFactory.ReadHeader()`, which throws a `NotSupportedException` when the bytes do not match a valid header.

To be clear, this exception is caught and `IsZipFile()` returns `false`, but when called in a hot-path, these exceptions can become expensive.

To address this issue, `ReadHeader` now returns `null` in the default cause instead of throwing. All callsites were already checking for and handling `null`, so no behavior should change.