### PR TITLE
Changes to populate ZipArchive.ZipVolumne.Comment

### DIFF
--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -358,6 +358,22 @@ namespace SharpCompress.Test.Zip
         }
 
         [Fact]
+        public void Zip_Read_Volume_Comment()
+        {
+            using (var reader = ZipArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, "Zip.zip64.zip"), new ReaderOptions()
+            {
+                Password = "test"
+            }))
+            {
+                var isComplete = reader.IsComplete;
+                Assert.Equal(1, reader.Volumes.Count);
+
+                string expectedComment = "Encoding:utf-8 || Compression:Deflate levelDefault || Encrypt:None || ZIP64:Always\r\nCreated at 2017-Jan-23 14:10:43 || DotNetZip Tool v1.9.1.8\r\nTest zip64 archive";
+                Assert.Equal(expectedComment, reader.Volumes.First().Comment);
+            }
+        }
+
+        [Fact]
         public void Zip_BZip2_Pkware_Read()
         {
             using (var reader = ZipArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"), new ReaderOptions()


### PR DESCRIPTION
(Related to #290)

Looking at the code, it looks to me like ZipArchive.LoadEntries already contains support for populating the ZipVolume Comment field from the DirectoryEndHeader, but that doesn't get hit because SeekableZipHeaderFactory.ReadSeekableHeader never seems to return the DirectoryEndHeader, it just breaks when there are no more DirectoryEntryHeaders.

This change changes ReadSeekableHeader to return the DirectoryEndHeader, such that the volume comment is populated.

(i'm trying to work out how this stuff works as i go along, and i'm not quite sure how all the cases for returning/breaking in ReadSeekableHeader should ne handled, but the test case suggests that the simple case of getting the archive header works.)