### PR TITLE
Allowing to seek empty zip files

### DIFF
--- a/src/SharpCompress/Common/Zip/SeekableZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/SeekableZipHeaderFactory.cs
@@ -117,7 +117,8 @@ namespace SharpCompress.Common.Zip
             // Search in reverse
             Array.Reverse(seek);
 
-            var max_search_area = len - MINIMUM_EOCD_LENGTH;
+            // don't exclude the minimum eocd region, otherwise you fail to locate the header in empty zip files
+            var max_search_area = len; // - MINIMUM_EOCD_LENGTH;
 
             for( int pos_from_end = 0; pos_from_end < max_search_area; ++pos_from_end)
             {

--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -290,6 +290,28 @@ namespace SharpCompress.Test.Zip
             Directory.Delete(SCRATCH_FILES_PATH, true);
         }
 
+        /// <summary>
+        /// Creates an empty zip file and attempts to read it right afterwards. 
+        /// Ensures that parsing file headers works even in that case
+        /// </summary>
+        [Fact]
+        public void Zip_Create_Empty_And_Read()
+        {
+            var archive = ZipArchive.Create();
+
+            var archiveStream = new MemoryStream();
+
+            archive.SaveTo(archiveStream, CompressionType.LZMA);
+
+            archiveStream.Position = 0;
+
+            var readArchive = ArchiveFactory.Open(archiveStream);
+
+            var count = readArchive.Entries.Count();
+
+            Assert.Equal(0, count);
+        }
+
         [Fact]
         public void Zip_Create_New_Add_Remove()
         {


### PR DESCRIPTION
In our workflow it may happen that we attempt to access zip files that don't actually have any content. Until earlier versions that worked, but with the last implementation of SeekableZipHeaderFactory it fails. I suggest parsing the entire stream instead of skipping the oecd region. Respective unit test is added, too.

If you accept the changes, please publish a new nuget package.

Best regards