### PR TITLE
release to master

### DIFF
--- a/src/SharpCompress/IO/BufferedSubStream.cs
+++ b/src/SharpCompress/IO/BufferedSubStream.cs
@@ -29,17 +29,25 @@ internal class BufferedSubStream : SharpCompressStream, IStreamStack
 #if DEBUG_STREAMS
         this.DebugDispose(typeof(BufferedSubStream));
 #endif
-        if (disposing)
+        if (_isDisposed)
+        {
+            return;
+        }
+        _isDisposed = true;
+
+        if (disposing && _cache is not null)
         {
             ArrayPool<byte>.Shared.Return(_cache);
+            _cache = null;
         }
         base.Dispose(disposing);
     }
 
     private int _cacheOffset;
     private int _cacheLength;
-    private readonly byte[] _cache = ArrayPool<byte>.Shared.Rent(32 << 10);
+    private byte[]? _cache = ArrayPool<byte>.Shared.Rent(81920);
     private long origin;
+    private bool _isDisposed;
 
     private long BytesLeftToRead { get; set; }
 
@@ -61,14 +69,26 @@ internal class BufferedSubStream : SharpCompressStream, IStreamStack
 
     private void RefillCache()
     {
-        var count = (int)Math.Min(BytesLeftToRead, _cache.Length);
+        if (_isDisposed)
+        {
+            throw new ObjectDisposedException(nameof(BufferedSubStream));
+        }
+
+        var count = (int)Math.Min(BytesLeftToRead, _cache!.Length);
         _cacheOffset = 0;
         if (count == 0)
         {
             _cacheLength = 0;
             return;
         }
-        Stream.Position = origin;
+
+        // Only seek if we're not already at the correct position
+        // This avoids expensive seek operations when reading sequentially
+        if (Stream.CanSeek && Stream.Position != origin)
+        {
+            Stream.Position = origin;
+        }
+
         _cacheLength = Stream.Read(_cache, 0, count);
         origin += _cacheLength;
         BytesLeftToRead -= _cacheLength;
@@ -76,14 +96,24 @@ internal class BufferedSubStream : SharpCompressStream, IStreamStack
 
     private async ValueTask RefillCacheAsync(CancellationToken cancellationToken)
     {
-        var count = (int)Math.Min(BytesLeftToRead, _cache.Length);
+        if (_isDisposed)
+        {
+            throw new ObjectDisposedException(nameof(BufferedSubStream));
+        }
+
+        var count = (int)Math.Min(BytesLeftToRead, _cache!.Length);
         _cacheOffset = 0;
         if (count == 0)
         {
             _cacheLength = 0;
             return;
         }
-        Stream.Position = origin;
+        // Only seek if we're not already at the correct position
+        // This avoids expensive seek operations when reading sequentially
+        if (Stream.CanSeek && Stream.Position != origin)
+        {
+            Stream.Position = origin;
+        }
         _cacheLength = await Stream
             .ReadAsync(_cache, 0, count, cancellationToken)
             .ConfigureAwait(false);
@@ -106,7 +136,7 @@ internal class BufferedSubStream : SharpCompressStream, IStreamStack
             }
 
             count = Math.Min(count, _cacheLength - _cacheOffset);
-            Buffer.BlockCopy(_cache, _cacheOffset, buffer, offset, count);
+            Buffer.BlockCopy(_cache!, _cacheOffset, buffer, offset, count);
             _cacheOffset += count;
         }
 
@@ -124,7 +154,7 @@ internal class BufferedSubStream : SharpCompressStream, IStreamStack
             }
         }
 
-        return _cache[_cacheOffset++];
+        return _cache![_cacheOffset++];
     }
 
     public override async Task<int> ReadAsync(
@@ -147,7 +177,7 @@ internal class BufferedSubStream : SharpCompressStream, IStreamStack
             }
 
             count = Math.Min(count, _cacheLength - _cacheOffset);
-            Buffer.BlockCopy(_cache, _cacheOffset, buffer, offset, count);
+            Buffer.BlockCopy(_cache!, _cacheOffset, buffer, offset, count);
             _cacheOffset += count;
         }
 
@@ -174,7 +204,7 @@ internal class BufferedSubStream : SharpCompressStream, IStreamStack
             }
 
             count = Math.Min(count, _cacheLength - _cacheOffset);
-            _cache.AsSpan(_cacheOffset, count).CopyTo(buffer.Span);
+            _cache!.AsSpan(_cacheOffset, count).CopyTo(buffer.Span);
             _cacheOffset += count;
         }
 

--- a/src/SharpCompress/IO/SharpCompressStream.cs
+++ b/src/SharpCompress/IO/SharpCompressStream.cs
@@ -255,7 +255,6 @@ public class SharpCompressStream : Stream, IStreamStack
             ValidateBufferState();
         }
 
-        long orig = _internalPosition;
         long targetPos;
         // Calculate the absolute target position based on origin
         switch (origin)


### PR DESCRIPTION
This pull request improves the safety and robustness of the `BufferedSubStream` implementation in `SharpCompress`, particularly around resource management and stream disposal. The changes ensure that the underlying buffer is managed correctly, prevent double disposal issues, and add a new test to verify this behavior. Additionally, minor code improvements and test enhancements are included.

### Resource management and disposal safety

* Added an `_isDisposed` flag to `BufferedSubStream` to prevent double disposal and ensure the buffer is only returned to the pool once, avoiding pool corruption. The buffer (`_cache`) is now set to `null` after being returned. (`[src/SharpCompress/IO/BufferedSubStream.csL32-R50](diffhunk://#diff-e05b040e70e38b0d116d8d268e407131b5ba8b6614af841bc9188cd7f368fee3L32-R50)`)
* Updated all usages of `_cache` to use null-forgiving operator (`_cache!`) and added checks for `_isDisposed` in methods that access the buffer, throwing `ObjectDisposedException` if accessed after disposal. (`[[1]](diffhunk://#diff-e05b040e70e38b0d116d8d268e407131b5ba8b6614af841bc9188cd7f368fee3L64-R116)`, `[[2]](diffhunk://#diff-e05b040e70e38b0d116d8d268e407131b5ba8b6614af841bc9188cd7f368fee3L109-R139)`, `[[3]](diffhunk://#diff-e05b040e70e38b0d116d8d268e407131b5ba8b6614af841bc9188cd7f368fee3L127-R157)`, `[[4]](diffhunk://#diff-e05b040e70e38b0d116d8d268e407131b5ba8b6614af841bc9188cd7f368fee3L150-R180)`, `[[5]](diffhunk://#diff-e05b040e70e38b0d116d8d268e407131b5ba8b6614af841bc9188cd7f368fee3L177-R207)`)

### Test improvements

* Added a new unit test `BufferedSubStream_DoubleDispose_DoesNotCorruptArrayPool` to verify that double disposal does not corrupt the array pool or throw exceptions. (`[tests/SharpCompress.Test/Streams/SharpCompressStreamTest.csR100-R120](diffhunk://#diff-5203913d939d601de98a07fe1ef8384114c7cbb9de17ccc5a93297b51c301e6eR100-R120)`)
* Modified the existing test to use a `ForwardOnlyStream` wrapper for more accurate stream behavior simulation. (`[tests/SharpCompress.Test/Streams/SharpCompressStreamTest.csL67-R75](diffhunk://#diff-5203913d939d601de98a07fe1ef8384114c7cbb9de17ccc5a93297b51c301e6eL67-R75)`)
* Added missing test mock import for completeness. (`[tests/SharpCompress.Test/Streams/SharpCompressStreamTest.csR8](diffhunk://#diff-5203913d939d601de98a07fe1ef8384114c7cbb9de17ccc5a93297b51c301e6eR8)`)

### Minor codebase cleanups

* Removed an unused variable (`orig`) from the `Seek` method in `SharpCompressStream`. (`[src/SharpCompress/IO/SharpCompressStream.csL258](diffhunk://#diff-d90e17bbeae23cfc33ba23708baa5342f5eb76666ee072503791fee3432a1c04L258)`)