### PR TITLE
Fix condition in rar v3 code

### DIFF
--- a/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack.cs
+++ b/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack.cs
@@ -713,6 +713,8 @@ internal sealed partial class Unpack : BitInput, IRarUnpack, IDisposable
 
     private void UnpWriteData(byte[] data, int offset, int size)
     {
+        // allow destUnpSize == 0 here to ensure that 0 size writes
+        // go through RarStream's Write so that Suspended is set correctly
         if (destUnpSize < 0)
         {
             return;

--- a/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack.cs
+++ b/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack.cs
@@ -263,7 +263,7 @@ internal sealed partial class Unpack : BitInput, IRarUnpack, IDisposable
             if (((wrPtr - unpPtr) & PackDef.MAXWINMASK) < 260 && wrPtr != unpPtr)
             {
                 UnpWriteBuf();
-                if (destUnpSize <= 0)
+                if (destUnpSize < 0)
                 {
                     return;
                 }
@@ -713,7 +713,7 @@ internal sealed partial class Unpack : BitInput, IRarUnpack, IDisposable
 
     private void UnpWriteData(byte[] data, int offset, int size)
     {
-        if (destUnpSize <= 0)
+        if (destUnpSize < 0)
         {
             return;
         }

--- a/src/SharpCompress/Compressors/Rar/UnpackV2017/Unpack.unpack50_cpp.cs
+++ b/src/SharpCompress/Compressors/Rar/UnpackV2017/Unpack.unpack50_cpp.cs
@@ -655,7 +655,9 @@ internal partial class Unpack
 
     private void UnpWriteData(byte[] Data, size_t offset, size_t Size)
     {
-        if (WrittenFileSize >= DestUnpSize)
+        // allow WrittenFileSize == DestUnpSize here to ensure that 0 size writes
+        // go through RarStream's Write so that Suspended is set correctly
+        if (WrittenFileSize > DestUnpSize)
         {
             return;
         }

--- a/src/SharpCompress/Compressors/Rar/UnpackV2017/Unpack.unpack50_cpp.cs
+++ b/src/SharpCompress/Compressors/Rar/UnpackV2017/Unpack.unpack50_cpp.cs
@@ -655,9 +655,7 @@ internal partial class Unpack
 
     private void UnpWriteData(byte[] Data, size_t offset, size_t Size)
     {
-        // allow WrittenFileSize == DestUnpSize here to ensure that 0 size writes
-        // go through RarStream's Write so that Suspended is set correctly
-        if (WrittenFileSize > DestUnpSize)
+        if (WrittenFileSize >= DestUnpSize)
         {
             return;
         }


### PR DESCRIPTION
- closes #890

This was an interesting one to track down. Basically, when `UnpWriteData` is called with a size of `0`, it must call `writeStream.Write` even if `destUnpSize` is 0 to ensure that `Suspended` is set to false.
The same condition change must be done here: https://github.com/adamhathcock/sharpcompress/blob/94789ce455cf88cbe0636abc0071c1c03d4a2ebf/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack.cs#L266 
to make sure that the code passes over both `if (destUnpSize < 0)` and `if (suspended)` conditions and continues below.

While investigating this bug I found some other issues in the rarVM code, but I'm not sure how to test them and whether that code is even still used nowadays.

TODO: Find some example archive that shows this bug that isn't 40MB and add a test case for it.