### PR TITLE
Fix for clients failing on just having a 64 bit offset in ZIP64

### DIFF
--- a/src/SharpCompress/Writers/Zip/ZipCentralDirectoryEntry.cs
+++ b/src/SharpCompress/Writers/Zip/ZipCentralDirectoryEntry.cs
@@ -39,9 +39,9 @@ namespace SharpCompress.Writers.Zip
             var zip64 = zip64_stream || HeaderOffset >= uint.MaxValue;
             var usedCompression = compression;
 
-            var compressedvalue = Compressed < uint.MaxValue ? (uint)Compressed : uint.MaxValue;
-            var decompressedvalue = Decompressed < uint.MaxValue ? (uint)Decompressed : uint.MaxValue;
-            var headeroffsetvalue = HeaderOffset < uint.MaxValue ? (uint)HeaderOffset : uint.MaxValue;
+            var compressedvalue = zip64 ? uint.MaxValue : (uint)Compressed;
+            var decompressedvalue = zip64 ? uint.MaxValue : (uint)Decompressed;
+            var headeroffsetvalue = zip64 ? uint.MaxValue : (uint)HeaderOffset;
             var extralength = zip64 ? (2 + 2 + 8 + 8 + 8 + 4) : 0;
             var version = (byte)(zip64 ? 45 : 20); // Version 20 required for deflate/encryption
 


### PR DESCRIPTION
Sorry Adam, while testing some bigger ZIP64 files I found a case where some archive tools don't accept having just 0xFFFFFFFF only for relative offset. This should fix that by also forcing it for compressed/decompressed size to make sure they read everything from the ZIP64 directory record when anything goes over uint32 max for that specific entry.

(according to the spec it's allowed - so technically the commit before was not wrong, but it's probably better to be on the safe side:
https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
   4.4.16 relative offset of local header: (4 bytes)

       This is the offset from the start of the first disk on
       which this file appears, to where the local header SHOULD
       be found.  If an archive is in ZIP64 format and the value
       in this field is 0xFFFFFFFF, the size will be in the 
       corresponding 8 byte zip64 extended information extra field.)

![image](https://user-images.githubusercontent.com/5462782/58343363-1454d500-7e53-11e9-9c9d-ea77c4339d90.png)

![image](https://user-images.githubusercontent.com/5462782/58343626-cb515080-7e53-11e9-812e-cee3c09fe1ef.png)
