### PR TITLE
Ensure TarArchive enumerates all entries

### DIFF
--- a/src/SharpCompress/Common/Tar/TarFilePart.cs
+++ b/src/SharpCompress/Common/Tar/TarFilePart.cs
@@ -24,7 +24,7 @@ namespace SharpCompress.Common.Tar
             if (_seekableStream != null)
             {
                 _seekableStream.Position = Header.DataStartPosition!.Value;
-                return new ReadOnlySubStream(_seekableStream, Header.Size);
+                return new TarReadOnlySubStream(_seekableStream, Header.Size);
             }
             return Header.PackedStream;
         }

--- a/src/SharpCompress/Common/Tar/TarReadOnlySubStream.cs
+++ b/src/SharpCompress/Common/Tar/TarReadOnlySubStream.cs
@@ -20,22 +20,24 @@ namespace SharpCompress.Common.Tar
             {
                 return;
             }
+
             _isDisposed = true;
+
             if (disposing)
             {
-                long skipBytes = _amountRead % 512;
-                if (skipBytes == 0)
+                // Ensure we read all remaining blocks for this entry.
+                Stream.Skip(BytesLeftToRead);
+                _amountRead += BytesLeftToRead;
+
+                // If the last block wasn't a full 512 bytes, skip the remaining padding bytes.
+                var bytesInLastBlock = _amountRead % 512;
+
+                if (bytesInLastBlock != 0)
                 {
-                    return;
+                    Stream.Skip(512 - bytesInLastBlock);
                 }
-                skipBytes = 512 - skipBytes;
-                if (skipBytes == 0)
-                {
-                    return;
-                }
-                var buffer = new byte[skipBytes];
-                Stream.ReadFully(buffer);
             }
+
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
While enumerating the entries of a tar file and writing their contents
to disk using TarArchive, it was discovered TarArchive was not properly
discarding padding bytes in the last block of each entry. TarArchive was
sometimes able to recover depending on the number of padding bytes due
to the logic it uses to find the next entry header, but not always.

TarArchive was changed to use TarReadOnlySubStream when opening entries
and TarReadOnlySubstream was changed to ensure all an entry's blocks are
read when it is being disposed.

Fixes adamhathcock/sharpcompress#524