### PR TITLE
replace Activator.CreateInstance to Func for avoiding error in NativeAOT

### DIFF
--- a/src/SharpCompress/Compressors/Xz/Filters/BlockFilter.cs
+++ b/src/SharpCompress/Compressors/Xz/Filters/BlockFilter.cs
@@ -19,18 +19,18 @@ public abstract class BlockFilter : ReadOnlyStream
         LZMA2 = 0x21
     }
 
-    private static readonly Dictionary<FilterTypes, Type> FilterMap = new Dictionary<
+    private static readonly Dictionary<FilterTypes, Func<BlockFilter>> FilterMap = new Dictionary<
         FilterTypes,
         Type
     >
     {
-        { FilterTypes.ARCH_x86_FILTER, typeof(X86Filter) },
-        { FilterTypes.ARCH_PowerPC_FILTER, typeof(PowerPCFilter) },
-        { FilterTypes.ARCH_IA64_FILTER, typeof(IA64Filter) },
-        { FilterTypes.ARCH_ARM_FILTER, typeof(ArmFilter) },
-        { FilterTypes.ARCH_ARMTHUMB_FILTER, typeof(ArmThumbFilter) },
-        { FilterTypes.ARCH_SPARC_FILTER, typeof(SparcFilter) },
-        { FilterTypes.LZMA2, typeof(Lzma2Filter) }
+        { FilterTypes.ARCH_x86_FILTER, () => new X86Filter() },
+        { FilterTypes.ARCH_PowerPC_FILTER, () => new PowerPCFilter() },
+        { FilterTypes.ARCH_IA64_FILTER, () => new IA64Filter() },
+        { FilterTypes.ARCH_ARM_FILTER, () => new ArmFilter() },
+        { FilterTypes.ARCH_ARMTHUMB_FILTER, () => new ArmThumbFilter() },
+        { FilterTypes.ARCH_SPARC_FILTER, () => new SparcFilter() },
+        { FilterTypes.LZMA2, () => new Lzma2Filter() }
     };
 
     public abstract bool AllowAsLast { get; }
@@ -48,7 +48,7 @@ public abstract class BlockFilter : ReadOnlyStream
             throw new NotImplementedException($"Filter {filterType} has not yet been implemented");
         }
 
-        var filter = (BlockFilter)Activator.CreateInstance(FilterMap[filterType])!;
+        var filter = FilterMap[filterType]()!;
 
         var sizeOfProperties = reader.ReadXZInteger();
         if (sizeOfProperties > int.MaxValue)

--- a/src/SharpCompress/Compressors/Xz/Filters/BlockFilter.cs
+++ b/src/SharpCompress/Compressors/Xz/Filters/BlockFilter.cs
@@ -24,12 +24,12 @@ public abstract class BlockFilter : ReadOnlyStream
         Func<BlockFilter>
     >
     {
-        { FilterTypes.ARCH_x86_FILTER, (Func<BlockFilter>)(() => new X86Filter()) },
-        { FilterTypes.ARCH_PowerPC_FILTER, (Func<BlockFilter>)(() => new PowerPCFilter()) },
-        { FilterTypes.ARCH_IA64_FILTER, (Func<BlockFilter>)(() => new IA64Filter()) },
-        { FilterTypes.ARCH_ARM_FILTER, (Func<BlockFilter>)(() => new ArmFilter()) },
-        { FilterTypes.ARCH_ARMTHUMB_FILTER, (Func<BlockFilter>)(() => new ArmThumbFilter()) },
-        { FilterTypes.ARCH_SPARC_FILTER, (Func<BlockFilter>)(() => new SparcFilter()) },
+        { FilterTypes.ARCH_x86_FILTER, () => new X86Filter() },
+        { FilterTypes.ARCH_PowerPC_FILTER, () => new PowerPCFilter() },
+        { FilterTypes.ARCH_IA64_FILTER, () => new IA64Filter() },
+        { FilterTypes.ARCH_ARM_FILTER, () => new ArmFilter() },
+        { FilterTypes.ARCH_ARMTHUMB_FILTER, () => new ArmThumbFilter() },
+        { FilterTypes.ARCH_SPARC_FILTER, () => new SparcFilter() },
         { FilterTypes.LZMA2, () => new Lzma2Filter() }
     };
 

--- a/src/SharpCompress/Compressors/Xz/Filters/BlockFilter.cs
+++ b/src/SharpCompress/Compressors/Xz/Filters/BlockFilter.cs
@@ -21,15 +21,15 @@ public abstract class BlockFilter : ReadOnlyStream
 
     private static readonly Dictionary<FilterTypes, Func<BlockFilter>> FilterMap = new Dictionary<
         FilterTypes,
-        Type
+        Func<BlockFilter>
     >
     {
-        { FilterTypes.ARCH_x86_FILTER, () => new X86Filter() },
-        { FilterTypes.ARCH_PowerPC_FILTER, () => new PowerPCFilter() },
-        { FilterTypes.ARCH_IA64_FILTER, () => new IA64Filter() },
-        { FilterTypes.ARCH_ARM_FILTER, () => new ArmFilter() },
-        { FilterTypes.ARCH_ARMTHUMB_FILTER, () => new ArmThumbFilter() },
-        { FilterTypes.ARCH_SPARC_FILTER, () => new SparcFilter() },
+        { FilterTypes.ARCH_x86_FILTER, (Func<BlockFilter>)(() => new X86Filter()) },
+        { FilterTypes.ARCH_PowerPC_FILTER, (Func<BlockFilter>)(() => new PowerPCFilter()) },
+        { FilterTypes.ARCH_IA64_FILTER, (Func<BlockFilter>)(() => new IA64Filter()) },
+        { FilterTypes.ARCH_ARM_FILTER, (Func<BlockFilter>)(() => new ArmFilter()) },
+        { FilterTypes.ARCH_ARMTHUMB_FILTER, (Func<BlockFilter>)(() => new ArmThumbFilter()) },
+        { FilterTypes.ARCH_SPARC_FILTER, (Func<BlockFilter>)(() => new SparcFilter()) },
         { FilterTypes.LZMA2, () => new Lzma2Filter() }
     };
 


### PR DESCRIPTION
# Overview

This fixes `System.MissingMethodException` when using XZ decompressor in NativeAOT.

## Steps of reproduce

1. create new console project and set TargetFramework to net7.0
2. add SharpCompress package(this issue was investigated in 0.32.2)
3. edit cs to following reproducible code
4. publish with NativeAOT(and rid) option
5. create xz archive file
6. execute published executable file

### Repro code

```csharp
using SharpCompress.Compressors.Xz;

using(var istm = File.OpenRead("test.xz"))
using(var xstm = new XZStream(istm))
using(var ostm = File.Create("test.txt"))
{
    xstm.CopyTo(ostm);
}
```

## Expected

"test.txt" is created and written decompressed result

## Actual

System.MissingMethodException is thrown.

```
Unhandled Exception: System.MissingMethodException: No parameterless constructor defined for type 'SharpCompress.Compressors.Xz.Filters.Lzma2Filter'.
   at System.ActivatorImplementation.CreateInstance(Type, Boolean) + 0x208
   at System.Reflection.Runtime.General.ReflectionCoreCallbacksImplementation.ActivatorCreateInstance(Type, Boolean) + 0x2c
   at System.Activator.CreateInstance(Type, Boolean) + 0x48
   at System.Activator.CreateInstance(Type) + 0x20
   at SharpCompress.Compressors.Xz.Filters.BlockFilter.Read(BinaryReader) + 0x147
   at SharpCompress.Compressors.Xz.XZBlock.ReadFilters(BinaryReader, Int64) + 0x64
   at SharpCompress.Compressors.Xz.XZBlock.LoadHeader() + 0xdd
   at SharpCompress.Compressors.Xz.XZBlock.Read(Byte[], Int32, Int32) + 0x3f
   at SharpCompress.Compressors.Xz.XZStream.ReadBlocks(Byte[], Int32, Int32) + 0x89
   at SharpCompress.Compressors.Xz.XZStream.Read(Byte[], Int32, Int32) + 0x69
   at System.IO.Stream.CopyTo(Stream, Int32) + 0x155
   at System.IO.Stream.CopyTo(Stream) + 0x58
   at Program.<Main>$(String[]) + 0x82
   at xzcomptest!<BaseAddress>+0x2b9c57
   at xzcomptest!<BaseAddress>+0x2b9cea
```

## Workaround

Currently, this can be avoided by adding class under `SharpCompress.Compressors.Xz.Filters` in rd.xml.
here is example of [rd.xml](https://github.com/kant2002/RdXmlLibrary)

```xml
<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
    <Application>
        <Assembly Name="SharpCompress">
            <Type Name="SharpCompress.Compressors.Xz.Filters.Lzma2Filter" Dynamic="Required All"/>
        </Assembly>
    </Application>
</Directives>
```