### PR TITLE
Implement ReadByte for LzmaStream and LzOutWindow

### DIFF
--- a/src/SharpCompress/Compressors/LZMA/LZ/LzOutWindow.cs
+++ b/src/SharpCompress/Compressors/LZMA/LZ/LzOutWindow.cs
@@ -188,6 +188,25 @@ internal class OutWindow
         return size;
     }
 
+    public int ReadByte()
+    {
+        if (_streamPos >= _pos)
+        {
+            return -1;
+        }
+
+        int value = _buffer[_streamPos];
+
+        _streamPos++;
+        if (_streamPos >= _windowSize)
+        {
+            _pos = 0;
+            _streamPos = 0;
+        }
+
+        return value;
+    }
+
     public void CopyPending()
     {
         if (_pendingLen > 0)


### PR DESCRIPTION
Similar to #897, this improves performance and reduces memory allocations when reading certain 7-zip files.

Using the .7z file from https://github.com/adamhathcock/sharpcompress/issues/399#issuecomment-405028725, I measured a speedup in reading / skipping the entire .7z file from ~23 seconds to ~18 seconds, and memory allocations dropped by ~8.5GB.