### PR TITLE
Fix reporting size / position

### DIFF
--- a/src/SharpCompress/IO/DataDescriptorStream.cs
+++ b/src/SharpCompress/IO/DataDescriptorStream.cs
@@ -51,7 +51,7 @@ public class DataDescriptorStream : Stream
 
     public override long Position
     {
-        get => _stream.Position;
+        get => _stream.Position - _start;
         set => _stream.Position = value;
     }
 


### PR DESCRIPTION
#795

We get out of sync after reporting the wrong size, mess up the 64 bit detection later