### PR TITLE
use File.OpenRead instead of File.Open in tests to allow concurrent access

### DIFF
--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -568,7 +568,7 @@ public class ZipArchiveTests : ArchiveTests
     {
         var zipFile = Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.pkware.zip");
 
-        using var fileStream = File.Open(zipFile, FileMode.Open);
+        using var fileStream = File.OpenRead(zipFile);
         using var archive = ArchiveFactory.Open(
             fileStream,
             new ReaderOptions { Password = "12345678" }
@@ -729,7 +729,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_Uncompressed_Read_All()
     {
         var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
-        using var stream = File.Open(zipPath, FileMode.Open, FileAccess.Read);
+        using var stream = File.OpenRead(zipPath);
         var archive = ArchiveFactory.Open(stream);
         var reader = archive.ExtractAllEntries();
         var entries = 0;
@@ -758,7 +758,7 @@ public class ZipArchiveTests : ArchiveTests
             "DEADBEEF",
         };
         var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
-        using var stream = File.Open(zipPath, FileMode.Open, FileAccess.Read);
+        using var stream = File.OpenRead(zipPath);
         var archive = ArchiveFactory.Open(stream);
         var reader = archive.ExtractAllEntries();
         var x = 0;
@@ -775,7 +775,7 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_Forced_Ignores_UnicodePathExtra()
     {
         var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.UnicodePathExtra.zip");
-        using (var stream = File.Open(zipPath, FileMode.Open, FileAccess.Read))
+        using (var stream = File.OpenRead(zipPath))
         {
             var archive = ArchiveFactory.Open(
                 stream,
@@ -791,7 +791,7 @@ public class ZipArchiveTests : ArchiveTests
             reader.MoveToNextEntry();
             Assert.Equal("궖귛궖귙귪궖귗귪궖귙_wav.frq", reader.Entry.Key);
         }
-        using (var stream = File.Open(zipPath, FileMode.Open, FileAccess.Read))
+        using (var stream = File.OpenRead(zipPath))
         {
             var archive = ArchiveFactory.Open(
                 stream,

--- a/tests/SharpCompress.Test/Zip/ZipReaderTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipReaderTests.cs
@@ -342,7 +342,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_ReaderFactory_Uncompressed_Read_All()
     {
         var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
-        using var stream = File.Open(zipPath, FileMode.Open, FileAccess.Read);
+        using var stream = File.OpenRead(zipPath);
         using var reader = ReaderFactory.Open(stream);
         while (reader.MoveToNextEntry())
         {
@@ -355,7 +355,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_ReaderFactory_Uncompressed_Skip_All()
     {
         var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "Zip.uncompressed.zip");
-        using var stream = File.Open(zipPath, FileMode.Open, FileAccess.Read);
+        using var stream = File.OpenRead(zipPath);
         using var reader = ReaderFactory.Open(stream);
         while (reader.MoveToNextEntry()) { }
     }
@@ -364,7 +364,7 @@ public class ZipReaderTests : ReaderTests
     public void Zip_Uncompressed_64bit()
     {
         var zipPath = Path.Combine(TEST_ARCHIVES_PATH, "64bitstream.zip.7z");
-        using var stream = File.Open(zipPath, FileMode.Open, FileAccess.Read);
+        using var stream = File.OpenRead(zipPath);
         var archive = ArchiveFactory.Open(stream);
         var reader = archive.ExtractAllEntries();
         reader.MoveToNextEntry();


### PR DESCRIPTION
When running all tests concurrently, it could happens that multiple tests accessed the same test file at the same time.

This should not be an issue when just reading the files, however the usage of `File.Open` without a `FileShare` parameter made the access exclusive and caused each subsequent call to fail. This was especially noticable in the `Zip_Uncompressed_64bit` test due to the long time it takes. 