### PR TITLE
Added Seeking feature for BufferedSubStream and ReadOnlySubStream.

### DIFF
--- a/src/SharpCompress/IO/BufferedSubStream.cs
+++ b/src/SharpCompress/IO/BufferedSubStream.cs
@@ -5,79 +5,247 @@ namespace SharpCompress.IO
 {
     internal class BufferedSubStream : NonDisposingStream
     {
-        private long position;
-        private int cacheOffset;
-        private int cacheLength;
-        private readonly byte[] cache;
+        private const int DEFAULT_BUFFER_SIZE = 32768;
+        private readonly long startIndexInBaseStream;
+        private readonly long endIndexInBaseStream;
+        private long positionInBaseStream;
+        private readonly long length;
+        private readonly Stream baseStream;
+        private bool canRead;
+        private bool disposedValue;
 
-        public BufferedSubStream(Stream stream, long origin, long bytesToRead) : base(stream, throwOnDispose: false)
+        private readonly int bufferSize;
+        private int bufferOffset;
+        private int bufferLength;
+        private byte[] buffer;
+
+        public BufferedSubStream(Stream stream) : this(stream, stream.Position, stream.Length - stream.Position, DEFAULT_BUFFER_SIZE)
         {
-            position = origin;
-            BytesLeftToRead = bytesToRead;
-            cache = new byte[32 << 10];
         }
 
-        private long BytesLeftToRead { get; set; }
+        public BufferedSubStream(Stream stream, int bufferSize) : this(stream, stream.Position, stream.Length - stream.Position, bufferSize)
+        {
+        }
 
-        public override bool CanRead => true;
+        public BufferedSubStream(Stream stream, long startIndex, long length) : this(stream, startIndex, length, DEFAULT_BUFFER_SIZE)
+        {
+        }
 
-        public override bool CanSeek => false;
+        public BufferedSubStream(Stream stream, long startIndex, long length, int bufferSize) : base(stream, false)
+        {
+            if (stream == null)
+                throw new ArgumentNullException("stream");
+
+            if (!stream.CanRead)
+                throw new NotSupportedException("A stream that can be read is required");
+
+            if (!stream.CanSeek)
+                throw new NotSupportedException("A stream that supports seeking is required");
+
+            this.endIndexInBaseStream = startIndex + length;
+            if (this.endIndexInBaseStream > stream.Length)
+                throw new ArgumentException("length");
+
+            this.baseStream = stream;
+            this.startIndexInBaseStream = startIndex;
+            this.positionInBaseStream = startIndex;
+            this.length = length;
+            this.bufferOffset = 0;
+            this.bufferLength = 0;
+            this.bufferSize = bufferSize <= 4096 ? DEFAULT_BUFFER_SIZE : bufferSize;
+            this.canRead = true;
+            this.disposedValue = false;
+        }
+
+        public Stream BaseStream
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return this.baseStream;
+            }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return this.length;
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return positionInBaseStream - startIndexInBaseStream - bufferLength + bufferOffset;
+            }
+            set
+            {
+                ThrowIfDisposed();
+                if (value == Position)
+                    return;
+                Seek(value, SeekOrigin.Begin);
+            }
+        }
+
+        public override bool CanRead => canRead && baseStream.CanRead;
+
+        public override bool CanSeek => true;
 
         public override bool CanWrite => false;
 
-        public override void Flush()
+        private void ThrowIfDisposed()
         {
-            throw new NotSupportedException();
+            if (disposedValue)
+                throw new ObjectDisposedException(GetType().ToString());
         }
 
-        public override long Length => BytesLeftToRead;
-
-        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
-
-        public override int Read(byte[] buffer, int offset, int count)
+        private void ThrowIfCantRead()
         {
-            if (count > BytesLeftToRead)
+            if (!CanRead)
+                throw new NotSupportedException("This stream does not support reading");
+        }
+
+        public override int Read(byte[] array, int offset, int count)
+        {
+            if (array == null)
+                throw new ArgumentNullException("array");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", "offset < 0");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", "count < 0");
+            if (array.Length - offset < count)
+                throw new ArgumentException("The size of the array is not enough.");
+
+            ThrowIfDisposed();
+            ThrowIfCantRead();
+
+            if (count == 0)
+                return 0;
+
+            int bytesFromBuffer = ReadFromBuffer(array, offset, count);
+
+            if (bytesFromBuffer == count)
+                return bytesFromBuffer;
+
+            int alreadySatisfied = bytesFromBuffer;
+            if (bytesFromBuffer > 0)
             {
-                count = (int)BytesLeftToRead;
+                count -= bytesFromBuffer;
+                offset += bytesFromBuffer;
             }
 
-            if (count > 0)
+            bufferOffset = bufferLength = 0;
+            lock (baseStream)
             {
-                if (cacheLength == 0)
+                long remaining = endIndexInBaseStream - positionInBaseStream;
+                if (remaining <= 0)
+                    return 0;
+
+                if (count > remaining)
+                    count = (int)remaining;
+
+                if (baseStream.Position != positionInBaseStream)
+                    baseStream.Seek(positionInBaseStream, SeekOrigin.Begin);
+
+                if (count >= this.bufferSize)
                 {
-                    cacheOffset = 0;
-                    Stream.Position = position;
-                    cacheLength = Stream.Read(cache, 0, cache.Length);
-                    position += cacheLength;
+                    int read = baseStream.Read(array, offset, count);
+                    this.positionInBaseStream += read;
+                    return read + alreadySatisfied;
                 }
 
-                if (count > cacheLength)
-                {
-                    count = cacheLength;
-                }
+                if (buffer == null)
+                    buffer = new byte[bufferSize];
 
-                Buffer.BlockCopy(cache, cacheOffset, buffer, offset, count);
-                cacheOffset += count;
-                cacheLength -= count;
-                BytesLeftToRead -= count;
+                bufferLength = baseStream.Read(buffer, 0, (int)Math.Min(remaining, bufferSize));
+                if (bufferLength < 0)
+                    throw new EndOfStreamException();
+                this.positionInBaseStream += bufferLength;
             }
 
-            return count;
+            bytesFromBuffer = ReadFromBuffer(array, offset, count);
+            return bytesFromBuffer + alreadySatisfied;
+        }
+
+        private int ReadFromBuffer(byte[] array, int offset, int count)
+        {
+            int readBytes = bufferLength - bufferOffset;
+            if (readBytes == 0)
+                return 0;
+
+            if (readBytes > count)
+                readBytes = count;
+
+            Buffer.BlockCopy(buffer, bufferOffset, array, offset, readBytes);
+            bufferOffset += readBytes;
+            return readBytes;
         }
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            throw new NotSupportedException();
+            ThrowIfDisposed();
+            long newPos = 0;
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    newPos = offset;
+                    break;
+                case SeekOrigin.Current:
+                    newPos = this.Position + offset;
+                    break;
+                case SeekOrigin.End:
+                    newPos = this.length - offset;
+                    break;
+            }
+
+            long newPosInBaseStream = startIndexInBaseStream + newPos;
+            if (positionInBaseStream - bufferLength <= newPosInBaseStream && newPosInBaseStream <= positionInBaseStream)
+            {
+                bufferOffset = (int)(newPosInBaseStream - (positionInBaseStream - bufferLength));
+            }
+            else
+            {
+                bufferLength = 0;
+                bufferOffset = 0;
+                this.positionInBaseStream = newPosInBaseStream;
+            }
+
+            return newPos;
         }
 
         public override void SetLength(long value)
         {
+            ThrowIfDisposed();
             throw new NotSupportedException();
         }
 
         public override void Write(byte[] buffer, int offset, int count)
         {
+            ThrowIfDisposed();
             throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+            ThrowIfDisposed();
+            throw new NotSupportedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !disposedValue)
+            {
+                canRead = false;
+                disposedValue = true;
+                buffer = null;
+                bufferLength = 0;
+                bufferOffset = 0;
+            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/SharpCompress/IO/ReadOnlySubStream.cs
+++ b/src/SharpCompress/IO/ReadOnlySubStream.cs
@@ -5,79 +5,179 @@ namespace SharpCompress.IO
 {
     internal class ReadOnlySubStream : NonDisposingStream
     {
-        public ReadOnlySubStream(Stream stream, long bytesToRead)
-            : this(stream, null, bytesToRead)
+        private readonly long startIndexInBaseStream;
+        private readonly long endIndexInBaseStream;
+        private long positionInBaseStream;
+        private readonly long length;
+        private readonly Stream baseStream;
+        private bool canRead;
+        private bool disposedValue;
+
+        public ReadOnlySubStream(Stream stream) : this(stream, stream.Position, stream.Length - stream.Position)
         {
         }
 
-        public ReadOnlySubStream(Stream stream, long? origin, long bytesToRead)
-            : base(stream, throwOnDispose: false)
+        public ReadOnlySubStream(Stream stream, long length) : this(stream, stream.Position, length)
         {
-            if (origin != null)
+        }
+
+        public ReadOnlySubStream(Stream stream, long startIndex, long length) : base(stream, false)
+        {
+            if (stream == null)
+                throw new ArgumentNullException("the stream is null");
+
+            if (!stream.CanRead)
+                throw new NotSupportedException("A stream that can be read is required");
+
+            if (!stream.CanSeek)
+                throw new NotSupportedException("A stream that supports seeking is required");
+
+            this.endIndexInBaseStream = startIndex + length;
+            if (this.endIndexInBaseStream > stream.Length)
+                throw new ArgumentException("length");
+
+            this.baseStream = stream;
+            this.startIndexInBaseStream = startIndex;
+            this.positionInBaseStream = startIndex;
+            this.length = length;
+            this.canRead = true;
+            this.disposedValue = false;
+        }
+
+        public Stream BaseStream
+        {
+            get
             {
-                stream.Position = origin.Value;
+                ThrowIfDisposed();
+                return this.baseStream;
             }
-            BytesLeftToRead = bytesToRead;
         }
 
-        private long BytesLeftToRead { get; set; }
+        public override long Length
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return this.length;
+            }
+        }
 
-        public override bool CanRead => true;
+        public override long Position
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return positionInBaseStream - startIndexInBaseStream;
+            }
+            set
+            {
+                ThrowIfDisposed();
+                if (value == Position)
+                    return;
+                Seek(value, SeekOrigin.Begin);
+            }
+        }
 
-        public override bool CanSeek => false;
+        public override bool CanRead => canRead && baseStream.CanRead;
+
+        public override bool CanSeek => true;
 
         public override bool CanWrite => false;
 
-        public override void Flush()
+        private void ThrowIfDisposed()
         {
-            throw new NotSupportedException();
+            if (disposedValue)
+                throw new ObjectDisposedException(GetType().ToString());
         }
 
-        public override long Length => throw new NotSupportedException();
-
-        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
-
-        public override int Read(byte[] buffer, int offset, int count)
+        private void ThrowIfCantRead()
         {
-            if (BytesLeftToRead < count)
-            {
-                count = (int)BytesLeftToRead;
-            }
-            int read = Stream.Read(buffer, offset, count);
-            if (read > 0)
-            {
-                BytesLeftToRead -= read;
-            }
-            return read;
+            if (!CanRead)
+                throw new NotSupportedException("This stream does not support reading");
         }
 
-        public override int ReadByte()
+        public override int Read(byte[] array, int offset, int count)
         {
-            if (BytesLeftToRead <= 0)
+            if (array == null)
+                throw new ArgumentNullException("array");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException("offset", "offset < 0");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", "count < 0");
+            if (array.Length - offset < count)
+                throw new ArgumentException("The size of the array is not enough.");
+
+            ThrowIfDisposed();
+            ThrowIfCantRead();
+
+            if (count == 0)
+                return 0;
+
+            lock (baseStream)
             {
-                return -1;
+                long remaining = endIndexInBaseStream - positionInBaseStream;
+                if (remaining <= 0)
+                    return 0;
+
+                if (count > remaining)
+                    count = (int)remaining;
+
+                if (baseStream.Position != positionInBaseStream)
+                    baseStream.Seek(positionInBaseStream, SeekOrigin.Begin);
+
+                int read = baseStream.Read(array, offset, count);
+                this.positionInBaseStream += read;
+                return read;
             }
-            int value = Stream.ReadByte();
-            if (value != -1)
-            {
-                --BytesLeftToRead;
-            }
-            return value;
         }
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            throw new NotSupportedException();
+            ThrowIfDisposed();
+            long newPos = 0;
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    newPos = offset;
+                    break;
+                case SeekOrigin.Current:
+                    newPos = this.Position + offset;
+                    break;
+                case SeekOrigin.End:
+                    newPos = this.length - offset;
+                    break;
+            }
+
+            this.positionInBaseStream = startIndexInBaseStream + newPos;
+            return newPos;
         }
 
         public override void SetLength(long value)
         {
+            ThrowIfDisposed();
             throw new NotSupportedException();
         }
 
         public override void Write(byte[] buffer, int offset, int count)
         {
+            ThrowIfDisposed();
             throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+            ThrowIfDisposed();
+            throw new NotSupportedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !disposedValue)
+            {
+                canRead = false;
+                disposedValue = true;
+            }
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
Added the seeking feature for BufferedSubStream and ReadOnlySubStream. When the compression type of an entry is Store (uncompressed) in the Zip or APK file, a seekable stream will be obtained by entry.OpenEntryStream(). In game development on the Android platform, it avoids having to decompress files to disk due to a seekable stream being required.

