### PR TITLE
SourceStream Position counting bug fix

### DIFF
--- a/src/SharpCompress/IO/SourceStream.cs
+++ b/src/SharpCompress/IO/SourceStream.cs
@@ -143,9 +143,17 @@ namespace SharpCompress.IO
 
                 if (!IsVolumes && count != 0 && Current.Position == Current.Length)
                 {
-                    _prevSize += Current.Length;
-                    if (!SetStream(_stream + 1)) //will load next file if present
+                    var length = Current.Length;
+
+                    // Load next file if present
+                    if (!SetStream(_stream + 1)) 
+                    {
                         break;
+                    }
+
+                    // Current stream switched
+                    // Add length of previous stream
+                    _prevSize += length;
                     Current.Seek(0, SeekOrigin.Begin);
                 }
             }

--- a/src/SharpCompress/Utility.cs
+++ b/src/SharpCompress/Utility.cs
@@ -170,10 +170,8 @@ namespace SharpCompress
             byte[] buffer = GetTransferByteArray();
             try
             {
-                var pos = source.Position;
                 int count = 0;
                 var len = source.Read(buffer, 0, buffer.Length);
-                source.Position = pos + len;
 
                 do
                 {


### PR DESCRIPTION
Encountered a position counting bug, it add the stream size even if the stream is not switched.
This should fix it and I also removed the workaround I had.
