### PR TITLE
Improve how missing parts are handled

### DIFF
--- a/src/SharpCompress/Archives/Rar/RarArchive.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchive.cs
@@ -10,7 +10,8 @@ using SharpCompress.Readers.Rar;
 
 namespace SharpCompress.Archives.Rar
 {
-    public class RarArchive : AbstractArchive<RarArchiveEntry, RarVolume>
+    public class 
+        RarArchive : AbstractArchive<RarArchiveEntry, RarVolume>
     {
         internal Lazy<IRarUnpack> UnpackV2017 { get; } = new Lazy<IRarUnpack>(() => new SharpCompress.Compressors.Rar.UnpackV2017.Unpack());
         internal Lazy<IRarUnpack> UnpackV1 { get; } = new Lazy<IRarUnpack>(() => new SharpCompress.Compressors.Rar.UnpackV1.Unpack());
@@ -42,7 +43,7 @@ namespace SharpCompress.Archives.Rar
 
         protected override IEnumerable<RarArchiveEntry> LoadEntries(IEnumerable<RarVolume> volumes)
         {
-            return RarArchiveEntryFactory.GetEntries(this, volumes);
+            return RarArchiveEntryFactory.GetEntries(this, volumes, ReaderOptions);
         }
 
         protected override IEnumerable<RarVolume> LoadVolumes(IEnumerable<Stream> streams)

--- a/src/SharpCompress/Archives/Rar/RarArchiveEntry.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchiveEntry.cs
@@ -72,7 +72,7 @@ namespace SharpCompress.Archives.Rar
         {
             get
             {
-                return parts.Select(fp => fp.FileHeader).Any(fh => !fh.IsSplitAfter);
+                return parts.Select(fp => fp.FileHeader).Any(fh => !fh.IsSplitBefore && !fh.IsSplitAfter);
             }
         }
 

--- a/src/SharpCompress/Archives/Rar/RarArchiveEntry.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchiveEntry.cs
@@ -6,6 +6,7 @@ using SharpCompress.Common;
 using SharpCompress.Common.Rar;
 using SharpCompress.Common.Rar.Headers;
 using SharpCompress.Compressors.Rar;
+using SharpCompress.Readers;
 
 namespace SharpCompress.Archives.Rar
 {
@@ -13,11 +14,13 @@ namespace SharpCompress.Archives.Rar
     {
         private readonly ICollection<RarFilePart> parts;
         private readonly RarArchive archive;
+        private readonly ReaderOptions readerOptions;
 
-        internal RarArchiveEntry(RarArchive archive, IEnumerable<RarFilePart> parts)
+        internal RarArchiveEntry(RarArchive archive, IEnumerable<RarFilePart> parts, ReaderOptions readerOptions)
         {
             this.parts = parts.ToList();
             this.archive = archive;
+            this.readerOptions = readerOptions;
         }
 
         public override CompressionType CompressionType => CompressionType.Rar;
@@ -75,7 +78,7 @@ namespace SharpCompress.Archives.Rar
 
         private void CheckIncomplete()
         {
-            if (!IsComplete)
+            if (!readerOptions.DisableCheckIncomplete && !IsComplete)
             {
                 throw new IncompleteArchiveException("ArchiveEntry is incomplete and cannot perform this operation.");
             }

--- a/src/SharpCompress/Archives/Rar/RarArchiveEntryFactory.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchiveEntryFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using SharpCompress.Common.Rar;
+using SharpCompress.Readers;
 
 namespace SharpCompress.Archives.Rar
 {
@@ -36,11 +37,12 @@ namespace SharpCompress.Archives.Rar
         }
 
         internal static IEnumerable<RarArchiveEntry> GetEntries(RarArchive archive,
-                                                                IEnumerable<RarVolume> rarParts)
+                                                                IEnumerable<RarVolume> rarParts,
+                                                                ReaderOptions readerOptions)
         {
             foreach (var groupedParts in GetMatchedFileParts(rarParts))
             {
-                yield return new RarArchiveEntry(archive, groupedParts);
+                yield return new RarArchiveEntry(archive, groupedParts, readerOptions);
             }
         }
     }

--- a/src/SharpCompress/Common/Rar/Headers/FileHeader.cs
+++ b/src/SharpCompress/Common/Rar/Headers/FileHeader.cs
@@ -437,6 +437,7 @@ namespace SharpCompress.Common.Rar.Headers
         internal long DataStartPosition { get; set; }
         public Stream PackedStream { get; set; }
 
+        public bool IsSplitBefore => IsRar5 ? HasHeaderFlag(HeaderFlagsV5.SPLIT_BEFORE) : HasFlag(FileFlagsV4.SPLIT_BEFORE);
         public bool IsSplitAfter => IsRar5 ? HasHeaderFlag(HeaderFlagsV5.SPLIT_AFTER) : HasFlag(FileFlagsV4.SPLIT_AFTER);
 
         public bool IsDirectory => HasFlag(IsRar5 ? FileFlagsV5.DIRECTORY : FileFlagsV4.DIRECTORY);

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -10,5 +10,7 @@ namespace SharpCompress.Readers
         public bool LookForHeader { get; set; }
 
         public string? Password { get; set; }
+
+        public bool DisableCheckIncomplete { get; set; }
     }
 }


### PR DESCRIPTION
I have been doing some work involving processing incomplete RAR files and file sets, and I had to make a few tweaks to make SharpCompress ok with trying to read the partial data and figured they useful enough to share.