### PR TITLE
Added SupportsRandomAccess property to IArchiveFactory

### DIFF
--- a/src/SharpCompress/Archives/GZip/GZipArchiveFactory.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchiveFactory.cs
@@ -13,6 +13,9 @@ namespace SharpCompress.Archives.GZip
         public string Name => "GZip";
 
         /// <inheritdoc/>
+        public bool SupportsRandomAccess => false;
+
+        /// <inheritdoc/>
         public IEnumerable<string> GetSupportedExtensions()
         {
             yield return "gz";

--- a/src/SharpCompress/Archives/IArchiveFactory.cs
+++ b/src/SharpCompress/Archives/IArchiveFactory.cs
@@ -28,7 +28,13 @@ namespace SharpCompress.Archives
         string Name { get; }
 
         /// <summary>
-        /// returns the extensions typically used by this archive type.
+        /// Indicates whether the archive supports reading entries in a random order,
+        /// or needs to read the entries sequentially using <see cref="IReader"/>.
+        /// </summary>
+        bool SupportsRandomAccess { get; }
+
+        /// <summary>
+        /// Returns the extensions typically used by this archive type.
         /// </summary>
         /// <returns></returns>
         IEnumerable<string> GetSupportedExtensions();

--- a/src/SharpCompress/Archives/Rar/RarArchiveFactory.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchiveFactory.cs
@@ -13,6 +13,9 @@ namespace SharpCompress.Archives.Rar
         public string Name => "Rar";
 
         /// <inheritdoc/>
+        public bool SupportsRandomAccess => true;
+
+        /// <inheritdoc/>
         public IEnumerable<string> GetSupportedExtensions()
         {
             yield return "rar";

--- a/src/SharpCompress/Archives/SevenZip/SevenZipArchiveFactory.cs
+++ b/src/SharpCompress/Archives/SevenZip/SevenZipArchiveFactory.cs
@@ -13,6 +13,9 @@ namespace SharpCompress.Archives.SevenZip
         public string Name => "7Zip";
 
         /// <inheritdoc/>
+        public bool SupportsRandomAccess => true;
+
+        /// <inheritdoc/>
         public IEnumerable<string> GetSupportedExtensions()
         {
             yield return "7z";

--- a/src/SharpCompress/Archives/Tar/TarArchiveFactory.cs
+++ b/src/SharpCompress/Archives/Tar/TarArchiveFactory.cs
@@ -13,9 +13,13 @@ namespace SharpCompress.Archives.Tar
         public string Name => "Tar";
 
         /// <inheritdoc/>
+        public bool SupportsRandomAccess => false;
+
+        /// <inheritdoc/>
         public IEnumerable<string> GetSupportedExtensions()
         {
             yield return "tar";
+            yield return "tgz";
         }
 
         /// <inheritdoc/>

--- a/src/SharpCompress/Archives/Zip/ZipArchiveFactory.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchiveFactory.cs
@@ -13,6 +13,9 @@ namespace SharpCompress.Archives.Zip
         public string Name => "Zip";
 
         /// <inheritdoc/>
+        public bool SupportsRandomAccess => true;
+
+        /// <inheritdoc/>
         public IEnumerable<string> GetSupportedExtensions()
         {
             yield return "zip";


### PR DESCRIPTION
I've been using tgz files and I've realized they require being opened using the IReader interface to read them sequentially.

I thought it could be useful to embed that knowledge in the IArchiveFactory.

So both TAR and GZip factories have that property set to false.

This way, a program that wants to open any kind of archive, would know beforehand which is the preferred way of reading the archive and adjust accordingly.

Also added the "tgz" extension to tar factory....  I guess it would also require "tar.gz"  but I'm hesitant to add extensions with extra dots.
