### PR TITLE
Fix gzip archives having a `Type` of `ArchiveType.Tar` instead of `ArchiveType.Gzip`

### DIFF
--- a/src/SharpCompress/Archives/GZip/GZipArchive.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchive.cs
@@ -101,7 +101,7 @@ public class GZipArchive : AbstractWritableArchive<GZipArchiveEntry, GZipVolume>
     /// </summary>
     /// <param name="sourceStream"></param>
     private GZipArchive(SourceStream sourceStream)
-        : base(ArchiveType.Tar, sourceStream) { }
+        : base(ArchiveType.GZip, sourceStream) { }
 
     protected override IEnumerable<GZipVolume> LoadVolumes(SourceStream sourceStream)
     {

--- a/tests/SharpCompress.Test/GZip/GZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using SharpCompress.Archives;
 using SharpCompress.Archives.GZip;
 using SharpCompress.Archives.Tar;
+using SharpCompress.Common;
 using Xunit;
 
 namespace SharpCompress.Test.GZip;
@@ -106,7 +107,7 @@ public class GZipArchiveTests : ArchiveTests
     }
 
     [Fact]
-    public void TestGzCrcWithMostSignificaltBitNotNegative()
+    public void TestGzCrcWithMostSignificantBitNotNegative()
     {
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         using var archive = GZipArchive.Open(stream);
@@ -115,5 +116,13 @@ public class GZipArchiveTests : ArchiveTests
         {
             Assert.InRange(entry.Crc, 0L, 0xFFFFFFFFL);
         }
+    }
+
+    [Fact]
+    public void TestGzArchiveTypeGzip()
+    {
+        using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
+        using var archive = GZipArchive.Open(stream);
+        Assert.Equal(archive.Type, ArchiveType.GZip);
     }
 }


### PR DESCRIPTION
- fixes #845
