### PR TITLE
Fix for missing empty directories when using ExtractToDirectory

### DIFF
--- a/src/SharpCompress/Archives/IArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveExtensions.cs
@@ -55,7 +55,10 @@ public static class IArchiveExtensions
             if (entry.IsDirectory)
             {
                 var dirPath = Path.Combine(destination, entry.Key.NotNull("Entry Key is null"));
-                if (Path.GetDirectoryName(dirPath + "/") is { } emptyDirectory && seenDirectories.Add(dirPath))
+                if (
+                    Path.GetDirectoryName(dirPath + "/") is { } emptyDirectory
+                    && seenDirectories.Add(dirPath)
+                )
                 {
                     Directory.CreateDirectory(emptyDirectory);
                 }

--- a/src/SharpCompress/Archives/IArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveExtensions.cs
@@ -54,14 +54,23 @@ public static class IArchiveExtensions
             var entry = entries.Entry;
             if (entry.IsDirectory)
             {
+                var dirPath = Path.Combine(destination, entry.Key.NotNull("Entry Key is null"));
+                if (Path.GetDirectoryName(dirPath + "/") is { } emptyDirectory && seenDirectories.Add(dirPath))
+                {
+                    Directory.CreateDirectory(emptyDirectory);
+                }
                 continue;
             }
 
-            // Create each directory
+            // Create each directory if not already created
             var path = Path.Combine(destination, entry.Key.NotNull("Entry Key is null"));
-            if (Path.GetDirectoryName(path) is { } directory && seenDirectories.Add(path))
+            if (Path.GetDirectoryName(path) is { } directory)
             {
-                Directory.CreateDirectory(directory);
+                if (!Directory.Exists(directory) && !seenDirectories.Contains(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                    seenDirectories.Add(directory);
+                }
             }
 
             // Write file


### PR DESCRIPTION
Fixes: #851 
This creates empty directories without skipping them when using ExtractToDirectory.