### PR TITLE
Fixed extractions after first ZIP64 entry is read from stream

### DIFF
--- a/src/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
@@ -34,13 +34,7 @@ internal class StreamingZipHeaderFactory : ZipHeaderFactory
             ZipHeader? header;
             var reader = new BinaryReader(rewindableStream);
             uint headerBytes = 0;
-            if (
-                _lastEntryHeader != null
-                && (
-                    FlagUtility.HasFlag(_lastEntryHeader.Flags, HeaderFlags.UsePostDataDescriptor)
-                    || _lastEntryHeader.IsZip64
-                )
-            )
+            if (_lastEntryHeader != null && FlagUtility.HasFlag(_lastEntryHeader.Flags, HeaderFlags.UsePostDataDescriptor))
             {
                 if (_lastEntryHeader.Part is null)
                 {
@@ -52,15 +46,57 @@ internal class StreamingZipHeaderFactory : ZipHeaderFactory
 
                 var pos = rewindableStream.CanSeek ? (long?)rewindableStream.Position : null;
 
+                var crc = reader.ReadUInt32();
+                if (crc == POST_DATA_DESCRIPTOR)
+                {
+                    crc = reader.ReadUInt32();
+                }
+                _lastEntryHeader.Crc = crc;
+
+                // The DataDescriptor can be either 64bit or 32bit
+                var compressed_size = reader.ReadUInt32();
+                var uncompressed_size = reader.ReadUInt32();
+
+                // Check if we have header or 64bit DataDescriptor
+                headerBytes = reader.ReadUInt32();
+                var test_header = !(headerBytes == 0x04034b50 || headerBytes == 0x02014b50);
+
+                var test_64bit = ((long)uncompressed_size << 32) | compressed_size;
+                if (test_64bit == _lastEntryHeader.CompressedSize && test_header)
+                {
+                    _lastEntryHeader.UncompressedSize =
+                        ((long)reader.ReadUInt32() << 32) | headerBytes;
+                    headerBytes = reader.ReadUInt32();
+                }
+                else
+                {
+                    _lastEntryHeader.UncompressedSize = uncompressed_size;
+                }
+
+                if (pos.HasValue)
+                {
+                    _lastEntryHeader.DataStartPosition = pos - _lastEntryHeader.CompressedSize;
+                }
+            }
+            else if (_lastEntryHeader != null && _lastEntryHeader.IsZip64)
+            {
+                if (_lastEntryHeader.Part is null)
+                    continue;
+
+                reader = ((StreamingZipFilePart)_lastEntryHeader.Part).FixStreamedFileLocation(ref rewindableStream);
+
+                var pos = rewindableStream.CanSeek ? (long?)rewindableStream.Position : null;
+
                 headerBytes = reader.ReadUInt32();
 
                 var version = reader.ReadUInt16();
                 var flags = (HeaderFlags)reader.ReadUInt16();
                 var compressionMethod = (ZipCompressionMethod)reader.ReadUInt16();
-                var lastModifiedTime = reader.ReadUInt16();
                 var lastModifiedDate = reader.ReadUInt16();
+                var lastModifiedTime = reader.ReadUInt16();
 
                 var crc = reader.ReadUInt32();
+
                 if (crc == POST_DATA_DESCRIPTOR)
                 {
                     crc = reader.ReadUInt32();

--- a/src/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/StreamingZipHeaderFactory.cs
@@ -34,7 +34,10 @@ internal class StreamingZipHeaderFactory : ZipHeaderFactory
             ZipHeader? header;
             var reader = new BinaryReader(rewindableStream);
             uint headerBytes = 0;
-            if (_lastEntryHeader != null && FlagUtility.HasFlag(_lastEntryHeader.Flags, HeaderFlags.UsePostDataDescriptor))
+            if (
+                _lastEntryHeader != null
+                && FlagUtility.HasFlag(_lastEntryHeader.Flags, HeaderFlags.UsePostDataDescriptor)
+            )
             {
                 if (_lastEntryHeader.Part is null)
                 {
@@ -83,7 +86,9 @@ internal class StreamingZipHeaderFactory : ZipHeaderFactory
                 if (_lastEntryHeader.Part is null)
                     continue;
 
-                reader = ((StreamingZipFilePart)_lastEntryHeader.Part).FixStreamedFileLocation(ref rewindableStream);
+                reader = ((StreamingZipFilePart)_lastEntryHeader.Part).FixStreamedFileLocation(
+                    ref rewindableStream
+                );
 
                 var pos = rewindableStream.CanSeek ? (long?)rewindableStream.Position : null;
 

--- a/src/SharpCompress/Common/Zip/ZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/ZipHeaderFactory.cs
@@ -56,11 +56,11 @@ internal class ZipHeaderFactory
             case POST_DATA_DESCRIPTOR:
             {
                 if (
+                    _lastEntryHeader != null &&
                     FlagUtility.HasFlag(
                         _lastEntryHeader.NotNull().Flags,
                         HeaderFlags.UsePostDataDescriptor
                     )
-                    && _lastEntryHeader != null
                 )
                 {
                     _lastEntryHeader.Crc = reader.ReadUInt32();

--- a/src/SharpCompress/Common/Zip/ZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/ZipHeaderFactory.cs
@@ -56,8 +56,8 @@ internal class ZipHeaderFactory
             case POST_DATA_DESCRIPTOR:
             {
                 if (
-                    _lastEntryHeader != null &&
-                    FlagUtility.HasFlag(
+                    _lastEntryHeader != null
+                    && FlagUtility.HasFlag(
                         _lastEntryHeader.NotNull().Flags,
                         HeaderFlags.UsePostDataDescriptor
                     )


### PR DESCRIPTION
When a ZIP64 entry is extracted from an archive, the header for the next entry is read out of order. This commit reads the header again, then resets the position of the RewindableStream back to the beginning of the entry, just after the 4 byte header signature. This ensures the correct header signature data and reader (in the correct position) are fed to ReadHeader. Previously this would have read the data at an incorrect offset and would not yield a viable ZipHeader.

I haven't done extensive testing with this nor did I write any automated tests.