### PR TITLE
Throw ReaderCancelledException on reader cancelled

### DIFF
--- a/src/SharpCompress/Common/ReaderCancelledException.cs
+++ b/src/SharpCompress/Common/ReaderCancelledException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace SharpCompress.Common;
+
+public class ReaderCancelledException : Exception
+
+{
+    public ReaderCancelledException(string message)
+        : base(message) { }
+
+    public ReaderCancelledException(string message, Exception inner)
+        : base(message, inner) { }
+}

--- a/src/SharpCompress/Readers/AbstractReader.cs
+++ b/src/SharpCompress/Readers/AbstractReader.cs
@@ -75,7 +75,7 @@ public abstract class AbstractReader<TEntry, TVolume> : IReader, IReaderExtracti
         }
         if (Cancelled)
         {
-            throw new InvalidOperationException("Reader has been cancelled.");
+            throw new ReaderCancelledException("Reader has been cancelled.");
         }
         if (entriesForCurrentReadStream is null)
         {


### PR DESCRIPTION
I needed a way to gracefully handle a cancellation. It would have been much easier to catch a specific type of exception instead of relying on the message of `InvalidOperationException`.

So, here you go!