### PR TITLE
ZipWriter: Write correct EOCD record when more than 65,535 files

### DIFF
--- a/src/SharpCompress/Writers/Zip/ZipWriter.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriter.cs
@@ -304,7 +304,10 @@ public class ZipWriter : AbstractWriter
 
         // Write normal end of central directory record
         OutputStream.Write(stackalloc byte[] { 80, 75, 5, 6, 0, 0, 0, 0 });
-        BinaryPrimitives.WriteUInt16LittleEndian(intBuf, (ushort)entries.Count);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            intBuf,
+            (ushort)(entries.Count < 0xFFFF ? entries.Count : 0xFFFF)
+        );
         OutputStream.Write(intBuf.Slice(0, 2));
         OutputStream.Write(intBuf.Slice(0, 2));
         BinaryPrimitives.WriteUInt32LittleEndian(intBuf, sizevalue);


### PR DESCRIPTION
0xFFFF will be written to the EOCD to signal to use the ZIP64 CentralDirectory record when the number of files is 65,535 or more. Fixes #791