### PR TITLE
Fix #858 - Replaces invalid filename characters

### DIFF
--- a/src/SharpCompress/Common/ExtractionMethods.cs
+++ b/src/SharpCompress/Common/ExtractionMethods.cs
@@ -37,6 +37,7 @@ internal static class ExtractionMethods
         options ??= new ExtractionOptions() { Overwrite = true };
 
         var file = Path.GetFileName(entry.Key.NotNull("Entry Key is null")).NotNull("File is null");
+        file = Utility.ReplaceInvalidFileNameChars(file);
         if (options.ExtractFullPath)
         {
             var folder = Path.GetDirectoryName(entry.Key.NotNull("Entry Key is null"))

--- a/src/SharpCompress/Utility.cs
+++ b/src/SharpCompress/Utility.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using SharpCompress.Readers;
 
 namespace SharpCompress;
@@ -433,5 +434,18 @@ public static class Utility
         buffer[offset + 1] = (byte)(number >> 16);
         buffer[offset + 2] = (byte)(number >> 8);
         buffer[offset + 3] = (byte)number;
+    }
+
+    public static string ReplaceInvalidFileNameChars(string fileName)
+    {
+        var invalidChars = new HashSet<char>(Path.GetInvalidFileNameChars());
+        var sb = new StringBuilder(fileName.Length);
+        foreach (var c in fileName)
+        {
+            var newChar = invalidChars.Contains(c) ? '_' : c;
+            sb.Append(newChar);
+        }
+
+        return sb.ToString();
     }
 }


### PR DESCRIPTION
Add a method to replace invalid characters in file names with underscores during file extraction. This prevents errors related to invalid file names.