### PR TITLE
Fix for Rar4 v20 compression.

### DIFF
--- a/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack20.cs
+++ b/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack20.cs
@@ -369,7 +369,7 @@ internal partial class Unpack
         destUnpSize -= Length;
 
         var DestPtr = unpPtr - Distance;
-        if (DestPtr < PackDef.MAXWINSIZE - 300 && unpPtr < PackDef.MAXWINSIZE - 300)
+        if (DestPtr >= 0 && DestPtr < PackDef.MAXWINSIZE - 300 && unpPtr < PackDef.MAXWINSIZE - 300)
         {
             window[unpPtr++] = window[DestPtr++];
             window[unpPtr++] = window[DestPtr++];


### PR DESCRIPTION
Fix for #216 which I had recently encountered too. This is a small change to CopyString20(), after making it I noticed the same condition already existed in CopyString(). So I'm confident it's good.

The fix has since been tested on over 300 archives that were failing to decompress with the latest SharpCompress and over 250ish were fixed. 