### PR TITLE
Mark as IsAotCompatible

### DIFF
--- a/src/SharpCompress/SharpCompress.csproj
+++ b/src/SharpCompress/SharpCompress.csproj
@@ -33,6 +33,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0' ">
     <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
     <DefineConstants>$(DefineConstants);DEBUG_STREAMS</DefineConstants>


### PR DESCRIPTION
For .NET 8 and .NET 10

I tested with `dotnet build` and `dotnet pack` from **src** folder. Also I ran `dotnet test` without issues. Tested with Ubuntu 24.04 + .NET 10 under WSL.