### PR TITLE
Fix and re-enable tests

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -77,7 +77,7 @@ Task("Pack")
 Task("Default")
     .IsDependentOn("Restore")
     .IsDependentOn("Build")
-    //.IsDependentOn("Test")
+    .IsDependentOn("Test")
     .IsDependentOn("Pack");
 
  Task("RunTests")

--- a/tests/SharpCompress.Test/ArchiveTests.cs
+++ b/tests/SharpCompress.Test/ArchiveTests.cs
@@ -23,7 +23,6 @@ namespace SharpCompress.Test
         {
             foreach (var path in testArchives)
             {
-                ResetScratch();
                 using (var stream = new NonDisposingStream(File.OpenRead(path), true))
                 using (var archive = ArchiveFactory.Open(stream))
                 {
@@ -69,7 +68,6 @@ namespace SharpCompress.Test
         {
             foreach (var path in testArchives)
             {
-                ResetScratch();
                 using (var stream = new NonDisposingStream(File.OpenRead(path), true))
                 using (var archive = ArchiveFactory.Open(stream, readerOptions))
                 {
@@ -113,7 +111,6 @@ namespace SharpCompress.Test
         {
             foreach (var path in testArchives)
             {
-                ResetScratch();
                 using (var archive = ArchiveFactory.Open(path, readerOptions))
                 {
                     //archive.EntryExtractionBegin += archive_EntryExtractionBegin;
@@ -174,7 +171,6 @@ namespace SharpCompress.Test
         {
             foreach (var path in testArchives)
             {
-                ResetScratch();
                 using (var archive = ArchiveFactory.Open(path))
                 {
                     totalSize = archive.TotalUncompressSize;

--- a/tests/SharpCompress.Test/GZip/GZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveTests.cs
@@ -17,7 +17,6 @@ namespace SharpCompress.Test.GZip
         [Fact]
         public void GZip_Archive_Generic()
         {
-            ResetScratch();
             using (Stream stream = File.Open(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"), FileMode.Open))
             using (var archive = ArchiveFactory.Open(stream))
             {
@@ -31,7 +30,6 @@ namespace SharpCompress.Test.GZip
         [Fact]
         public void GZip_Archive()
         {
-            ResetScratch();
             using (Stream stream = File.Open(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"), FileMode.Open))
             using (var archive = GZipArchive.Open(stream))
             {
@@ -47,7 +45,6 @@ namespace SharpCompress.Test.GZip
         public void GZip_Archive_NoAdd()
         {
             string jpg = Path.Combine(ORIGINAL_FILES_PATH, "jpg", "test.jpg");
-            ResetScratch();
             using (Stream stream = File.Open(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"), FileMode.Open))
             using (var archive = GZipArchive.Open(stream))
             {
@@ -60,7 +57,6 @@ namespace SharpCompress.Test.GZip
         [Fact]
         public void GZip_Archive_Multiple_Reads()
         {
-            ResetScratch();
             var inputStream = new MemoryStream();
             using (var fileStream = File.Open(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"), FileMode.Open))
             {

--- a/tests/SharpCompress.Test/GZip/GZipWriterTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipWriterTests.cs
@@ -17,7 +17,6 @@ namespace SharpCompress.Test.GZip
         [Fact]
         public void GZip_Writer_Generic()
         {
-            ResetScratch();
             using (Stream stream = File.Open(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"), FileMode.OpenOrCreate, FileAccess.Write))
             using (var writer = WriterFactory.Open(stream, ArchiveType.GZip, CompressionType.GZip))
             {
@@ -30,7 +29,6 @@ namespace SharpCompress.Test.GZip
         [Fact]
         public void GZip_Writer()
         {
-            ResetScratch();
             using (Stream stream = File.Open(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz"), FileMode.OpenOrCreate, FileAccess.Write))
             using (var writer = new GZipWriter(stream))
             {
@@ -45,7 +43,6 @@ namespace SharpCompress.Test.GZip
         {
             Assert.Throws<InvalidFormatException>(() =>
                                                   {
-                            ResetScratch();
                             using (Stream stream = File.OpenWrite(Path.Combine(SCRATCH_FILES_PATH, "Tar.tar.gz")))
                             using (var writer = WriterFactory.Open(stream, ArchiveType.GZip, CompressionType.BZip2))
                             {

--- a/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
@@ -48,7 +48,6 @@ namespace SharpCompress.Test.Rar
 
         private void ReadRarPassword(string testArchive, string password)
         {
-            ResetScratch();
             using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, testArchive)))
             using (var archive = RarArchive.Open(stream, new ReaderOptions()
             {
@@ -80,7 +79,6 @@ namespace SharpCompress.Test.Rar
 
         protected void ArchiveFileReadPassword(string archiveName, string password)
         {
-            ResetScratch();
             using (var archive = RarArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, archiveName), new ReaderOptions()
             {
                 Password = password,
@@ -131,7 +129,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_test_invalid_exttime_ArchiveStreamRead(string filename)
         {
-            ResetScratch();
             using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
             {
                 using (var archive = ArchiveFactory.Open(stream))
@@ -151,7 +148,6 @@ namespace SharpCompress.Test.Rar
         [Fact]
         public void Rar_Jpg_ArchiveStreamRead()
         {
-            ResetScratch();
             using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg")))
             {
                 using (var archive = RarArchive.Open(stream, new ReaderOptions()
@@ -185,7 +181,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_IsSolidArchiveCheck(string filename)
         {
-            ResetScratch();
             using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
             {
                 using (var archive = RarArchive.Open(stream))
@@ -253,7 +248,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_Multi_ArchiveStreamRead(string[] archives)
         {
-            ResetScratch();
             using (var archive = RarArchive.Open(archives.Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
                 .Select(File.OpenRead)))
             {
@@ -305,7 +299,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_ArchiveFileRead_HasDirectories(string filename)
         {
-            ResetScratch();
             using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
             {
                 using (var archive = RarArchive.Open(stream))
@@ -319,7 +312,6 @@ namespace SharpCompress.Test.Rar
         [Fact]
         public void Rar_Jpg_ArchiveFileRead()
         {
-            ResetScratch();
             using (var archive = RarArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"), new ReaderOptions()
             {
                 LookForHeader = true

--- a/tests/SharpCompress.Test/Rar/RarHeaderFactoryTest.cs
+++ b/tests/SharpCompress.Test/Rar/RarHeaderFactoryTest.cs
@@ -15,7 +15,6 @@ namespace SharpCompress.Test.Rar
 
         public RarHeaderFactoryTest()
         {
-            ResetScratch();
             rarHeaderFactory = new RarHeaderFactory(
                 StreamingMode.Seekable, 
                 new ReaderOptions { LeaveStreamOpen = true });

--- a/tests/SharpCompress.Test/Rar/RarReaderTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarReaderTests.cs
@@ -33,7 +33,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_Multi_Reader(string[] archives)
         {
-            ResetScratch();
             using (var reader = RarReader.Open(archives.Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
                 .Select(p => File.OpenRead(p))))
             {
@@ -64,7 +63,6 @@ namespace SharpCompress.Test.Rar
         {
             Assert.Throws<InvalidFormatException>(() =>
                                                   {
-                                                      ResetScratch();
                                                       using (var reader = RarReader.Open(archives.Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
                                                                                                      .Select(p => File.OpenRead(p)),
                                                                                          new ReaderOptions()
@@ -110,7 +108,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_Multi_Reader_Delete_Files(string[] archives)
         {
-            ResetScratch();
 
             foreach (var file in archives)
             {
@@ -202,7 +199,6 @@ namespace SharpCompress.Test.Rar
 
         private void ReadRar(string testArchive, string password)
         {
-            ResetScratch();
             using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, testArchive)))
             using (var reader = RarReader.Open(stream, new ReaderOptions()
             {
@@ -237,7 +233,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_Entry_Stream(string filename)
         {
-            ResetScratch();
             using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
             using (var reader = RarReader.Open(stream))
             {
@@ -271,7 +266,6 @@ namespace SharpCompress.Test.Rar
         [Fact]
         public void Rar_Reader_Audio_program()
         {
-            ResetScratch();
             using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.Audio_program.rar")))
             using (var reader = RarReader.Open(stream, new ReaderOptions()
             {
@@ -295,7 +289,6 @@ namespace SharpCompress.Test.Rar
         [Fact]
         public void Rar_Jpg_Reader()
         {
-            ResetScratch();
             using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg")))
             using (var reader = RarReader.Open(stream, new ReaderOptions()
             {
@@ -339,7 +332,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_Solid_Skip_Reader(string filename)
         {
-            ResetScratch();
             using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
             using (var reader = RarReader.Open(stream, new ReaderOptions()
             {
@@ -373,7 +365,6 @@ namespace SharpCompress.Test.Rar
 
         private void DoRar_Reader_Skip(string filename)
         {
-            ResetScratch();
             using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename)))
             using (var reader = RarReader.Open(stream, new ReaderOptions()
             {

--- a/tests/SharpCompress.Test/ReaderTests.cs
+++ b/tests/SharpCompress.Test/ReaderTests.cs
@@ -33,7 +33,6 @@ namespace SharpCompress.Test
 
         public static void UseReader(TestBase test, IReader reader, CompressionType expectedCompression)
         {
-            test.ResetScratch();
             while (reader.MoveToNextEntry())
             {
                 if (!reader.Entry.IsDirectory)

--- a/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
@@ -48,7 +48,6 @@ namespace SharpCompress.Test.Tar
         {
             string archive = "Tar_VeryLongFilepathReadback.tar";
 
-            ResetScratch();
 
             // create a very long filename
             string longFilename = "";
@@ -103,7 +102,6 @@ namespace SharpCompress.Test.Tar
             string scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Tar.tar");
             string unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
-            ResetScratch();
             using (var archive = TarArchive.Create())
             {
                 archive.AddAllFromDirectory(ORIGINAL_FILES_PATH);
@@ -119,7 +117,6 @@ namespace SharpCompress.Test.Tar
             string unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.mod.tar");
             string modified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
-            ResetScratch();
             using (var archive = TarArchive.Open(unmodified))
             {
                 archive.AddEntry("jpg\\test.jpg", jpg);
@@ -135,7 +132,6 @@ namespace SharpCompress.Test.Tar
             string modified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.mod.tar");
             string unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Tar.noEmptyDirs.tar");
 
-            ResetScratch();
             using (var archive = TarArchive.Open(unmodified))
             {
                 var entry = archive.Entries.Single(x => x.Key.EndsWith("jpg"));

--- a/tests/SharpCompress.Test/Tar/TarReaderTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarReaderTests.cs
@@ -26,7 +26,6 @@ namespace SharpCompress.Test.Tar
             using (Stream stream = new ForwardOnlyStream(File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"))))
             using (IReader reader = ReaderFactory.Open(stream))
             {
-                ResetScratch();
                 int x = 0;
                 while (reader.MoveToNextEntry())
                 {
@@ -74,7 +73,6 @@ namespace SharpCompress.Test.Tar
         [Fact]
         public void Tar_BZip2_Entry_Stream()
         {
-            ResetScratch();
             using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.bz2")))
             using (var reader = TarReader.Open(stream))
             {

--- a/tests/SharpCompress.Test/TestBase.cs
+++ b/tests/SharpCompress.Test/TestBase.cs
@@ -39,6 +39,12 @@ namespace SharpCompress.Test
 
         public void Dispose()
         {
+            // WARNING: This garbage collection is needed to reclaim leaked file handles
+            // (likely due to improperly handled IDisposables). Without it, The following
+            // delete fails because files are still is use. This GC should be removed once
+            // all the files pass without it.
+            GC.Collect(2, GCCollectionMode.Forced, true, false);
+
             Directory.Delete(SCRATCH_BASE_PATH, true);
         }
 

--- a/tests/SharpCompress.Test/TestBase.cs
+++ b/tests/SharpCompress.Test/TestBase.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using SharpCompress.Readers;
 using Xunit;
 
@@ -11,15 +10,15 @@ using Xunit;
 
 namespace SharpCompress.Test
 {
-    public class TestBase
+    public class TestBase : IDisposable
     {
         private string SOLUTION_BASE_PATH;
         protected string TEST_ARCHIVES_PATH;
         protected string ORIGINAL_FILES_PATH;
         protected string MISC_TEST_FILES_PATH;
+        private string SCRATCH_BASE_PATH;
         public string SCRATCH_FILES_PATH;
         protected string SCRATCH2_FILES_PATH;
-       
 
         public TestBase()
         {
@@ -29,23 +28,18 @@ namespace SharpCompress.Test
             TEST_ARCHIVES_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", "Archives");
             ORIGINAL_FILES_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", "Original");
             MISC_TEST_FILES_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", "MiscTest");
-            SCRATCH_FILES_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", "Scratch");
-            SCRATCH2_FILES_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", "Scratch2");
-        }
-        
-        public void ResetScratch()
-        {
-            if (Directory.Exists(SCRATCH_FILES_PATH))
-            {
-                Directory.Delete(SCRATCH_FILES_PATH, true);
-            }
-            Directory.CreateDirectory(SCRATCH_FILES_PATH);
-            if (Directory.Exists(SCRATCH2_FILES_PATH))
-            {
-                Directory.Delete(SCRATCH2_FILES_PATH, true);
-            }
-            Directory.CreateDirectory(SCRATCH2_FILES_PATH);
 
+            SCRATCH_BASE_PATH = Path.Combine(SOLUTION_BASE_PATH, "TestArchives", Guid.NewGuid().ToString());
+            SCRATCH_FILES_PATH = Path.Combine(SCRATCH_BASE_PATH, "Scratch");
+            SCRATCH2_FILES_PATH = Path.Combine(SCRATCH_BASE_PATH, "Scratch2");
+
+            Directory.CreateDirectory(SCRATCH_FILES_PATH);
+            Directory.CreateDirectory(SCRATCH2_FILES_PATH);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(SCRATCH_BASE_PATH, true);
         }
 
         public void VerifyFiles()

--- a/tests/SharpCompress.Test/WriterTests.cs
+++ b/tests/SharpCompress.Test/WriterTests.cs
@@ -19,7 +19,6 @@ namespace SharpCompress.Test
 
         protected void Write(CompressionType compressionType, string archive, string archiveToVerifyAgainst)
         {
-            ResetScratch();
             using (Stream stream = File.OpenWrite(Path.Combine(SCRATCH2_FILES_PATH, archive))) {
                 WriterOptions writerOptions = new WriterOptions(compressionType) 
                 {

--- a/tests/SharpCompress.Test/Zip/Zip64Tests.cs
+++ b/tests/SharpCompress.Test/Zip/Zip64Tests.cs
@@ -100,7 +100,6 @@ namespace SharpCompress.Test.Zip
 
         public void RunSingleTest(long files, long filesize, bool set_zip64, bool forward_only, long write_chunk_size = 1024 * 1024, string filename = "zip64-test.zip")
         {
-            ResetScratch();
             filename = Path.Combine(SCRATCH2_FILES_PATH, filename);
             
             if (File.Exists(filename))

--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -158,7 +158,6 @@ namespace SharpCompress.Test.Zip
             string unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
             string modified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
 
-            ResetScratch();
             using (var archive = ZipArchive.Open(unmodified))
             {
                 var entry = archive.Entries.Single(x => x.Key.EndsWith("jpg"));
@@ -180,7 +179,6 @@ namespace SharpCompress.Test.Zip
             string unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.mod.zip");
             string modified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.mod2.zip");
 
-            ResetScratch();
             using (var archive = ZipArchive.Open(unmodified))
             {
                 archive.AddEntry("jpg\\test.jpg", jpg);
@@ -199,7 +197,6 @@ namespace SharpCompress.Test.Zip
             string scratchPath1 = Path.Combine(SCRATCH_FILES_PATH, "a.zip");
             string scratchPath2 = Path.Combine(SCRATCH_FILES_PATH, "b.zip");
 
-            ResetScratch();
             using (var arc = ZipArchive.Create())
             {
                 string str = "test.txt";
@@ -215,7 +212,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_Removal_Poly()
         {
-            ResetScratch();
 
             string scratchPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
 
@@ -263,7 +259,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_Create_New()
         {
-            ResetScratch();
             foreach (var file in Directory.EnumerateFiles(ORIGINAL_FILES_PATH, "*.*", SearchOption.AllDirectories))
             {
                 var newFileName = file.Substring(ORIGINAL_FILES_PATH.Length);
@@ -298,7 +293,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_Create_New_Add_Remove()
         {
-            ResetScratch();
             foreach (var file in Directory.EnumerateFiles(ORIGINAL_FILES_PATH, "*.*", SearchOption.AllDirectories))
             {
                 var newFileName = file.Substring(ORIGINAL_FILES_PATH.Length);
@@ -328,7 +322,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_Deflate_WinzipAES_Read()
         {
-            ResetScratch();
             using (var reader = ZipArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"), new ReaderOptions()
             {
                 Password = "test"
@@ -349,7 +342,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_Deflate_WinzipAES_MultiOpenEntryStream()
         {
-            ResetScratch();
             using (var reader = ZipArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES2.zip"), new ReaderOptions()
             {
                 Password = "test"
@@ -368,7 +360,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_BZip2_Pkware_Read()
         {
-            ResetScratch();
             using (var reader = ZipArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"), new ReaderOptions()
             {
                 Password = "test"
@@ -391,7 +382,6 @@ namespace SharpCompress.Test.Zip
         {
             string unmodified = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.noEmptyDirs.zip");
 
-            ResetScratch();
             ZipArchive a = ZipArchive.Open(unmodified);
             int count = 0;
             foreach (var e in a.Entries)

--- a/tests/SharpCompress.Test/Zip/ZipReaderTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipReaderTests.cs
@@ -19,7 +19,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Issue_269_Double_Skip()
         {
-            ResetScratch();
             var path = Path.Combine(TEST_ARCHIVES_PATH, "PrePostHeaders.zip");
             using (Stream stream = new ForwardOnlyStream(File.OpenRead(path)))
             using (IReader reader = ReaderFactory.Open(stream))
@@ -77,7 +76,6 @@ namespace SharpCompress.Test.Zip
             using (Stream stream = new ForwardOnlyStream(File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))))
             using (IReader reader = ReaderFactory.Open(stream))
             {
-                ResetScratch();
                 int x = 0;
                 while (reader.MoveToNextEntry())
                 {
@@ -144,7 +142,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_BZip2_PkwareEncryption_Read()
         {
-            ResetScratch();
             using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip")))
             using (var reader = ZipReader.Open(stream, new ReaderOptions()
             {
@@ -170,7 +167,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_Reader_Disposal_Test()
         {
-            ResetScratch();
             using (TestStream stream = new TestStream(File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))))
             {
                 using (var reader = ReaderFactory.Open(stream))
@@ -195,7 +191,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_Reader_Disposal_Test2()
         {
-            ResetScratch();
             using (TestStream stream = new TestStream(File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.dd.zip"))))
             {
                 var reader = ReaderFactory.Open(stream);
@@ -220,7 +215,6 @@ namespace SharpCompress.Test.Zip
         {
             Assert.Throws<NotSupportedException>(() =>
                                             {
-                                                ResetScratch();
                                                 using (
                                                     Stream stream =
                                                         File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH,
@@ -251,7 +245,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void Zip_Deflate_WinzipAES_Read()
         {
-            ResetScratch();
             using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip")))
             using (var reader = ZipReader.Open(stream, new ReaderOptions()
             {
@@ -283,7 +276,6 @@ namespace SharpCompress.Test.Zip
         [Fact]
         public void TestSharpCompressWithEmptyStream()
         {
-            ResetScratch();
 
             MemoryStream stream = new NonSeekableMemoryStream();
 


### PR DESCRIPTION
Fix two problems with the test harness

1. Give each test its own unique scratch space to prevent conflicts between tests

As part of having a unique scratch space, we can remove the `ResetScratch()` method and make the tests simpler and more resilient.

2. Avoid leaking file handles by forcing a garbage collection prior to cleanup for each test