### PR TITLE
Handle XZ CheckType SHA-256

### DIFF
--- a/src/SharpCompress/Compressors/Xz/XZHeader.cs
+++ b/src/SharpCompress/Compressors/Xz/XZHeader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -11,7 +12,11 @@ public class XZHeader
     private readonly byte[] MagicHeader = { 0xFD, 0x37, 0x7A, 0x58, 0x5a, 0x00 };
 
     public CheckType BlockCheckType { get; private set; }
-    public int BlockCheckSize => ((((int)BlockCheckType) + 2) / 3) * 4;
+    public int BlockCheckSize =>
+        BlockCheckType == CheckType.NONE ? 0 :
+        BlockCheckType == CheckType.CRC32 ? 4 :
+        BlockCheckType == CheckType.CRC64 ? 8 :
+        BlockCheckType == CheckType.SHA256 ? 32 : throw new ArgumentOutOfRangeException();
 
     public XZHeader(BinaryReader reader) => _reader = reader;
 

--- a/src/SharpCompress/Compressors/Xz/XZStream.cs
+++ b/src/SharpCompress/Compressors/Xz/XZStream.cs
@@ -25,13 +25,10 @@ public sealed class XZStream : XZReadOnlyStream
         switch (Header.BlockCheckType)
         {
             case CheckType.NONE:
-                break;
             case CheckType.CRC32:
-                break;
             case CheckType.CRC64:
-                break;
             case CheckType.SHA256:
-                throw new NotImplementedException();
+                break;
             default:
                 throw new NotSupportedException("Check Type unknown to this version of decoder.");
         }


### PR DESCRIPTION
Add `CheckType.SHA256` to the `XZHeader.BlockCheckSize` 'calculation' so XZ can decompress e.g. RPM package payloads.