### PR TITLE
make WriteToDirectory functions use ExtractAllEntries

### DIFF
--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -122,10 +122,7 @@ public static class ArchiveFactory
     )
     {
         using var archive = Open(sourceArchive);
-        foreach (var entry in archive.Entries)
-        {
-            entry.WriteToDirectory(destinationDirectory, options);
-        }
+        archive.WriteToDirectory(destinationDirectory, options);
     }
 
     private static T FindFactory<T>(FileInfo finfo)

--- a/src/SharpCompress/Archives/IArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveExtensions.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using SharpCompress.Common;
+using SharpCompress.Readers;
 
 namespace SharpCompress.Archives;
 
@@ -18,10 +19,8 @@ public static class IArchiveExtensions
         ExtractionOptions? options = null
     )
     {
-        foreach (var entry in archive.Entries.Where(x => !x.IsDirectory))
-        {
-            entry.WriteToDirectory(destinationDirectory, options);
-        }
+        using var reader = archive.ExtractAllEntries();
+        reader.WriteAllToDirectory(destinationDirectory, options);
     }
 
     /// <summary>


### PR DESCRIPTION
- closes #710 and possibly some other related ones

For extracting files from solid archives calling `ExtractAllEntries` is required to get acceptable extraction performance and should therefore always be called.

Clearly people are not aware of this function, and the base library not using it is not helping. Perhaps it should be mentioned in the `USAGE.md`?