### PR TITLE
Skip if we know the size, set blank password if not set for rar

### DIFF
--- a/src/SharpCompress/Common/Rar/RarCryptoWrapper.cs
+++ b/src/SharpCompress/Common/Rar/RarCryptoWrapper.cs
@@ -15,7 +15,7 @@ internal sealed class RarCryptoWrapper : Stream
     {
         _actualStream = actualStream;
         _salt = salt;
-        _rijndael = RarRijndael.InitializeFrom(password, salt);
+        _rijndael = RarRijndael.InitializeFrom(password ?? "", salt);
     }
 
     public override void Flush() => throw new NotSupportedException();

--- a/src/SharpCompress/Readers/AbstractReader.cs
+++ b/src/SharpCompress/Readers/AbstractReader.cs
@@ -129,7 +129,7 @@ public abstract class AbstractReader<TEntry, TVolume> : IReader, IReaderExtracti
     {
         var part = Entry.Parts.First();
 
-        if (ArchiveType != ArchiveType.Rar && !Entry.IsSolid && Entry.CompressedSize > 0)
+        if ( !Entry.IsSolid && Entry.CompressedSize > 0)
         {
             //not solid and has a known compressed size then we can skip raw bytes.
             var rawStream = part.GetRawStream();

--- a/src/SharpCompress/Readers/AbstractReader.cs
+++ b/src/SharpCompress/Readers/AbstractReader.cs
@@ -129,7 +129,7 @@ public abstract class AbstractReader<TEntry, TVolume> : IReader, IReaderExtracti
     {
         var part = Entry.Parts.First();
 
-        if ( !Entry.IsSolid && Entry.CompressedSize > 0)
+        if (!Entry.IsSolid && Entry.CompressedSize > 0)
         {
             //not solid and has a known compressed size then we can skip raw bytes.
             var rawStream = part.GetRawStream();

--- a/src/SharpCompress/Readers/Rar/NonSeekableStreamFilePart.cs
+++ b/src/SharpCompress/Readers/Rar/NonSeekableStreamFilePart.cs
@@ -11,5 +11,7 @@ internal class NonSeekableStreamFilePart : RarFilePart
 
     internal override Stream GetCompressedStream() => FileHeader.PackedStream;
 
+    internal override Stream? GetRawStream() => FileHeader.PackedStream;
+
     internal override string FilePartName => "Unknown Stream - File Entry: " + FileHeader.FileName;
 }

--- a/tests/SharpCompress.Test/Rar/RarReaderTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarReaderTests.cs
@@ -332,4 +332,44 @@ public class RarReaderTests : ReaderTests
             }
         }
     }
+
+    [Fact]
+    public void Rar_NullReference()
+    {
+        {
+            var archives = new[]
+            {
+            "Rar.EncryptedParts.part01.rar",
+            "Rar.EncryptedParts.part02.rar",
+            "Rar.EncryptedParts.part03.rar",
+            "Rar.EncryptedParts.part04.rar",
+            "Rar.EncryptedParts.part05.rar",
+            "Rar.EncryptedParts.part06.rar"
+        };
+
+            using (
+                var reader = RarReader.Open(
+                    archives
+                        .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
+                        .Select(p => File.OpenRead(p)),
+                    new ReaderOptions() { Password = "test" }
+                )
+            )
+            {
+                while (reader.MoveToNextEntry())
+                {
+                    //
+                }
+            }
+        }
+
+        {
+            using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar"));
+            using var reader = ReaderFactory.Open(stream, new ReaderOptions() { LookForHeader = true });
+            while (reader.MoveToNextEntry())
+            {
+                //
+            }
+        }
+    }
 }

--- a/tests/SharpCompress.Test/Rar/RarReaderTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarReaderTests.cs
@@ -339,13 +339,13 @@ public class RarReaderTests : ReaderTests
         {
             var archives = new[]
             {
-            "Rar.EncryptedParts.part01.rar",
-            "Rar.EncryptedParts.part02.rar",
-            "Rar.EncryptedParts.part03.rar",
-            "Rar.EncryptedParts.part04.rar",
-            "Rar.EncryptedParts.part05.rar",
-            "Rar.EncryptedParts.part06.rar"
-        };
+                "Rar.EncryptedParts.part01.rar",
+                "Rar.EncryptedParts.part02.rar",
+                "Rar.EncryptedParts.part03.rar",
+                "Rar.EncryptedParts.part04.rar",
+                "Rar.EncryptedParts.part05.rar",
+                "Rar.EncryptedParts.part06.rar"
+            };
 
             using (
                 var reader = RarReader.Open(
@@ -364,8 +364,13 @@ public class RarReaderTests : ReaderTests
         }
 
         {
-            using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar"));
-            using var reader = ReaderFactory.Open(stream, new ReaderOptions() { LookForHeader = true });
+            using var stream = File.OpenRead(
+                Path.Combine(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar")
+            );
+            using var reader = ReaderFactory.Open(
+                stream,
+                new ReaderOptions() { LookForHeader = true }
+            );
             while (reader.MoveToNextEntry())
             {
                 //


### PR DESCRIPTION
Proposal for #743 , where the rar archive headers are not encrypted but the files are.
@yousa123080 , you can try this and see if it helps your case.