### PR TITLE
Revert change disabling strong name signing in 92df1ec

### DIFF
--- a/src/SharpCompress/SharpCompress.csproj
+++ b/src/SharpCompress/SharpCompress.csproj
@@ -9,7 +9,7 @@
 		<TargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
 		<AssemblyName>SharpCompress</AssemblyName>
 		<AssemblyOriginatorKeyFile>../../SharpCompress.snk</AssemblyOriginatorKeyFile>
-		<SignAssembly>False</SignAssembly>
+		<SignAssembly>true</SignAssembly>
 		<PackageId>SharpCompress</PackageId>
 		<PackageTags>rar;unrar;zip;unzip;bzip2;gzip;tar;7zip;lzip;xz</PackageTags>
 		<PackageProjectUrl>https://github.com/adamhathcock/sharpcompress</PackageProjectUrl>
@@ -23,7 +23,7 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<IsTrimmable>true</IsTrimmable>
 		<LangVersion>latest</LangVersion>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
As title mentions. Strong name signing was disabled via 92df1ec in a large merge adding zstd support. 

Due to [this comment from @adamhathcock](https://github.com/adamhathcock/sharpcompress/issues/764#issuecomment-1723218890), I believe this was just a mistake. So here is a PR which resolves the issue. 

Accepting this PR will fix #764