### PR TITLE
Fix volume FileName property potentially missing

### DIFF
--- a/src/SharpCompress/Common/Volume.cs
+++ b/src/SharpCompress/Common/Volume.cs
@@ -7,12 +7,14 @@ namespace SharpCompress.Common;
 
 public abstract class Volume : IVolume
 {
+    private readonly Stream _baseStream;
     private readonly Stream _actualStream;
 
     internal Volume(Stream stream, ReaderOptions? readerOptions, int index = 0)
     {
         Index = index;
         ReaderOptions = readerOptions ?? new ReaderOptions();
+        _baseStream = stream;
         if (ReaderOptions.LeaveStreamOpen)
         {
             stream = NonDisposingStream.Create(stream);
@@ -32,7 +34,7 @@ public abstract class Volume : IVolume
 
     public virtual int Index { get; internal set; }
 
-    public string? FileName => (_actualStream as FileStream)?.Name;
+    public string? FileName => (_baseStream as FileStream)?.Name;
 
     /// <summary>
     /// RarArchive is part of a multi-part archive.


### PR DESCRIPTION
- closes #920

If the `ReaderOptions` has `LeaveStreamOpen` set (which is set to true by default), the stream used to report a volume's `FileName` was a `NonDisposingStream` instead of the originally passed in stream, which never worked.