### PR TITLE
Fix regression with BufferedSubStream calculation

### DIFF
--- a/src/SharpCompress/IO/BufferedSubStream.cs
+++ b/src/SharpCompress/IO/BufferedSubStream.cs
@@ -57,11 +57,7 @@ internal class BufferedSubStream(Stream stream, long origin, long bytesToRead)
                 RefillCache();
             }
 
-            if (count > _cacheLength)
-            {
-                count = _cacheLength;
-            }
-
+            count = Math.Min(count, _cacheLength - _cacheOffset);
             Buffer.BlockCopy(_cache, _cacheOffset, buffer, offset, count);
             _cacheOffset += count;
         }


### PR DESCRIPTION
Fixes regression introduced in #912. Most of my test archives didn't trigger this code path so I didn't notice until now.