### PR TITLE
Added support for reading comment header for Rar v5 archives

### DIFF
--- a/src/SharpCompress/Common/Rar/RarVolume.cs
+++ b/src/SharpCompress/Common/Rar/RarVolume.cs
@@ -57,6 +57,18 @@ namespace SharpCompress.Common.Rar
                             yield return CreateFilePart(lastMarkHeader!, fh);
                         }
                         break;
+                    case HeaderType.Service:
+					    {
+						    var fh = (FileHeader)header;
+						    if (fh.FileName == "CMT")
+						    {
+							    var part = CreateFilePart(lastMarkHeader!, fh);
+							    var buffer = new byte[fh.CompressedSize];
+							    part.GetCompressedStream().Read(buffer, 0, buffer.Length);
+							    Comment = System.Text.Encoding.UTF8.GetString(buffer);
+						    }
+					    }
+					    break;        
                 }
             }
         }
@@ -145,5 +157,7 @@ namespace SharpCompress.Common.Rar
                     return 1;
             }
         }
+        
+        public string? Comment { get; internal set; }
     }
 }


### PR DESCRIPTION
Hello! Like for the Zip archives i tried to add the Comment property in RarVolume, in order to read the comment header from the archive. It only works with Rar v5 archives though