### PR TITLE
Fixed bug in zip time header flags

### DIFF
--- a/src/SharpCompress/Common/Zip/Headers/LocalEntryHeaderExtraFactory.cs
+++ b/src/SharpCompress/Common/Zip/Headers/LocalEntryHeaderExtraFactory.cs
@@ -166,10 +166,10 @@ internal sealed class UnixTimeExtraField : ExtraData
                 return Tuple.Create<DateTime?, DateTime?, DateTime?>(null, null, null);
             }
 
-            var flags = DataBytes[0];
-            var isModifiedTimeSpecified = (flags & 0x01) == 1;
-            var isLastAccessTimeSpecified = (flags & 0x02) == 1;
-            var isCreationTimeSpecified = (flags & 0x04) == 1;
+            var flags = (RecordedTimeFlag)DataBytes[0];
+            var isModifiedTimeSpecified = flags.HasFlag(RecordedTimeFlag.LastModified);
+            var isLastAccessTimeSpecified = flags.HasFlag(RecordedTimeFlag.LastAccessed);
+            var isCreationTimeSpecified = flags.HasFlag(RecordedTimeFlag.Created);
             var currentIndex = 1;
             DateTime? modifiedTime = null;
             DateTime? lastAccessTime = null;
@@ -189,7 +189,7 @@ internal sealed class UnixTimeExtraField : ExtraData
             {
                 if (currentIndex + 4 > DataBytes.Length)
                 {
-                    throw new ArchiveException("Invalid UnicodeExtraTime field");
+                    return Tuple.Create<DateTime?, DateTime?, DateTime?>(null, null, null);
                 }
 
                 var lastAccessEpochTime = BinaryPrimitives.ReadInt32LittleEndian(
@@ -206,7 +206,7 @@ internal sealed class UnixTimeExtraField : ExtraData
             {
                 if (currentIndex + 4 > DataBytes.Length)
                 {
-                    throw new ArchiveException("Invalid UnicodeExtraTime field");
+                    return Tuple.Create<DateTime?, DateTime?, DateTime?>(null, null, null);
                 }
 
                 var creationTimeEpochTime = BinaryPrimitives.ReadInt32LittleEndian(
@@ -221,6 +221,15 @@ internal sealed class UnixTimeExtraField : ExtraData
 
             return Tuple.Create(modifiedTime, lastAccessTime, creationTime);
         }
+    }
+
+    [Flags]
+    private enum RecordedTimeFlag
+    {
+        None = 0,
+        LastModified = 1,
+        LastAccessed = 2,
+        Created = 4
     }
 }
 

--- a/src/SharpCompress/Common/Zip/ZipEntry.cs
+++ b/src/SharpCompress/Common/Zip/ZipEntry.cs
@@ -22,7 +22,10 @@ public class ZipEntry : Entry
             filePart.Header.LastModifiedTime
         );
 
-        var times = filePart.Header.Extra.FirstOrDefault(header => header.GetType() == typeof(UnixTimeExtraField)) as UnixTimeExtraField;
+        var times =
+            filePart.Header.Extra.FirstOrDefault(header =>
+                header.GetType() == typeof(UnixTimeExtraField)
+            ) as UnixTimeExtraField;
 
         LastAccessedTime = times?.UnicodeTimes.Item2;
         CreatedTime = times?.UnicodeTimes.Item3;

--- a/src/SharpCompress/Common/Zip/ZipEntry.cs
+++ b/src/SharpCompress/Common/Zip/ZipEntry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using SharpCompress.Common.Zip.Headers;
 
 namespace SharpCompress.Common.Zip;
@@ -15,10 +16,16 @@ public class ZipEntry : Entry
             return;
         }
         _filePart = filePart;
+
         LastModifiedTime = Utility.DosDateToDateTime(
             filePart.Header.LastModifiedDate,
             filePart.Header.LastModifiedTime
         );
+
+        var times = filePart.Header.Extra.FirstOrDefault(header => header.GetType() == typeof(UnixTimeExtraField)) as UnixTimeExtraField;
+
+        LastAccessedTime = times?.UnicodeTimes.Item2;
+        CreatedTime = times?.UnicodeTimes.Item3;
     }
 
     public override CompressionType CompressionType =>
@@ -51,9 +58,17 @@ public class ZipEntry : Entry
 
     public override DateTime? LastModifiedTime { get; }
 
-    public override DateTime? CreatedTime => null;
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The returned time is UTC, not local.
+    /// </remarks>
+    public override DateTime? CreatedTime { get; }
 
-    public override DateTime? LastAccessedTime => null;
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The returned time is UTC, not local.
+    /// </remarks>
+    public override DateTime? LastAccessedTime { get; }
 
     public override DateTime? ArchivedTime => null;
 


### PR DESCRIPTION
Parsing the times in the zip headers worked, but the flag check was wrong, so only modified time was ever parsed. Corrected this in a more readable way.

Also stopped exceptions being thrown if there was an issue during this header parsing, returning null values instead.

Remarks have been added to highlight that they return UTC `DateTime`'s, rather than `LastModifiedTime` which returns a local `DateTime`.