### PR TITLE
Rar2 v20,v26 Multimedia (Audio) decoder fix

### DIFF
--- a/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack20.cs
+++ b/src/SharpCompress/Compressors/Rar/UnpackV1/Unpack20.cs
@@ -14,7 +14,13 @@ namespace SharpCompress.Compressors.Rar.UnpackV1;
 
 internal partial class Unpack
 {
-    private readonly MultDecode[] MD = new MultDecode[4];
+    private readonly MultDecode[] MD = new[]
+    {
+        new MultDecode(),
+        new MultDecode(),
+        new MultDecode(),
+        new MultDecode()
+    };
 
     private readonly byte[] UnpOldTable20 = new byte[PackDef.MC20 * 4];
 
@@ -475,6 +481,31 @@ internal partial class Unpack
                 {
                     Table[I++] = 0;
                 }
+                // Nanook. Working port from Rar C code. Added when working on Audio Decode Fix. Seems equal to above, so commented it
+                //byte v;
+                //if (Number == 16)
+                //{
+                //    N = (Utility.URShift(GetBits(), 14)) + 3;
+                //    AddBits(2);
+                //    v = Table[I - 1];
+                //}
+                //else
+                //{
+                //    N = (Number - 17) * 4;
+                //    int bits = 3 + N;
+                //    N += N + 3 + (Utility.URShift(GetBits(), 16 - bits));
+                //    AddBits(bits);
+                //    v = 0;
+                //}
+                //N += I;
+                //if (N > TableSize)
+                //{
+                //    N = TableSize; // original unRAR
+                //}
+                //do
+                //{
+                //    Table[I++] = v;
+                //} while (I < N);
             }
         }
         if (inAddr > readTop)
@@ -559,8 +590,7 @@ internal partial class Unpack
         PCh = (Utility.URShift(PCh, 3)) & 0xFF;
 
         var Ch = PCh - Delta;
-
-        var D = ((byte)Delta) << 3;
+        var D = ((sbyte)Delta) << 3;
 
         v.Dif[0] += Math.Abs(D); // V->Dif[0]+=abs(D);
         v.Dif[1] += Math.Abs(D - v.D1); // V->Dif[1]+=abs(D-V->D1);
@@ -574,7 +604,7 @@ internal partial class Unpack
         v.Dif[9] += Math.Abs(D - UnpChannelDelta); // V->Dif[9]+=abs(D-UnpChannelDelta);
         v.Dif[10] += Math.Abs(D + UnpChannelDelta); // V->Dif[10]+=abs(D+UnpChannelDelta);
 
-        v.LastDelta = (byte)(Ch - v.LastChar);
+        v.LastDelta = (sbyte)(Ch - v.LastChar);
         UnpChannelDelta = v.LastDelta;
         v.LastChar = Ch; // V->LastChar=Ch;
 


### PR DESCRIPTION
This is a fix for the Audio Decoder in unpack20 (v20/v26). When decoding a rar that uses the old multimedia compression algorithm an error is raised:

```
Object reference not set to an instance of an object.
   at SharpCompress.Compressors.Rar.UnpackV1.UnpackUtility.makeDecodeTables(Span`1 lenTab, Int32 offset, Decode dec, Int32 size) in /_/SharpCompress/Compressors/Rar/UnpackV1/UnpackUtility.cs:line 197

```

This is because the MultiDecode[] objects are never instantiated.

`private readonly MultDecode[] MD = new MultDecode[4];`  (Unpack20.cs:17)

I looked back through the repo hoping to find and old working commit, but they have never been set. I even dug out the original Unrar project (pre SharpCompress) and that was the same.

This fixed the crash, but the decompression still wasn't correct. After many hours, I decided to compare the code with the C++ implementation used by 7zip and finally tracked it down to 2 bad casts in the Audio Decoder - (byte) when it should actually be (sbyte). Fortunately the rest of the code seemed to work perfectly after that (big relief).

I've not got any small archives that display this behaviour for use with unit tests. Current tests pass and this fix is being tested on many archives.

:-)
