### PR TITLE
WIP: Automating Deploy to NuGet and Release

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -10,9 +10,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.302
     - run: dotnet run -p build/build.csproj
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -9,7 +9,7 @@ jobs:
         os: [windows-latest, ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.3.3
     - run: dotnet run -p build/build.csproj
     - uses: actions/upload-artifact@v2
       with:
@@ -19,3 +19,24 @@ jobs:
       with:
         name: ${{ matrix.os }}-sharpcompress.snupkg
         path: artifacts/*
+
+  Publish: 
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    runs-on: windows-latest
+    steps:
+        - uses: actions/checkout@v2.3.3
+          with:
+            fetch-depth: 0
+
+        - name: pub
+          shell: pwsh
+          run:  |
+                dotnet tool install GitVersion.Tool --global
+                $version = ((dotnet gitversion src/SharpCompress/SharpCompress.csproj)| ConvertFrom-Json).NuGetVersionV2
+                dotnet run -p build/build.csproj -- $version
+                write-output ${{ secrets.SharpCompress_Token }} | gh auth login --with-token
+                gh release create $version "./artifacts/SharpCompress.$version.nupkg" "./artifacts/SharpCompress.$version.snupkg" --target master --draft
+                dotnet nuget push ./artifacts/SharpCompress.$version.nupkg -k ${{ secrets.SharpCompress_NuGet_Token }} -s https://api.nuget.org/v3/index.json
+                dotnet nuget push ./artifacts/SharpCompress.$version.snupkg -k ${{ secrets.SharpCompress_NuGet_Token }} -s https://api.nuget.org/v3/index.json
+


### PR DESCRIPTION
In response to #506 

### Changes Not Directly Related to Automated Release/Push

- Updated Checkout Action
  - seems there have been many improvements since v1
- Removed dotnet-setup
  - unnecessary as all the images used  have the specified dotnet sdk pre-installed

### GitVersion changes
`        string version = args.Length > 0 ? args[0] : ""; ` and `RunTargetsAndExit(args.Skip(1).ToArray());` kinda bother me, but I wasn't sure how you would want to handle it, so I did a quick and dirty that allowed automation to run, but does require you to give it a version when specifying a target. I could just write it to a file and pull it in if the file exists if you want.

GitVersion is fairly configurable, and you can manually push/create tags to change the major/minor revisions without configuring anything.

### Gihtub Releases
This is dependant on a github token being created (and stored as a secret with the name `SharpCompress_Token`. It needs the `repo` and ` read:org` scopes (https://github.com/settings/tokens). If you add it as a secret for this repo, even if an action printed it to the logs, it should be sanitized before it was written. 

I have it set to save them as drafts with the nuget and symbol package attached. This should allow you to fill in wahtever release notes you like before publishing. This can be configured.

### NuGet Releases
Similar to GitHub Releases, you need a secret named `SharpCompress_NuGet_Token` that can be retrieved from your NuGet account. I have it overriding the versions in the file on build, so they will be automatic thanks to GitVersion.

#### Let me know if there are **Any** changes needed or things that you may need help setting up or working with (I'll do what I can without compromising the security of the repo).

