### PR TITLE
Do not place extension classes in common namespace

### DIFF
--- a/src/SharpCompress/Polyfills/StreamExtensions.cs
+++ b/src/SharpCompress/Polyfills/StreamExtensions.cs
@@ -1,12 +1,14 @@
 ﻿#if NET461 || NETSTANDARD2_0
 
+using System;
 using System.Buffers;
+using System.IO;
 
-namespace System.IO
+namespace SharpCompress
 {
-    public static class StreamExtensions
+    internal static class StreamExtensions
     {
-        public static int Read(this Stream stream, Span<byte> buffer)
+        internal static int Read(this Stream stream, Span<byte> buffer)
         {
             byte[] temp = ArrayPool<byte>.Shared.Rent(buffer.Length);
 
@@ -24,7 +26,7 @@ namespace System.IO
             }
         }
 
-        public static void Write(this Stream stream, ReadOnlySpan<byte> buffer)
+        internal static void Write(this Stream stream, ReadOnlySpan<byte> buffer)
         {
             byte[] temp = ArrayPool<byte>.Shared.Rent(buffer.Length);
 

--- a/src/SharpCompress/Polyfills/StringExtensions.cs
+++ b/src/SharpCompress/Polyfills/StringExtensions.cs
@@ -1,15 +1,15 @@
 ﻿#if NET461 || NETSTANDARD2_0
 
-namespace System
+namespace SharpCompress
 {
-    public static class StringExtensions
+    internal static class StringExtensions
     {
-        public static bool EndsWith(this string text, char value)
+        internal static bool EndsWith(this string text, char value)
         {
             return text.Length > 0 && text[text.Length - 1] == value;
         }
 
-        public static bool Contains(this string text, char value)
+        internal static bool Contains(this string text, char value)
         {
             return text.IndexOf(value) > -1;
         }


### PR DESCRIPTION
Do not place extension classes in common namespace, as the extension methods might conflict with the same counterpart (same name, same signature) from another separated namespace.