### PR TITLE
Zip: Use last modified time from basic header when validating zip decryption

### DIFF
--- a/src/SharpCompress/Common/Zip/Headers/DirectoryEntryHeader.cs
+++ b/src/SharpCompress/Common/Zip/Headers/DirectoryEntryHeader.cs
@@ -14,8 +14,8 @@ internal class DirectoryEntryHeader : ZipFileEntry
         VersionNeededToExtract = reader.ReadUInt16();
         Flags = (HeaderFlags)reader.ReadUInt16();
         CompressionMethod = (ZipCompressionMethod)reader.ReadUInt16();
-        LastModifiedTime = reader.ReadUInt16();
-        LastModifiedDate = reader.ReadUInt16();
+        OriginalLastModifiedTime = LastModifiedTime = reader.ReadUInt16();
+        OriginalLastModifiedDate = LastModifiedDate = reader.ReadUInt16();
         Crc = reader.ReadUInt32();
         CompressedSize = reader.ReadUInt32();
         UncompressedSize = reader.ReadUInt32();

--- a/src/SharpCompress/Common/Zip/Headers/LocalEntryHeader.cs
+++ b/src/SharpCompress/Common/Zip/Headers/LocalEntryHeader.cs
@@ -13,8 +13,8 @@ internal class LocalEntryHeader : ZipFileEntry
         Version = reader.ReadUInt16();
         Flags = (HeaderFlags)reader.ReadUInt16();
         CompressionMethod = (ZipCompressionMethod)reader.ReadUInt16();
-        LastModifiedTime = reader.ReadUInt16();
-        LastModifiedDate = reader.ReadUInt16();
+        OriginalLastModifiedTime = LastModifiedTime = reader.ReadUInt16();
+        OriginalLastModifiedDate = LastModifiedDate = reader.ReadUInt16();
         Crc = reader.ReadUInt32();
         CompressedSize = reader.ReadUInt32();
         UncompressedSize = reader.ReadUInt32();

--- a/src/SharpCompress/Common/Zip/Headers/ZipFileEntry.cs
+++ b/src/SharpCompress/Common/Zip/Headers/ZipFileEntry.cs
@@ -67,8 +67,26 @@ internal abstract class ZipFileEntry : ZipHeader
 
     internal WinzipAesEncryptionData WinzipAesEncryptionData { get; set; }
 
+    /// <summary>
+    /// The last modified date as read from the Local or Central Directory header.
+    /// </summary>
+    internal ushort OriginalLastModifiedDate { get; set; }
+
+    /// <summary>
+    /// The last modified date from the UnixTimeExtraField, if present, or the
+    /// Local or Cental Directory header, if not.
+    /// </summary>
     internal ushort LastModifiedDate { get; set; }
 
+    /// <summary>
+    /// The last modified time as read from the Local or Central Directory header.
+    /// </summary>
+    internal ushort OriginalLastModifiedTime { get; set; }
+
+    /// <summary>
+    /// The last modified time from the UnixTimeExtraField, if present, or the
+    /// Local or Cental Directory header, if not.
+    /// </summary>
     internal ushort LastModifiedTime { get; set; }
 
     internal uint Crc { get; set; }

--- a/src/SharpCompress/Common/Zip/PkwareTraditionalEncryptionData.cs
+++ b/src/SharpCompress/Common/Zip/PkwareTraditionalEncryptionData.cs
@@ -39,7 +39,7 @@ internal class PkwareTraditionalEncryptionData
             {
                 throw new CryptographicException("The password did not match.");
             }
-            if (plainTextHeader[11] != (byte)((header.LastModifiedTime >> 8) & 0xff))
+            if (plainTextHeader[11] != (byte)((header.OriginalLastModifiedTime >> 8) & 0xff))
             {
                 throw new CryptographicException("The password did not match.");
             }


### PR DESCRIPTION
The last modified time used for zip decryption validation must be the one from the basic header. If UnixTimeExtraFields are present, the previous implementation was attempting to verify against that value instead.
Fixed #804