### PR TITLE
Added default implementation with warning for symbolic links

### DIFF
--- a/src/SharpCompress/Common/ExtractionOptions.cs
+++ b/src/SharpCompress/Common/ExtractionOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace SharpCompress.Common
+﻿using System;
+
+namespace SharpCompress.Common
 {
     public class ExtractionOptions
     {
@@ -29,6 +31,10 @@
         /// </summary>
         public delegate void SymbolicLinkWriterDelegate(string sourcePath, string targetPath);
 
-        public SymbolicLinkWriterDelegate WriteSymbolicLink;
+        public SymbolicLinkWriterDelegate WriteSymbolicLink =
+            (sourcePath, targetPath) =>
+            {
+                Console.WriteLine($"Could not write symlink {sourcePath} -> {targetPath}, for more information please see https://github.com/dotnet/runtime/issues/24271");
+            };
     }
 }


### PR DESCRIPTION
Hi 

I changed the default implementation for writing symbolic links to emit a warning instead of throwing an exception for this [issue](https://github.com/adamhathcock/sharpcompress/issues/464). 

Not sure how this runs for performance. 

Another thing we could try is to create platform specific commands that call out to a shell command for the various platforms. 

Something like:

```csharp
if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
   ShellCommands.Exec($"mklink /H {source} {target}")
} else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
   ShellCommands.Exec($"ln -s {target} {source}")
} else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
   ShellCommands.Exec($"ln -s {target} {source}")
}
```