### PR TITLE
Allow writing a TarHeader directly via TarWriter

### DIFF
--- a/src/SharpCompress/Writers/Tar/TarWriter.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriter.cs
@@ -86,6 +86,12 @@ namespace SharpCompress.Writers.Tar
             header.LastModifiedTime = modificationTime ?? TarHeader.EPOCH;
             header.Name = NormalizeFilename(filename);
             header.Size = realSize;
+
+            Write(header, content);
+        }
+
+        public void Write(TarHeader header, Stream content)
+        {
             header.Write(OutputStream);
 
             size = source.TransferTo(OutputStream);


### PR DESCRIPTION
This splits TarWriter.Write up and adds a new public method to allow writing TarHeaders directly. This allows users to set POSIX attributes that are otherwise not accessible

Fixes #639