### PR TITLE
Provide access to extended attributes for 7-zip

### DIFF
--- a/src/SharpCompress/Common/SevenZip/ArchiveReader.cs
+++ b/src/SharpCompress/Common/SevenZip/ArchiveReader.cs
@@ -996,6 +996,11 @@ internal class ArchiveReader
                             numFiles,
                             delegate(int i, uint? attr)
                             {
+                                // Keep the original attribute value because it could potentially get
+                                // modified in the logic that follows. Some callers of the library may
+                                // find the original value useful.
+                                db._files[i].ExtendedAttrib = attr;
+
                                 // Some third party implementations established an unofficial extension
                                 // of the 7z archive format by placing posix file attributes in the high
                                 // bits of the windows file attributes. This makes use of the fact that

--- a/src/SharpCompress/Common/SevenZip/ArchiveReader.cs
+++ b/src/SharpCompress/Common/SevenZip/ArchiveReader.cs
@@ -1458,7 +1458,7 @@ internal class ArchiveReader
 #if DEBUG
             Log.WriteLine(_db._files[index].Name);
 #endif
-            if (_db._files[index].CrcDefined)
+            if (_db._files[index].Crc is not null)
             {
                 _stream = new CrcCheckStream(_db._files[index].Crc.Value);
             }

--- a/src/SharpCompress/Common/SevenZip/CFileItem.cs
+++ b/src/SharpCompress/Common/SevenZip/CFileItem.cs
@@ -14,12 +14,6 @@ internal class CFileItem
     public bool HasStream { get; internal set; }
     public bool IsDir { get; internal set; }
 
-    public bool CrcDefined => Crc != null;
-
-    public bool AttribDefined => Attrib != null;
-
-    public void SetAttrib(uint attrib) => Attrib = attrib;
-
     public DateTime? CTime { get; internal set; }
     public DateTime? ATime { get; internal set; }
     public DateTime? MTime { get; internal set; }

--- a/src/SharpCompress/Common/SevenZip/CFileItem.cs
+++ b/src/SharpCompress/Common/SevenZip/CFileItem.cs
@@ -8,6 +8,7 @@ internal class CFileItem
 {
     public long Size { get; internal set; }
     public uint? Attrib { get; internal set; }
+    public uint? ExtendedAttrib { get; internal set; }
     public uint? Crc { get; internal set; }
     public string Name { get; internal set; }
 

--- a/src/SharpCompress/Common/SevenZip/SevenZipEntry.cs
+++ b/src/SharpCompress/Common/SevenZip/SevenZipEntry.cs
@@ -38,5 +38,8 @@ public class SevenZipEntry : Entry
     public override int? Attrib =>
         FilePart.Header.Attrib.HasValue ? (int?)FilePart.Header.Attrib.Value : null;
 
+    public int? ExtendedAttrib =>
+        FilePart.Header.ExtendedAttrib.HasValue ? (int?)FilePart.Header.ExtendedAttrib.Value : null;
+
     internal override IEnumerable<FilePart> Parts => FilePart.AsEnumerable<FilePart>();
 }


### PR DESCRIPTION
Some 7-zip archives have extended attributes to store Unix permissions. This caused problems in the past so the extended attributes [were stripped](https://github.com/adamhathcock/sharpcompress/pull/153) when reading. However, this information can be useful or even critical in some cases, such as when extracting Linux/macOS prebuilt binaries for developing with Qt. These archives have execute permissions set for some files, and some of the files are intended to be created as symbolic links.

This PR provides access to the original full attributes via a new property in `SevenZipEntry`. The other changes were just small cleanups. Specifically, as I looked at `AttribDefined`/`SetAttrib` and wondered if there should be extended versions of these, I saw that these are properties in an internal class an nothing is ever referencing them. I also noticed `CrcDefined` had only one reference, and around where it was used showed an IDE warning that went away by using `is not null` instead, so I thought it would be better to remove it.

<img width="528" alt="image" src="https://github.com/user-attachments/assets/196d2c41-cf95-4012-8fe4-e0ef02d9e1f3" />

With this new `ExtendedAttrib` property, I was able to write an [extraction routine](https://github.com/jdpurcell/naqt/blob/7cdba606333b6cfabec00676151aa31a6e35cdf2/Helpers/General.cs#L52) that allows the Qt 7-zip archives to be extracted in a fully working state.