### PR TITLE
[bzip2] fix possible out of bounds access due to unsanitized nSelectors usage

### DIFF
--- a/src/SharpCompress/Compressors/BZip2/CBZip2InputStream.cs
+++ b/src/SharpCompress/Compressors/BZip2/CBZip2InputStream.cs
@@ -542,8 +542,13 @@ internal class CBZip2InputStream : Stream
             {
                 j++;
             }
-            selectorMtf[i] = (char)j;
+            if (i < BZip2Constants.MAX_SELECTORS)
+            {
+                selectorMtf[i] = (char)j;
+            }
         }
+
+        nSelectors = Math.Min(nSelectors, BZip2Constants.MAX_SELECTORS);
 
         /* Undo the MTF values for the selectors. */
         {


### PR DESCRIPTION
- closes #917 

I have checked the bzip2 source code and this is what is being done there as well.