### PR TITLE
Add net461 target to clean up issues with system.* nuget dependencies

### DIFF
--- a/src/SharpCompress/Algorithms/Alder32.cs
+++ b/src/SharpCompress/Algorithms/Alder32.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1 && !NETFRAMEWORK
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -22,7 +22,7 @@ namespace SharpCompress.Algorithms
         /// </summary>
         public const uint SeedValue = 1U;
 
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1 && !NETFRAMEWORK
         private const int MinBufferSize = 64;
 #endif
 
@@ -56,7 +56,7 @@ namespace SharpCompress.Algorithms
                 return SeedValue;
             }
 
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1 && !NETFRAMEWORK
             if (Sse3.IsSupported && buffer.Length >= MinBufferSize)
             {
                 return CalculateSse(adler, buffer);
@@ -69,7 +69,7 @@ namespace SharpCompress.Algorithms
         }
 
         // Based on https://github.com/chromium/chromium/blob/master/third_party/zlib/adler32_simd.c
-#if !NETSTANDARD2_0 && !NETSTANDARD2_1
+#if !NETSTANDARD2_0 && !NETSTANDARD2_1 && !NETFRAMEWORK
         private static unsafe uint CalculateSse(uint adler, ReadOnlySpan<byte> buffer)
         {
             uint s1 = adler & 0xFFFF;

--- a/src/SharpCompress/Common/ArchiveEncoding.cs
+++ b/src/SharpCompress/Common/ArchiveEncoding.cs
@@ -36,12 +36,10 @@ namespace SharpCompress.Common
             Password = password;
         }
 
-#if !NET461
         static ArchiveEncoding()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
-#endif
 
         public string Decode(byte[] bytes)
         {

--- a/src/SharpCompress/Common/ArchiveEncoding.cs
+++ b/src/SharpCompress/Common/ArchiveEncoding.cs
@@ -36,10 +36,12 @@ namespace SharpCompress.Common
             Password = password;
         }
 
+#if !NETFRAMEWORK
         static ArchiveEncoding()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
+#endif
 
         public string Decode(byte[] bytes)
         {

--- a/src/SharpCompress/Compressors/BZip2/BZip2Stream.cs
+++ b/src/SharpCompress/Compressors/BZip2/BZip2Stream.cs
@@ -83,7 +83,7 @@ namespace SharpCompress.Compressors.BZip2
             stream.SetLength(value);
         }
 
-#if !NET461 && !NETSTANDARD2_0
+#if !NETFRAMEWORK && !NETSTANDARD2_0
 
         public override int Read(Span<byte> buffer)
         {

--- a/src/SharpCompress/Compressors/LZMA/LZipStream.cs
+++ b/src/SharpCompress/Compressors/LZMA/LZipStream.cs
@@ -118,7 +118,7 @@ namespace SharpCompress.Compressors.LZMA
         public override void SetLength(long value) => throw new NotImplementedException();
 
 
-#if !NET461 && !NETSTANDARD2_0
+#if !NETFRAMEWORK && !NETSTANDARD2_0
 
         public override int Read(Span<byte> buffer)
         {

--- a/src/SharpCompress/Crypto/Crc32Stream.cs
+++ b/src/SharpCompress/Crypto/Crc32Stream.cs
@@ -42,7 +42,7 @@ namespace SharpCompress.Crypto
 
         public override void SetLength(long value) => throw new NotSupportedException();
 
-#if !NET461 && !NETSTANDARD2_0
+#if !NETFRAMEWORK && !NETSTANDARD2_0
 
         public override void Write(ReadOnlySpan<byte> buffer)
         {

--- a/src/SharpCompress/IO/NonDisposingStream.cs
+++ b/src/SharpCompress/IO/NonDisposingStream.cs
@@ -58,7 +58,7 @@ namespace SharpCompress.IO
             Stream.Write(buffer, offset, count);
         }
 
-#if !NET461 && !NETSTANDARD2_0
+#if !NETFRAMEWORK && !NETSTANDARD2_0
 
         public override int Read(Span<byte> buffer)
         {

--- a/src/SharpCompress/Polyfills/StreamExtensions.cs
+++ b/src/SharpCompress/Polyfills/StreamExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET461 || NETSTANDARD2_0
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
 
 using System;
 using System.Buffers;

--- a/src/SharpCompress/Polyfills/StringExtensions.cs
+++ b/src/SharpCompress/Polyfills/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET461 || NETSTANDARD2_0
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
 
 namespace SharpCompress
 {

--- a/src/SharpCompress/SharpCompress.csproj
+++ b/src/SharpCompress/SharpCompress.csproj
@@ -6,7 +6,7 @@
     <AssemblyVersion>0.29.0</AssemblyVersion>
     <FileVersion>0.29.0</FileVersion>
     <Authors>Adam Hathcock</Authors>
-    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <AssemblyName>SharpCompress</AssemblyName>

--- a/src/SharpCompress/SharpCompress.csproj
+++ b/src/SharpCompress/SharpCompress.csproj
@@ -6,7 +6,7 @@
     <AssemblyVersion>0.29.0</AssemblyVersion>
     <FileVersion>0.29.0</FileVersion>
     <Authors>Adam Hathcock</Authors>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <AssemblyName>SharpCompress</AssemblyName>
@@ -35,8 +35,10 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
-
+  <ItemGroup Condition=" '$(VersionlessImplicitFrameworkDefine)' == 'NETFRAMEWORK' ">
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Reason for change
.NET has a few known issues for libraries that depend on `System.*` and only ship a `netstandard2.0` target

1. .NET has different assembly versions for `netstandard2.0` versus `net461` (see #591). Unless assembly binding redirects are carefully applied, there will be runtime errors.
2. The build output will have tons of "façade" assemblies (see the blogpost in reference 2)

Given the two issues above official guidance is (see reference 1)

> ✔️ CONSIDER adding a target for net461 when you're offering a netstandard2.0 target.
> 
> Using .NET Standard 2.0 from .NET Framework has some issues that were addressed in .NET Framework 4.7.2. You can improve the experience for developers that are still on .NET Framework 4.6.1 - 4.7.1 by offering them a binary that is built for .NET Framework 4.6.1.

So this PR takes the above guidance to make it easier for those of us still stuck on .NET Framework < 4.7.2 :-)

### Example from my recent experience
Due to the recent CVE, I upgraded `SharpCompress` to version  `0.29`. Our code is mostly `.NETFramework`, so we unfortunately have `PackageReferences` to `System.Memory` and `System.Buffers`. Everything appeared to be fine, however at runtime things were failing left and right because most of our projects/nuget dependencies require the latest `System.Memory` and `System.Buffers` while `SharpCompress` requires older versions. This is all avoid requiring a `netstardard2.0` assembly that has an assembly version of `4.0.3.0` (see #591 ) .

After making my change, I found that `.NETFramework` projects work flawlessly without any tricky assembly binding redirects.

### References
1. https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting
2. https://weblog.west-wind.com/posts/2019/Feb/19/Using-NET-Standard-with-Full-Framework-NET
