### PR TITLE
Feature/malformed zip file generated

### DIFF
--- a/src/SharpCompress/Writers/Zip/ZipCentralDirectoryEntry.cs
+++ b/src/SharpCompress/Writers/Zip/ZipCentralDirectoryEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Binary;
 using System.IO;
 using System.Text;
@@ -98,10 +98,24 @@ namespace SharpCompress.Writers.Zip
 
             BinaryPrimitives.WriteUInt16LittleEndian(intBuf, 0);
             outputStream.Write(intBuf.Slice(0, 2)); // disk=0
-            BinaryPrimitives.WriteUInt16LittleEndian(intBuf, (ushort)flags);
-            outputStream.Write(intBuf.Slice(0, 2)); // file type: binary
-            BinaryPrimitives.WriteUInt16LittleEndian(intBuf, (ushort)flags);
-            outputStream.Write(intBuf.Slice(0, 2)); // Internal file attributes
+
+            // Internal file attributes:
+            // Bit 0: apparent ASCII/ text file
+            // Bit 1: reserved
+            // Bit 2: control field records precede logical records
+            // Bits 3 - 16: unused
+            BinaryPrimitives.WriteUInt16LittleEndian(intBuf, 0);
+            outputStream.Write(intBuf.Slice(0, 2)); // file type: binary, Internal file attributes
+
+            // External flags are host-dependent, this might match DOS
+            // Bit 0: Read-Only
+            // Bit 1: Hidden
+            // Bit 2: System
+            // Bit 3: Label
+            // Bit 4: Directory
+            // Bit 5: Archive
+            BinaryPrimitives.WriteUInt16LittleEndian(intBuf, 0);
+            outputStream.Write(intBuf.Slice(0, 2)); // External file attributes
             BinaryPrimitives.WriteUInt16LittleEndian(intBuf, 0x8100);
             outputStream.Write(intBuf.Slice(0, 2));
 

--- a/tests/SharpCompress.Test/Zip/ZipWriterTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipWriterTests.cs
@@ -2,9 +2,6 @@ using System.Text;
 
 using SharpCompress.Common;
 using Xunit;
-using System.IO;
-using SharpCompress.Writers.Zip;
-using SharpCompress.Compressors.Deflate;
 
 namespace SharpCompress.Test.Zip
 {
@@ -51,24 +48,6 @@ namespace SharpCompress.Test.Zip
         public void Zip_Rar_Write()
         {
             Assert.Throws<InvalidFormatException>(() => Write(CompressionType.Rar, "Zip.ppmd.noEmptyDirs.zip", "Zip.ppmd.noEmptyDirs.zip"));
-        }
-
-        [Fact]
-        public void Zip_Write_MemoryStream()
-        {
-            var ms = new MemoryStream();
-            var zw = new ZipWriter(ms, new ZipWriterOptions(compressionType: CompressionType.Deflate ) { DeflateCompressionLevel = CompressionLevel.None } );
-            var payload = new string('\n', 100000);
-            using (var stream = zw.WriteToStream("test.txt", new ZipWriterEntryOptions()))
-                using (var streamWriter = new StreamWriter(stream: stream))
-            {
-                streamWriter.Write(payload);
-            }
-
-            using( var file = new FileStream("d:\\projects\\test.zip", FileMode.Create, FileAccess.Write))
-            {
-                ms.WriteTo(file);
-            }
         }
     }
 }

--- a/tests/SharpCompress.Test/Zip/ZipWriterTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipWriterTests.cs
@@ -1,7 +1,10 @@
-﻿using System.Text;
+using System.Text;
 
 using SharpCompress.Common;
 using Xunit;
+using System.IO;
+using SharpCompress.Writers.Zip;
+using SharpCompress.Compressors.Deflate;
 
 namespace SharpCompress.Test.Zip
 {
@@ -48,6 +51,24 @@ namespace SharpCompress.Test.Zip
         public void Zip_Rar_Write()
         {
             Assert.Throws<InvalidFormatException>(() => Write(CompressionType.Rar, "Zip.ppmd.noEmptyDirs.zip", "Zip.ppmd.noEmptyDirs.zip"));
+        }
+
+        [Fact]
+        public void Zip_Write_MemoryStream()
+        {
+            var ms = new MemoryStream();
+            var zw = new ZipWriter(ms, new ZipWriterOptions(compressionType: CompressionType.Deflate ) { DeflateCompressionLevel = CompressionLevel.None } );
+            var payload = new string('\n', 100000);
+            using (var stream = zw.WriteToStream("test.txt", new ZipWriterEntryOptions()))
+                using (var streamWriter = new StreamWriter(stream: stream))
+            {
+                streamWriter.Write(payload);
+            }
+
+            using( var file = new FileStream("d:\\projects\\test.zip", FileMode.Create, FileAccess.Write))
+            {
+                ms.WriteTo(file);
+            }
         }
     }
 }


### PR DESCRIPTION
This is connected to issue #666
We are setting wrong flags in the zip directory headers, I am unable to create a test case since we don't expose them, might be the next step.
Would then as an example allow setting "read-only" on a file if an extractor honers it.