### PR TITLE
AddAllFromDirectoryContentOnly extension method for IWritableArchive

### DIFF
--- a/src/SharpCompress/Archives/IWritableArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IWritableArchiveExtensions.cs
@@ -58,6 +58,19 @@ namespace SharpCompress.Archives
             }
             return writableArchive.AddEntry(key, fileInfo.OpenRead(), true, fileInfo.Length, fileInfo.LastWriteTime);
         }
+
+        public static void AddAllFromDirectoryContentOnly(
+            this IWritableArchive writableArchive,
+            string filePath, string searchPattern = "*.*", SearchOption searchOption = SearchOption.AllDirectories)
+        {
+            var paths = Directory.GetFiles(filePath, searchPattern, searchOption);
+            Array.Sort(paths);
+            foreach (var path in paths)
+            {
+                var fileInfo = new FileInfo(path);
+                writableArchive.AddEntry(path.Substring(filePath.Length), fileInfo.OpenRead(), true, fileInfo.Length, null);
+            }
+        }
 #endif
     }
 }


### PR DESCRIPTION
Only write content (will ignore timestamp). This method is used to make sure same contents of a directory will always output the same binary.