### PR TITLE
Implement multipart rar handling for ExtractAllEntries

### DIFF
--- a/src/SharpCompress/Archives/Rar/RarArchive.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchive.cs
@@ -67,6 +67,16 @@ public class RarArchive : AbstractArchive<RarArchiveEntry, RarVolume>
 
     protected override IReader CreateReaderForSolidExtraction()
     {
+        if (this.IsMultipartVolume())
+        {
+            var streams = Volumes.Select(volume =>
+            {
+                volume.Stream.Position = 0;
+                return volume.Stream;
+            });
+            return RarReader.Open(streams, ReaderOptions);
+        }
+
         var stream = Volumes.First().Stream;
         stream.Position = 0;
         return RarReader.Open(stream, ReaderOptions);

--- a/src/SharpCompress/Readers/AbstractReader.cs
+++ b/src/SharpCompress/Readers/AbstractReader.cs
@@ -131,7 +131,7 @@ public abstract class AbstractReader<TEntry, TVolume> : IReader, IReaderExtracti
     {
         var part = Entry.Parts.First();
 
-        if (!Entry.IsSolid && Entry.CompressedSize > 0)
+        if (!Entry.IsSplitAfter && !Entry.IsSolid && Entry.CompressedSize > 0)
         {
             //not solid and has a known compressed size then we can skip raw bytes.
             var rawStream = part.GetRawStream();

--- a/tests/SharpCompress.Test/Rar/RarReaderTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarReaderTests.cs
@@ -330,43 +330,18 @@ public class RarReaderTests : ReaderTests
     }
 
     [Fact]
-    public void Rar_NullReference()
+    public void Rar_SkipEncryptedFilesWithoutPassword()
     {
+        using var stream = File.OpenRead(
+            Path.Combine(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar")
+        );
+        using var reader = ReaderFactory.Open(
+            stream,
+            new ReaderOptions { LookForHeader = true }
+        );
+        while (reader.MoveToNextEntry())
         {
-            var archives = new[]
-            {
-                "Rar.EncryptedParts.part01.rar",
-                "Rar.EncryptedParts.part02.rar",
-                "Rar.EncryptedParts.part03.rar",
-                "Rar.EncryptedParts.part04.rar",
-                "Rar.EncryptedParts.part05.rar",
-                "Rar.EncryptedParts.part06.rar",
-            };
-
-            using var reader = RarReader.Open(
-                archives
-                    .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
-                    .Select(p => File.OpenRead(p)),
-                new ReaderOptions { Password = "test" }
-            );
-            while (reader.MoveToNextEntry())
-            {
-                //
-            }
-        }
-
-        {
-            using var stream = File.OpenRead(
-                Path.Combine(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar")
-            );
-            using var reader = ReaderFactory.Open(
-                stream,
-                new ReaderOptions { LookForHeader = true }
-            );
-            while (reader.MoveToNextEntry())
-            {
-                //
-            }
+            //
         }
     }
 

--- a/tests/SharpCompress.Test/Rar/RarReaderTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarReaderTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections;
 using System.IO;
 using System.Linq;
+using SharpCompress.Archives.Rar;
 using SharpCompress.Common;
 using SharpCompress.Readers;
 using SharpCompress.Readers.Rar;
@@ -418,4 +420,16 @@ public class RarReaderTests : ReaderTests
                     CompressionType.Rar
                 )
         );
+
+    [Fact]
+    public void Rar_Iterate_Multipart()
+    {
+        var expectedOrder = new Stack(new[] {"Failure", "jpg", "exe", "Empty", "тест.txt", Path.Combine("jpg", "test.jpg"), Path.Combine("exe", "test.exe")});
+        using var archive = RarArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part01.rar"));
+        using var reader = archive.ExtractAllEntries();
+        while (reader.MoveToNextEntry())
+        {
+            Assert.Equal(expectedOrder.Pop(), reader.Entry.Key);
+        }
+    }
 }

--- a/tests/SharpCompress.Test/Rar/RarReaderTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarReaderTests.cs
@@ -335,10 +335,7 @@ public class RarReaderTests : ReaderTests
         using var stream = File.OpenRead(
             Path.Combine(TEST_ARCHIVES_PATH, "Rar.encrypted_filesOnly.rar")
         );
-        using var reader = ReaderFactory.Open(
-            stream,
-            new ReaderOptions { LookForHeader = true }
-        );
+        using var reader = ReaderFactory.Open(stream, new ReaderOptions { LookForHeader = true });
         while (reader.MoveToNextEntry())
         {
             //
@@ -399,8 +396,21 @@ public class RarReaderTests : ReaderTests
     [Fact]
     public void Rar_Iterate_Multipart()
     {
-        var expectedOrder = new Stack(new[] {"Failure", "jpg", "exe", "Empty", "тест.txt", Path.Combine("jpg", "test.jpg"), Path.Combine("exe", "test.exe")});
-        using var archive = RarArchive.Open(Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part01.rar"));
+        var expectedOrder = new Stack(
+            new[]
+            {
+                "Failure",
+                "jpg",
+                "exe",
+                "Empty",
+                "тест.txt",
+                Path.Combine("jpg", "test.jpg"),
+                Path.Combine("exe", "test.exe"),
+            }
+        );
+        using var archive = RarArchive.Open(
+            Path.Combine(TEST_ARCHIVES_PATH, "Rar.multi.part01.rar")
+        );
         using var reader = archive.ExtractAllEntries();
         while (reader.MoveToNextEntry())
         {


### PR DESCRIPTION
- closes #915.

One side-effect of the changes here is that *skipping over encrypted entries for which the password is not known in a multipart rar file using the reader interface* no longer works.

However *reading* those entries does not work because it isn't currently implemented, and the skipping was bad as well because it would fail to skip all file parts and returned after skipping the first part only, so I think it is fair to remove this functionality.
It could be implemented properly but I think it would take some effort to extract the needed information and perhaps need additional interface methods.