### PR TITLE
Embed debugging symbols

### DIFF
--- a/src/SharpCompress/SharpCompress.csproj
+++ b/src/SharpCompress/SharpCompress.csproj
@@ -19,8 +19,8 @@
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<Description>SharpCompress is a compression library for NET Standard 2.0/NET Standard 2.1/NET 6.0/NET 8.0 that can unrar, decompress 7zip, decompress xz, zip/unzip, tar/untar lzip/unlzip, bzip2/unbzip2 and gzip/ungzip with forward-only reading and file random access APIs. Write support for zip/tar/bzip2/gzip is implemented.</Description>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<DebugType>embedded</DebugType>
 		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<LangVersion>latest</LangVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
This greatly simplifies debugging of SharpCompress source because it removes the need to setup nuget symbol downloading.

It also simplifies debugging scenarios for anyone who is not using NuGet for some reason (e.g. git submodule, or another build system).