### PR TITLE
Fixes #465 EntryExtractionEnd event fired before the Outstream close

### DIFF
--- a/src/SharpCompress/Archives/IArchiveEntryExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveEntryExtensions.cs
@@ -34,7 +34,6 @@ namespace SharpCompress.Archives
                     s.TransferTo(streamToWriteTo);
                 }
             }
-            streamListener.FireEntryExtractionEnd(archiveEntry);
         }
 
 #if !NO_FILE
@@ -63,6 +62,8 @@ namespace SharpCompress.Archives
                                                    {
                                                        entry.WriteTo(fs);
                                                    }
+                                                   var streamListener = entry.Archive as IArchiveExtractionListener;
+                                                   streamListener.FireEntryExtractionEnd(entry);
                                                });
         }
 #endif


### PR DESCRIPTION
Fire Entry Extraction End event after write stream closes.