### PR TITLE
Implement ReadByte for BufferedSubStream

### DIFF
--- a/src/SharpCompress/IO/BufferedSubStream.cs
+++ b/src/SharpCompress/IO/BufferedSubStream.cs
@@ -59,6 +59,30 @@ internal class BufferedSubStream(Stream stream, long origin, long bytesToRead)
         return count;
     }
 
+    public override int ReadByte()
+    {
+        if (BytesLeftToRead == 0)
+        {
+            return -1;
+        }
+
+        if (_cacheLength == 0)
+        {
+            _cacheOffset = 0;
+            Stream.Position = origin;
+            _cacheLength = Stream.Read(_cache, 0, _cache.Length);
+            origin += _cacheLength;
+        }
+
+        int value = _cache[_cacheOffset];
+
+        _cacheOffset++;
+        _cacheLength--;
+        BytesLeftToRead--;
+
+        return value;
+    }
+
     public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
     public override void SetLength(long value) => throw new NotSupportedException();


### PR DESCRIPTION
I noticed absurd memory allocations when decompressing 7-zip files and tracked it down to `BufferedSubStream` not overriding `ReadByte`.
From the [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.stream?view=net-9.0): `The default implementations of ReadByte() and WriteByte(Byte) create a new single-element byte array, and then call your implementations of Read(Byte[], Int32, Int32) and Write(Byte[], Int32, Int32). When you derive from Stream, we recommend that you override these methods to access your internal buffer, if you have one, for substantially better performance.`

Testing with a ~300MB (compressed size) 7-zip file, I noticed an improvement in decompression speed from ~32 seconds to ~27 seconds and a reduction in memory allocations from ~7GB to ~100MB.