### PR TITLE
Fix zip entry handling for entries with data descriptors

### DIFF
--- a/src/SharpCompress/Common/Zip/SeekableZipFilePart.cs
+++ b/src/SharpCompress/Common/Zip/SeekableZipFilePart.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using SharpCompress.Common.Zip.Headers;
-using SharpCompress.IO;
 
 namespace SharpCompress.Common.Zip;
 
@@ -8,18 +7,13 @@ internal class SeekableZipFilePart : ZipFilePart
 {
     private bool _isLocalHeaderLoaded;
     private readonly SeekableZipHeaderFactory _headerFactory;
-    private readonly DirectoryEntryHeader _directoryEntryHeader;
 
     internal SeekableZipFilePart(
         SeekableZipHeaderFactory headerFactory,
         DirectoryEntryHeader header,
         Stream stream
     )
-        : base(header, stream)
-    {
-        _headerFactory = headerFactory;
-        _directoryEntryHeader = header;
-    }
+        : base(header, stream) => _headerFactory = headerFactory;
 
     internal override Stream GetCompressedStream()
     {
@@ -43,16 +37,6 @@ internal class SeekableZipFilePart : ZipFilePart
     protected override Stream CreateBaseStream()
     {
         BaseStream.Position = Header.DataStartPosition.NotNull();
-
-        if (
-            (Header.CompressedSize == 0)
-            && FlagUtility.HasFlag(Header.Flags, HeaderFlags.UsePostDataDescriptor)
-            && _directoryEntryHeader.HasData
-            && (_directoryEntryHeader.CompressedSize != 0)
-        )
-        {
-            return new ReadOnlySubStream(BaseStream, _directoryEntryHeader.CompressedSize);
-        }
 
         return BaseStream;
     }

--- a/src/SharpCompress/Common/Zip/SeekableZipHeaderFactory.cs
+++ b/src/SharpCompress/Common/Zip/SeekableZipHeaderFactory.cs
@@ -149,6 +149,12 @@ internal sealed class SeekableZipHeaderFactory : ZipHeaderFactory
         {
             throw new InvalidOperationException();
         }
+        if (FlagUtility.HasFlag(localEntryHeader.Flags, HeaderFlags.UsePostDataDescriptor))
+        {
+            localEntryHeader.Crc = directoryEntryHeader.Crc;
+            localEntryHeader.CompressedSize = directoryEntryHeader.CompressedSize;
+            localEntryHeader.UncompressedSize = directoryEntryHeader.UncompressedSize;
+        }
         return localEntryHeader;
     }
 }

--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -808,4 +808,14 @@ public class ZipArchiveTests : ArchiveTests
             Assert.Equal("きょきゅんきゃんきゅ_wav.frq", reader.Entry.Key);
         }
     }
+
+    [Fact]
+    public void TestDataDescriptorRead()
+    {
+        using var archive = ArchiveFactory.Open(Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip"));
+        var firstEntry = archive.Entries.First();
+        Assert.Equal(199, firstEntry.Size);
+        using var _ = firstEntry.OpenEntryStream();
+        Assert.Equal(199, firstEntry.Size);
+    }
 }

--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -812,7 +812,9 @@ public class ZipArchiveTests : ArchiveTests
     [Fact]
     public void TestDataDescriptorRead()
     {
-        using var archive = ArchiveFactory.Open(Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip"));
+        using var archive = ArchiveFactory.Open(
+            Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.datadescriptors.zip")
+        );
         var firstEntry = archive.Entries.First();
         Assert.Equal(199, firstEntry.Size);
         using var _ = firstEntry.OpenEntryStream();


### PR DESCRIPTION
- closes #88

See the included test for how this issue surfaces. The missing fields in the local header will now be set from the directory header if the `UsePostDataDescriptor` bit is set in the local header's flags.