### PR TITLE
Various fixes for ZIP64 writer (zero byte entries, 32 bit where supported)

### DIFF
--- a/src/SharpCompress/Writers/Zip/ZipWriter.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriter.cs
@@ -383,6 +383,14 @@ namespace SharpCompress.Writers.Zip
                         originalStream.Position = (long)(entry.HeaderOffset + 6);
                         originalStream.WriteByte(0);
 
+                        if (counting.Count == 0 && entry.Decompressed == 0)
+                        {
+                            // set compression to STORED for zero byte files (no compression data)
+                            originalStream.Position = (long)(entry.HeaderOffset + 8);
+                            originalStream.WriteByte(0);
+                            originalStream.WriteByte(0);
+                        }
+
                         originalStream.Position = (long)(entry.HeaderOffset + 14);
 
                         writer.WriteFooter(entry.Crc, compressedvalue, decompressedvalue);


### PR DESCRIPTION
To improve compatibility with older ZIP clients I've modified the directory headers to write the corresponding 32 bit values if values still fit in 32 bits (this will allow them to read as if it's a ZIP32, and able to completely ignore the extra ZIP64 fields in ZIP headers if the decompressed size <= 32 bits)

Another problem fixed in order not to trip up 7-zip/WinRAR, zero byte files need to have compression value 0 (STORED). Now with zero byte files in the archive they will validate correctly.

I've tested these changes on WinRAR, 7-zip and windows explorer .zip (Windows 10 RS5), and using the latest changes don't get any complaints anymore extracting ZIP/ZIP64.