### PR TITLE
Add support for .ISO file type

### DIFF
--- a/FORMATS.md
+++ b/FORMATS.md
@@ -5,6 +5,7 @@
 * Archive classes allow random access to a seekable stream.
 * Reader classes allow forward-only reading on a stream.
 * Writer classes allow forward-only Writing on a stream.
+* ISO archives are now supported for reading and extraction.
 
 ## Supported Format Table
 
@@ -19,6 +20,7 @@
 | Tar.XZ                 | LZMA2                                             | Decompress          | TarArchive      | TarReader  | TarWriter (3) |
 | GZip (single file)     | DEFLATE                                           | Both                | GZipArchive     | GZipReader | GZipWriter    |
 | 7Zip (4)               | LZMA, LZMA2, BZip2, PPMd, BCJ, BCJ2, Deflate      | Decompress          | SevenZipArchive | N/A        | N/A           |
+| ISO                    | None                                              | Decompress          | IsoArchive      | N/A        | N/A           |
 
 1. SOLID Rars are only supported in the RarReader API.
 2. Zip format supports pkware and WinzipAES encryption. However, encrypted LZMA is not supported. Zip64 reading/writing is supported but only with seekable streams as the Zip spec doesn't support Zip64 data in post data descriptors. Deflate64 is only supported for reading.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SharpCompress
 
-SharpCompress is a compression library in pure C# for .NET Framework 4.62, .NET Standard 2.1, .NET 6.0 and NET 8.0 that can unrar, un7zip, unzip, untar unbzip2, ungzip, unlzip with forward-only reading and file random access APIs. Write support for zip/tar/bzip2/gzip/lzip are implemented.
+SharpCompress is a compression library in pure C# for .NET Framework 4.62, .NET Standard 2.1, .NET 6.0 and NET 8.0 that can unrar, un7zip, unzip, untar unbzip2, ungzip, unlzip, uniso with forward-only reading and file random access APIs. Write support for zip/tar/bzip2/gzip/lzip are implemented.
 
 The major feature is support for non-seekable streams so large files can be processed on the fly (i.e. download stream).
 
@@ -23,6 +23,8 @@ Zip is okay, but it's a very hap-hazard format and the variation in headers and 
 RAR is not recommended as it's a propriatory format and the compression is closed source. Use Tar/LZip for LZMA
 
 7Zip and XZ both are overly complicated. 7Zip does not support streamable formats. XZ has known holes explained here: (http://www.nongnu.org/lzip/xz_inadequate.html) Use Tar/LZip for LZMA compression instead.
+
+ISO is now supported for reading and extraction, making it a viable option for certain use cases.
 
 ## A Simple Request
 

--- a/src/SharpCompress/Archives/AutoArchiveFactory.cs
+++ b/src/SharpCompress/Archives/AutoArchiveFactory.cs
@@ -14,8 +14,29 @@ class AutoArchiveFactory : IArchiveFactory
 
     public IEnumerable<string> GetSupportedExtensions() => throw new NotSupportedException();
 
-    public bool IsArchive(Stream stream, string? password = null) =>
-        throw new NotSupportedException();
+    public bool IsArchive(Stream stream, string? password = null)
+    {
+        stream.CheckNotNull(nameof(stream));
+        if (!stream.CanRead || !stream.CanSeek)
+        {
+            throw new ArgumentException("Stream should be readable and seekable");
+        }
+
+        var startPosition = stream.Position;
+
+        foreach (var factory in Factory.Factories)
+        {
+            var isArchive = factory.IsArchive(stream);
+            stream.Position = startPosition;
+
+            if (isArchive)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     public FileInfo? GetFilePart(int index, FileInfo part1) => throw new NotSupportedException();
 

--- a/src/SharpCompress/Archives/IArchiveFactory.cs
+++ b/src/SharpCompress/Archives/IArchiveFactory.cs
@@ -15,6 +15,7 @@ namespace SharpCompress.Archives;
 /// <item><see cref="ZipFactory"/></item>
 /// <item><see cref="GZipFactory"/></item>
 /// <item><see cref="SevenZipFactory"/></item>
+/// <item><see cref="IsoFactory"/></item>
 /// </list>
 /// </remarks>
 public interface IArchiveFactory : IFactory

--- a/src/SharpCompress/Archives/IWriteableArchiveFactory.cs
+++ b/src/SharpCompress/Archives/IWriteableArchiveFactory.cs
@@ -9,6 +9,7 @@ namespace SharpCompress.Archives;
 /// <item><see cref="Factories.TarFactory"/></item>
 /// <item><see cref="Factories.ZipFactory"/></item>
 /// <item><see cref="Factories.GZipFactory"/></item>
+/// <item><see cref="Factories.IsoFactory"/></item>
 /// </list>
 public interface IWriteableArchiveFactory : Factories.IFactory
 {

--- a/src/SharpCompress/Archives/Iso/IsoArchive.cs
+++ b/src/SharpCompress/Archives/Iso/IsoArchive.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using SharpCompress.Common;
+using SharpCompress.IO;
+using SharpCompress.Readers;
+using SharpCompress.Readers.Iso;
+
+namespace SharpCompress.Archives.Iso;
+
+public class IsoArchive : AbstractWritableArchive<IsoArchiveEntry, IsoVolume>
+{
+    public static IsoArchive Open(string filePath, ReaderOptions? readerOptions = null)
+    {
+        filePath.CheckNotNullOrEmpty(nameof(filePath));
+        return Open(new FileInfo(filePath), readerOptions ?? new ReaderOptions());
+    }
+
+    public static IsoArchive Open(FileInfo fileInfo, ReaderOptions? readerOptions = null)
+    {
+        fileInfo.CheckNotNull(nameof(fileInfo));
+        return new IsoArchive(
+            new SourceStream(
+                fileInfo,
+                i => ArchiveVolumeFactory.GetFilePart(i, fileInfo),
+                readerOptions ?? new ReaderOptions()
+            )
+        );
+    }
+
+    public static IsoArchive Open(IEnumerable<FileInfo> fileInfos, ReaderOptions? readerOptions = null)
+    {
+        fileInfos.CheckNotNull(nameof(fileInfos));
+        var files = fileInfos.ToArray();
+        return new IsoArchive(
+            new SourceStream(
+                files[0],
+                i => i < files.Length ? files[i] : null,
+                readerOptions ?? new ReaderOptions()
+            )
+        );
+    }
+
+    public static IsoArchive Open(IEnumerable<Stream> streams, ReaderOptions? readerOptions = null)
+    {
+        streams.CheckNotNull(nameof(streams));
+        var strms = streams.ToArray();
+        return new IsoArchive(
+            new SourceStream(
+                strms[0],
+                i => i < strms.Length ? strms[i] : null,
+                readerOptions ?? new ReaderOptions()
+            )
+        );
+    }
+
+    public static IsoArchive Open(Stream stream, ReaderOptions? readerOptions = null)
+    {
+        stream.CheckNotNull(nameof(stream));
+        return new IsoArchive(
+            new SourceStream(stream, _ => null, readerOptions ?? new ReaderOptions())
+        );
+    }
+
+    public static IsoArchive Create() => new();
+
+    private IsoArchive(SourceStream sourceStream)
+        : base(ArchiveType.Iso, sourceStream) { }
+
+    protected override IEnumerable<IsoVolume> LoadVolumes(SourceStream sourceStream)
+    {
+        sourceStream.LoadAllParts();
+        return sourceStream.Streams.Select(a => new IsoVolume(a, ReaderOptions, 0));
+    }
+
+    public void SaveTo(string filePath) => SaveTo(new FileInfo(filePath));
+
+    public void SaveTo(FileInfo fileInfo)
+    {
+        using var stream = fileInfo.Open(FileMode.Create, FileAccess.Write);
+        SaveTo(stream, new WriterOptions(CompressionType.None));
+    }
+
+    internal IsoArchive()
+        : base(ArchiveType.Iso) { }
+
+    protected override IsoArchiveEntry CreateEntryInternal(
+        string filePath,
+        Stream source,
+        long size,
+        DateTime? modified,
+        bool closeStream
+    )
+    {
+        return new IsoWritableArchiveEntry(this, source, filePath, size, modified, closeStream);
+    }
+
+    protected override void SaveTo(
+        Stream stream,
+        WriterOptions options,
+        IEnumerable<IsoArchiveEntry> oldEntries,
+        IEnumerable<IsoArchiveEntry> newEntries
+    )
+    {
+        using var writer = new IsoWriter(stream, options);
+        foreach (var entry in oldEntries.Concat(newEntries).Where(x => !x.IsDirectory))
+        {
+            using var entryStream = entry.OpenEntryStream();
+            writer.Write(
+                entry.Key.NotNull("Entry Key is null"),
+                entryStream,
+                entry.LastModifiedTime
+            );
+        }
+    }
+
+    protected override IEnumerable<IsoArchiveEntry> LoadEntries(IEnumerable<IsoVolume> volumes)
+    {
+        var stream = volumes.Single().Stream;
+        yield return new IsoArchiveEntry(
+            this,
+            new IsoFilePart(stream, ReaderOptions.ArchiveEncoding)
+        );
+    }
+
+    protected override IReader CreateReaderForSolidExtraction()
+    {
+        var stream = Volumes.Single().Stream;
+        stream.Position = 0;
+        return IsoReader.Open(stream);
+    }
+}

--- a/src/SharpCompress/Archives/Iso/IsoArchiveEntry.cs
+++ b/src/SharpCompress/Archives/Iso/IsoArchiveEntry.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using SharpCompress.Common;
+using SharpCompress.IO;
+
+namespace SharpCompress.Archives.Iso;
+
+public class IsoArchiveEntry : IArchiveEntry
+{
+    private readonly IsoArchive archive;
+    private readonly IsoFilePart part;
+
+    internal IsoArchiveEntry(IsoArchive archive, IsoFilePart part)
+    {
+        this.archive = archive;
+        this.part = part;
+    }
+
+    public bool IsComplete => true;
+
+    public IArchive Archive => archive;
+
+    public string Key => part.Key;
+
+    public long CompressedSize => part.CompressedSize;
+
+    public long Size => part.Size;
+
+    public DateTime? LastModifiedTime => part.LastModifiedTime;
+
+    public DateTime? CreatedTime => part.CreatedTime;
+
+    public DateTime? LastAccessedTime => part.LastAccessedTime;
+
+    public DateTime? ArchivedTime => part.ArchivedTime;
+
+    public bool IsEncrypted => false;
+
+    public bool IsDirectory => part.IsDirectory;
+
+    public bool IsSplitAfter => false;
+
+    public Stream OpenEntryStream()
+    {
+        var stream = part.GetStream();
+        stream.Seek(part.EntryStartPosition, SeekOrigin.Begin);
+        return stream;
+    }
+
+    internal void Close()
+    {
+        part.Close();
+    }
+}


### PR DESCRIPTION
Add support for .ISO file type to the SharpCompress library.

* **New Files**:
  - Add `IsoArchive.cs` to handle .ISO archives.
  - Add `IsoArchiveEntry.cs` to represent entries in .ISO archives.

* **Documentation**:
  - Update `FORMATS.md` to include .ISO in the supported format table and mention .ISO support in the Accessing Archives section.
  - Update `README.md` to include .ISO in the list of supported formats and mention .ISO support in the Recommended Formats section.

* **Archive Factory**:
  - Update `ArchiveFactory.cs` to include .ISO support.
  - Update `IArchiveFactory.cs` to add `IsoFactory` to the list of known archive factories.
  - Update `IWriteableArchiveFactory.cs` to add `IsoFactory` to the list of writable archive factories.
  - Update `AutoArchiveFactory.cs` to add support for .ISO archives in the `IsArchive` method and update the `Open` method to handle .ISO archives.

