### PR TITLE
Add fast `ExtractToDirectoryAsync` extension method on `IArchive`

### DIFF
--- a/src/SharpCompress/Archives/IArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveExtensions.cs
@@ -60,8 +60,7 @@ public static class IArchiveExtensions
 
             // Create each directory
             var path = Path.Combine(destination, entry.Key);
-            if (Path.GetDirectoryName(path) is { } directory
-                && seenDirectories.Add(path))
+            if (Path.GetDirectoryName(path) is { } directory && seenDirectories.Add(path))
             {
                 Directory.CreateDirectory(directory);
             }

--- a/src/SharpCompress/Archives/IArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveExtensions.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using SharpCompress.Common;
 
 namespace SharpCompress.Archives;
@@ -19,4 +24,56 @@ public static class IArchiveExtensions
             entry.WriteToDirectory(destinationDirectory, options);
         }
     }
+
+    /// <summary>
+    /// Extracts the archive to the destination directory in the thread pool. Directories will be created as needed.
+    /// </summary>
+    /// <param name="archive">The archive to extract.</param>
+    /// <param name="destination">The folder to extract into.</param>
+    /// <param name="progressReport">Optional progress report callback.</param>
+    /// <param name="cancellationToken">Optional cancellation token</param>
+    public static Task ExtractToDirectoryAsync(
+        this IArchive archive,
+        string destination,
+        Action<double>? progressReport = null,
+        CancellationToken cancellationToken = default
+    ) => Task.Run(() =>
+                  {
+                      // Prepare for progress reporting
+                      var totalBytes = archive.TotalUncompressSize;
+                      var bytesRead = 0L;
+
+                      // Tracking for created directories.
+                      var seenDirectories = new HashSet<string>();
+
+                      // Extract
+                      var entries = archive.ExtractAllEntries();
+                      while (entries.MoveToNextEntry())
+                      {
+                          cancellationToken.ThrowIfCancellationRequested();
+
+                          var entry = entries.Entry;
+                          if (entry.IsDirectory)
+                          {
+                              continue;
+                          }
+
+                          // Create each directory
+                          var path = Path.Combine(destination, entry.Key);
+                          if (Path.GetDirectoryName(path) is { } directory
+                              && seenDirectories.Add(path))
+                          {
+                              Directory.CreateDirectory(directory);
+                          }
+
+                          // Write file
+                          using var fs = File.OpenWrite(path);
+                          entries.WriteEntryTo(fs); // TODO: Some day, this may be async.
+
+                          // Update progress
+                          bytesRead += entry.Size;
+                          progressReport?.Invoke(bytesRead / (double)totalBytes);
+                      }
+                  },
+                  cancellationToken);
 }


### PR DESCRIPTION
As mentioned in #728 (and I believe some other issues), the `IArchive.WriteToDirectory(...)` extension method can be very slow for `.7z` files. This extension utilized `IArchive.ExtractAllEntries()` and `IReader` so is fast for .7z files.

Being async has nothing to do with the performance, rather, it's because I use this extension method from an async method and need it to perform the long-running work asynchronously. Ideally `IArchive.ExtractAllEntries()` and `IReader.WriteEntryTo(Stream)` would be async as well and then the whole Task.Run wouldn't be needed and then it would make more sense to be async.

It currently doesn't support `ExtractionOptions` or reporting progress through `IArchive`'s events (although it does report progress through a callback). But, it works great as-is for my use case, which I suspect is pretty common, and I wanted to share.