### PR TITLE
chore: add Copilot coding agent config and CI workflow

### DIFF
--- a/.copilot-agent.yml
+++ b/.copilot-agent.yml
@@ -1,0 +1,7 @@
+enabled: true
+agent:
+  name: copilot-coding-agent
+  allow:
+    - paths: ["src/**/*", "tests/**/*", "README.md", "AGENTS.md"]
+      actions: ["create", "modify"]
+  require_review_before_merge: true

--- a/.github/COPILOT_AGENT_README.md
+++ b/.github/COPILOT_AGENT_README.md
@@ -1,0 +1,13 @@
+# Copilot Coding Agent Configuration
+
+This repository includes a minimal opt-in configuration and CI workflow to allow the GitHub Copilot coding agent to open and validate PRs.
+
+- .copilot-agent.yml: opt-in config for automated agents
+- .github/workflows/dotnetcore.yml: CI runs on PRs touching the solution, source, or tests to validate changes
+- AGENTS.yml: general information for this project
+
+Maintainers can adjust the allowed paths or disable the agent by editing or removing .copilot-agent.yml.
+
+Notes:
+- Do not change any other files in the repository.
+- If build/test paths are different, update the workflow accordingly; this workflow targets SharpCompress.sln and the SharpCompress.Tests test project.


### PR DESCRIPTION
This pull request introduces initial configuration for enabling the GitHub Copilot coding agent in the repository, along with documentation for maintainers. The changes focus on agent setup and providing guidance for maintainers.

Copilot agent configuration:

* Added `.copilot-agent.yml` to opt-in to Copilot coding agent, specifying allowed file paths and actions, and requiring review before merging automated PRs.

Documentation for maintainers:

* Added `.github/COPILOT_AGENT_README.md` to explain the Copilot agent setup, allowed paths, CI workflow, and instructions for maintainers on managing agent configuration.