### PR TITLE
Optimize LZMA range decoder

### DIFF
--- a/src/SharpCompress/Compressors/LZMA/RangeCoder/RangeCoder.cs
+++ b/src/SharpCompress/Compressors/LZMA/RangeCoder/RangeCoder.cs
@@ -1,6 +1,7 @@
 #nullable disable
 
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace SharpCompress.Compressors.LZMA.RangeCoder;
 
@@ -152,6 +153,7 @@ internal class Decoder
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Normalize2()
     {
         if (_range < K_TOP_VALUE)

--- a/src/SharpCompress/Compressors/LZMA/RangeCoder/RangeCoderBit.cs
+++ b/src/SharpCompress/Compressors/LZMA/RangeCoder/RangeCoderBit.cs
@@ -107,24 +107,13 @@ internal struct BitDecoder
         {
             rangeDecoder._range = newBound;
             _prob += (K_BIT_MODEL_TOTAL - _prob) >> K_NUM_MOVE_BITS;
-            if (rangeDecoder._range < Decoder.K_TOP_VALUE)
-            {
-                rangeDecoder._code =
-                    (rangeDecoder._code << 8) | (byte)rangeDecoder._stream.ReadByte();
-                rangeDecoder._range <<= 8;
-                rangeDecoder._total++;
-            }
+            rangeDecoder.Normalize2();
             return 0;
         }
         rangeDecoder._range -= newBound;
         rangeDecoder._code -= newBound;
         _prob -= (_prob) >> K_NUM_MOVE_BITS;
-        if (rangeDecoder._range < Decoder.K_TOP_VALUE)
-        {
-            rangeDecoder._code = (rangeDecoder._code << 8) | (byte)rangeDecoder._stream.ReadByte();
-            rangeDecoder._range <<= 8;
-            rangeDecoder._total++;
-        }
+        rangeDecoder.Normalize2();
         return 1;
     }
 }


### PR DESCRIPTION
I noticed this duplicated bit of logic inside the range decoder. Turns out, there's a helper function called `Normalize2` that does the exact same thing and was never even called. This quirk came all the way from the original LZMA C# SDK it seems. I can see why, as with .NET Framework 4.8, attempting to use the helper function results in performance degradation, so someone manually inlined it. But that's not even necessary, as `[MethodImpl(MethodImplOptions.AggressiveInlining)]` can be used to achieve the same performance.

But the more interesting part, hence this PR, is that newer JITs (tested with .NET 8.0) don't like the manually inlined version of the code as much; when calling `Normalize2` instead, it seems to get inlined either way (even without the attribute that we put as a hint for .NET 4.8), and the performance is better.

Core i7-6700k (3.2% reduction):

| Method | Mean    | Error    | StdDev   |
|------- |--------:|---------:|---------:|
| Before  | 1.128 s | 0.0018 s | 0.0015 s |
| After  | 1.092 s | 0.0011 s | 0.0009 s |

Apple M3 (11.6% reduction):
| Method | Mean     | Error    | StdDev   |
|------- |---------:|---------:|---------:|
| Before  | 888.9 ms | 16.78 ms | 14.01 ms |
| After  | 785.8 ms |  1.98 ms |  1.85 ms |

That's reduction in overall time to extract the whole archive. Tested with a smaller archive in BenchmarkDotNet and I was honestly in disbelief at first on the M3, but it's real. I also manually benchmarked using the same setup/archive as my first PR, it was a 412MB Qt 7z taking 26+ seconds, and it indeed shaved an entire 3 seconds off the extraction time.