### PR TITLE
Restore stream position in ArchiveFactory.IsArchive

### DIFF
--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -189,9 +189,10 @@ public static class ArchiveFactory
 
         foreach (var factory in Factory.Factories)
         {
+            var isArchive = factory.IsArchive(stream);
             stream.Position = startPosition;
 
-            if (factory.IsArchive(stream, null))
+            if (isArchive)
             {
                 type = factory.KnownArchiveType;
                 return true;


### PR DESCRIPTION
- closes #870

By resetting the stream position after the archive check, the stream position will be restored to its original value after the method returns.