### PR TITLE
make test linux only

### DIFF
--- a/tests/SharpCompress.Test/SharpCompress.Test.csproj
+++ b/tests/SharpCompress.Test/SharpCompress.Test.csproj
@@ -12,6 +12,9 @@
   <PropertyGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))">
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))">
+    <DefineConstants>$(DefineConstants);LINUX</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SharpCompress\SharpCompress.csproj" />
   </ItemGroup>

--- a/tests/SharpCompress.Test/Tar/TarReaderTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarReaderTests.cs
@@ -201,13 +201,10 @@ public class TarReaderTests : ReaderTests
         Assert.Throws<IncompleteArchiveException>(() => reader.MoveToNextEntry());
     }
 
-#if !NETFRAMEWORK
+#if LINUX
     [Fact]
     public void Tar_GZip_With_Symlink_Entries()
     {
-        var isWindows = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
-            System.Runtime.InteropServices.OSPlatform.Windows
-        );
         using Stream stream = File.OpenRead(
             Path.Combine(TEST_ARCHIVES_PATH, "TarWithSymlink.tar.gz")
         );
@@ -226,38 +223,32 @@ public class TarReaderTests : ReaderTests
                     Overwrite = true,
                     WriteSymbolicLink = (sourcePath, targetPath) =>
                     {
-                        if (!isWindows)
+                        var link = new Mono.Unix.UnixSymbolicLinkInfo(sourcePath);
+                        if (File.Exists(sourcePath))
                         {
-                            var link = new Mono.Unix.UnixSymbolicLinkInfo(sourcePath);
-                            if (File.Exists(sourcePath))
-                            {
-                                link.Delete(); // equivalent to ln -s -f
-                            }
-                            link.CreateSymbolicLinkTo(targetPath);
+                            link.Delete(); // equivalent to ln -s -f
                         }
+                        link.CreateSymbolicLinkTo(targetPath);
                     },
                 }
             );
-            if (!isWindows)
+            if (reader.Entry.LinkTarget != null)
             {
-                if (reader.Entry.LinkTarget != null)
+                var path = Path.Combine(SCRATCH_FILES_PATH, reader.Entry.Key.NotNull());
+                var link = new Mono.Unix.UnixSymbolicLinkInfo(path);
+                if (link.HasContents)
                 {
-                    var path = Path.Combine(SCRATCH_FILES_PATH, reader.Entry.Key.NotNull());
-                    var link = new Mono.Unix.UnixSymbolicLinkInfo(path);
-                    if (link.HasContents)
-                    {
-                        // need to convert the link to an absolute path for comparison
-                        var target = reader.Entry.LinkTarget;
-                        var realTarget = Path.GetFullPath(
-                            Path.Combine($"{Path.GetDirectoryName(path)}", target)
-                        );
+                    // need to convert the link to an absolute path for comparison
+                    var target = reader.Entry.LinkTarget;
+                    var realTarget = Path.GetFullPath(
+                        Path.Combine($"{Path.GetDirectoryName(path)}", target)
+                    );
 
-                        Assert.Equal(realTarget, link.GetContents().ToString());
-                    }
-                    else
-                    {
-                        Assert.True(false, "Symlink has no target");
-                    }
+                    Assert.Equal(realTarget, link.GetContents().ToString());
+                }
+                else
+                {
+                    Assert.True(false, "Symlink has no target");
                 }
             }
         }


### PR DESCRIPTION
This pull request improves platform-specific test handling for symbolic links in tar archives, specifically targeting Linux environments. The main changes involve updating conditional compilation symbols and simplifying logic related to symlink extraction in the test suite.

**Platform-specific test improvements:**

* Added a `LINUX` compilation constant in the `SharpCompress.Test.csproj` file to enable Linux-specific code paths in tests.
* Changed the conditional compilation in `TarReaderTests.cs` to use `#if LINUX` instead of runtime OS checks, ensuring that the symlink extraction test only runs on Linux.

**Code simplification for symlink extraction:**

* Removed unnecessary runtime checks (`isWindows`) and simplified the symbolic link handling logic in the `Tar_GZip_With_Symlink_Entries` test, making the code cleaner and more maintainable. [[1]](diffhunk://#diff-b91ec5d1214f21b7df2b592de93938802bf504caa94e649401a9d4a75e356bfaL228-L242) [[2]](diffhunk://#diff-b91ec5d1214f21b7df2b592de93938802bf504caa94e649401a9d4a75e356bfaL264)