### PR TITLE
Moving extraction options back

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -246,11 +246,12 @@ using (var archive = ZipArchive.OpenArchive("file.zip", options))
 
 // Open-time presets
 var external = ReaderOptions.ForExternalStream;
-var owned = ReaderOptions.ForOwnedFile;
+var owned = ReaderOptions.ForFilePath;
 
 // Extraction presets
 var safeOptions = ExtractionOptions.SafeExtract;  // No overwrite
 var flatOptions = ExtractionOptions.FlatExtract;  // No directory structure
+var metadataOptions = ExtractionOptions.PreserveMetadata; // Keep timestamps and attributes
 
 // Factory defaults:
 // - file path / FileInfo overloads use LeaveStreamOpen = false
@@ -329,7 +330,7 @@ ZipWriterEntryOptions: per-entry ZIP overrides (compression, level, timestamps, 
 
 ```csharp
 var registry = CompressionProviderRegistry.Default.With(new SystemGZipCompressionProvider());
-var readerOptions = ReaderOptions.ForOwnedFile().WithProviders(registry);
+var readerOptions = ReaderOptions.ForFilePath.WithProviders(registry);
 var writerOptions = new WriterOptions(CompressionType.GZip)
 {
     CompressionLevel = 6,
@@ -417,7 +418,7 @@ var progress = new Progress<ProgressReport>(report =>
     Console.WriteLine($"Extracting {report.EntryPath}: {report.PercentComplete}%");
 });
 
-var options = ReaderOptions.ForOwnedFile().WithProgress(progress);
+var options = ReaderOptions.ForFilePath.WithProgress(progress);
 using (var archive = ZipArchive.OpenArchive("archive.zip", options))
 {
     archive.WriteToDirectory(@"C:\output");

--- a/docs/API.md
+++ b/docs/API.md
@@ -190,7 +190,7 @@ await using (var reader = await ReaderFactory.OpenAsyncReader(stream))
     // Async extraction of all entries
     await reader.WriteAllToDirectoryAsync(
         @"C:\output",
-        cancellationToken
+        cancellationToken: cancellationToken
     );
 }
 ```
@@ -244,9 +244,13 @@ using (var archive = ZipArchive.OpenArchive("file.zip", options))
     // ...
 }
 
-// Common presets
-var safeOptions = ReaderOptions.SafeExtract;      // No overwrite
-var flatOptions = ReaderOptions.FlatExtract;      // No directory structure
+// Open-time presets
+var external = ReaderOptions.ForExternalStream;
+var owned = ReaderOptions.ForOwnedFile;
+
+// Extraction presets
+var safeOptions = ExtractionOptions.SafeExtract;  // No overwrite
+var flatOptions = ExtractionOptions.FlatExtract;  // No directory structure
 
 // Factory defaults:
 // - file path / FileInfo overloads use LeaveStreamOpen = false
@@ -297,23 +301,24 @@ archive.SaveTo("output.zip", options);
 ### Extraction behavior
 
 ```csharp
-var options = new ReaderOptions
+var options = new ExtractionOptions
 {
     ExtractFullPath = true,                         // Recreate directory structure
     Overwrite = true,                               // Overwrite existing files
     PreserveFileTime = true                         // Keep original timestamps
 };
 
-using (var archive = ZipArchive.OpenArchive("file.zip", options))
+using (var archive = ZipArchive.OpenArchive("file.zip"))
 {
-    archive.WriteToDirectory(@"C:\output");
+    archive.WriteToDirectory(@"C:\output", options);
 }
 ```
 
 ### Options matrix
 
 ```text
-ReaderOptions: open-time behavior (password, encoding, stream ownership, extraction defaults)
+ReaderOptions: open-time behavior (password, encoding, stream ownership)
+ExtractionOptions: extract-time behavior (overwrite, paths, timestamps, attributes, symlinks)
 WriterOptions: write-time behavior (compression type/level, encoding, stream ownership)
 ZipWriterEntryOptions: per-entry ZIP overrides (compression, level, timestamps, comments, zip64)
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -231,11 +231,11 @@ using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, Compressio
 
 ### ReaderOptions
 
-Use factory presets and fluent helpers for common configurations:
+Use preset properties and fluent helpers for common configurations:
 
 ```csharp
 // External stream with password and custom encoding
-var options = ReaderOptions.ForExternalStream()
+var options = ReaderOptions.ForExternalStream
     .WithPassword("password")
     .WithArchiveEncoding(new ArchiveEncoding { Default = Encoding.GetEncoding(932) });
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,8 @@ Common types, options, and enumerations used across formats.
 - `ArchiveType.cs` - Enum for archive formats
 - `CompressionType.cs` - Enum for compression methods
 - `ArchiveEncoding.cs` - Character encoding configuration
-- `IExtractionOptions.cs` - Extraction configuration exposed through `ReaderOptions`
+- `IExtractionOptions.cs` - Interface for extraction configuration
+- `ExtractionOptions.cs` - Extraction behavior options for file extraction APIs
 - Format-specific headers: `Zip/Headers/`, `Tar/Headers/`, `Rar/Headers/`, etc.
 
 #### `Compressors/` - Compression Algorithms

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -333,7 +333,7 @@ using (var archive = ZipArchive.OpenArchive("archive.zip"))
 {
     await archive.WriteToDirectoryAsync(
         @"C:\output",
-        cancellationToken
+        cancellationToken: cancellationToken
     );
 }
 // Thread can handle other work while I/O happens
@@ -369,7 +369,7 @@ try
     {
         await archive.WriteToDirectoryAsync(
             @"C:\output",
-            cts.Token
+            cancellationToken: cts.Token
         );
     }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,7 +6,7 @@ SharpCompress now provides full async/await support for all I/O operations. All 
 
 **Key Async Methods:**
 - `reader.WriteEntryToAsync(stream, cancellationToken)` - Extract entry asynchronously  
-- `reader.WriteAllToDirectoryAsync(path, cancellationToken)` - Extract all asynchronously
+- `reader.WriteAllToDirectoryAsync(path, cancellationToken: cancellationToken)` - Extract all asynchronously
 - `writer.WriteAsync(filename, stream, modTime, cancellationToken)` - Write entry asynchronously
 - `writer.WriteAllAsync(directory, pattern, searchOption, cancellationToken)` - Write directory asynchronously
 - `entry.OpenEntryStreamAsync(cancellationToken)` - Open entry stream asynchronously
@@ -94,14 +94,14 @@ Note: Extracting a solid rar or 7z file needs to be done in sequential order to 
 `ExtractAllEntries` is primarily intended for solid archives (like solid Rar) or 7Zip archives, where sequential extraction provides the best performance. For general/simple extraction with any supported archive type, use `archive.WriteToDirectory()` instead.
 
 ```C#
-// Using fluent factory method for extraction options
-using (var archive = RarArchive.OpenArchive("Test.rar",
-    ReaderOptions.ForOwnedFile()
-        .WithExtractFullPath(true)
-        .WithOverwrite(true)))
+// Use ReaderOptions for open-time behavior and ExtractionOptions for extract-time behavior
+using (var archive = RarArchive.OpenArchive("Test.rar", ReaderOptions.ForOwnedFile()))
 {
     // Simple extraction with RarArchive; this WriteToDirectory pattern works for all archive types
-    archive.WriteToDirectory(@"D:\temp");
+    archive.WriteToDirectory(
+        @"D:\temp",
+        new ExtractionOptions { ExtractFullPath = true, Overwrite = true }
+    );
 }
 ```
 
@@ -132,11 +132,12 @@ var progress = new Progress<ProgressReport>(report =>
 
 using (var archive = RarArchive.OpenArchive("archive.rar",
     ReaderOptions.ForOwnedFile()
-        .WithProgress(progress)
-        .WithExtractFullPath(true)
-        .WithOverwrite(true))) // Must be solid Rar or 7Zip
+        .WithProgress(progress))) // Must be solid Rar or 7Zip
 {
-    archive.WriteToDirectory(@"D:\output");
+    archive.WriteToDirectory(
+        @"D:\output",
+        new ExtractionOptions { ExtractFullPath = true, Overwrite = true }
+    );
 }
 ```
 
@@ -261,7 +262,7 @@ using (var reader = ReaderFactory.OpenReader(stream))
 {
     await reader.WriteAllToDirectoryAsync(
         @"D:\temp",
-        cancellationToken
+        cancellationToken: cancellationToken
     );
 }
 ```
@@ -339,7 +340,7 @@ using (var archive = ZipArchive.OpenArchive("archive.zip"))
     // Simple async extraction - works for all archive types
     await archive.WriteToDirectoryAsync(
         @"C:\output",
-        cancellationToken
+        cancellationToken: cancellationToken
     );
 }
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -95,7 +95,7 @@ Note: Extracting a solid rar or 7z file needs to be done in sequential order to 
 
 ```C#
 // Use ReaderOptions for open-time behavior and ExtractionOptions for extract-time behavior
-using (var archive = RarArchive.OpenArchive("Test.rar", ReaderOptions.ForOwnedFile()))
+using (var archive = RarArchive.OpenArchive("Test.rar", ReaderOptions.ForFilePath))
 {
     // Simple extraction with RarArchive; this WriteToDirectory pattern works for all archive types
     archive.WriteToDirectory(
@@ -131,7 +131,7 @@ var progress = new Progress<ProgressReport>(report =>
 });
 
 using (var archive = RarArchive.OpenArchive("archive.rar",
-    ReaderOptions.ForOwnedFile()
+    ReaderOptions.ForFilePath
         .WithProgress(progress))) // Must be solid Rar or 7Zip
 {
     archive.WriteToDirectory(
@@ -219,7 +219,7 @@ To replace a specific algorithm (for example to use `System.IO.Compression` for 
 var systemGZip = new SystemGZipCompressionProvider();
 var customRegistry = CompressionProviderRegistry.Default.With(systemGZip);
 
-var readerOptions = ReaderOptions.ForOwnedFile()
+var readerOptions = ReaderOptions.ForFilePath
     .WithProviders(customRegistry);
 using var reader = ReaderFactory.OpenReader(stream, readerOptions);
 

--- a/src/SharpCompress/Archives/ArchiveFactory.Async.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.Async.cs
@@ -43,7 +43,7 @@ public static partial class ArchiveFactory
         CancellationToken cancellationToken = default
     )
     {
-        options ??= ReaderOptions.ForOwnedFile;
+        options ??= ReaderOptions.ForFilePath;
 
         var factory = await FindFactoryAsync<IArchiveFactory>(fileInfo, cancellationToken)
             .ConfigureAwait(false);
@@ -73,7 +73,7 @@ public static partial class ArchiveFactory
         }
 
         fileInfo.NotNull(nameof(fileInfo));
-        options ??= ReaderOptions.ForOwnedFile;
+        options ??= ReaderOptions.ForFilePath;
 
         var factory = await FindFactoryAsync<IMultiArchiveFactory>(fileInfo, cancellationToken)
             .ConfigureAwait(false);

--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -93,11 +93,11 @@ public static partial class ArchiveFactory
     public static void WriteToDirectory(
         string sourceArchive,
         string destinationDirectory,
-        ReaderOptions? options = null
+        ExtractionOptions? options = null
     )
     {
-        using var archive = OpenArchive(sourceArchive, options);
-        archive.WriteToDirectory(destinationDirectory);
+        using var archive = OpenArchive(sourceArchive);
+        archive.WriteToDirectory(destinationDirectory, options);
     }
 
     public static T FindFactory<T>(string path)

--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -40,7 +40,7 @@ public static partial class ArchiveFactory
 
     public static IArchive OpenArchive(FileInfo fileInfo, ReaderOptions? options = null)
     {
-        options ??= ReaderOptions.ForOwnedFile;
+        options ??= ReaderOptions.ForFilePath;
 
         return FindFactory<IArchiveFactory>(fileInfo).OpenArchive(fileInfo, options);
     }
@@ -64,7 +64,7 @@ public static partial class ArchiveFactory
         }
 
         fileInfo.NotNull(nameof(fileInfo));
-        options ??= ReaderOptions.ForOwnedFile;
+        options ??= ReaderOptions.ForFilePath;
 
         return FindFactory<IMultiArchiveFactory>(fileInfo).OpenArchive(filesArray, options);
     }

--- a/src/SharpCompress/Archives/IArchive.cs
+++ b/src/SharpCompress/Archives/IArchive.cs
@@ -13,7 +13,7 @@ public interface IArchive : IDisposable
     ArchiveType Type { get; }
 
     /// <summary>
-    /// The options used when opening this archive, including extraction behavior settings.
+    /// The options used when opening this archive.
     /// </summary>
     ReaderOptions ReaderOptions { get; }
 

--- a/src/SharpCompress/Archives/IArchiveEntryExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveEntryExtensions.cs
@@ -102,11 +102,15 @@ public static class IArchiveEntryExtensions
         /// <summary>
         /// Extract to specific directory, retaining filename
         /// </summary>
-        public void WriteToDirectory(string destinationDirectory) =>
+        public void WriteToDirectory(
+            string destinationDirectory,
+            ExtractionOptions? options = null
+        ) =>
             ExtractionMethods.WriteEntryToDirectory(
                 entry,
                 destinationDirectory,
-                (path) => entry.WriteToFile(path)
+                options,
+                (path) => entry.WriteToFile(path, options)
             );
 
         /// <summary>
@@ -114,14 +118,16 @@ public static class IArchiveEntryExtensions
         /// </summary>
         public async ValueTask WriteToDirectoryAsync(
             string destinationDirectory,
+            ExtractionOptions? options = null,
             CancellationToken cancellationToken = default
         ) =>
             await ExtractionMethods
                 .WriteEntryToDirectoryAsync(
                     entry,
                     destinationDirectory,
+                    options,
                     async (path, ct) =>
-                        await entry.WriteToFileAsync(path, ct).ConfigureAwait(false),
+                        await entry.WriteToFileAsync(path, options, ct).ConfigureAwait(false),
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -129,10 +135,11 @@ public static class IArchiveEntryExtensions
         /// <summary>
         /// Extract to specific file
         /// </summary>
-        public void WriteToFile(string destinationFileName) =>
+        public void WriteToFile(string destinationFileName, ExtractionOptions? options = null) =>
             ExtractionMethods.WriteEntryToFile(
                 entry,
                 destinationFileName,
+                options,
                 (x, fm) =>
                 {
                     using var fs = File.Open(destinationFileName, fm);
@@ -145,12 +152,14 @@ public static class IArchiveEntryExtensions
         /// </summary>
         public async ValueTask WriteToFileAsync(
             string destinationFileName,
+            ExtractionOptions? options = null,
             CancellationToken cancellationToken = default
         ) =>
             await ExtractionMethods
                 .WriteEntryToFileAsync(
                     entry,
                     destinationFileName,
+                    options,
                     async (x, fm, ct) =>
                     {
                         using var fs = File.Open(destinationFileName, fm);

--- a/src/SharpCompress/Archives/IArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveExtensions.cs
@@ -14,25 +14,28 @@ public static class IArchiveExtensions
         /// Extract to specific directory with progress reporting
         /// </summary>
         /// <param name="destinationDirectory">The folder to extract into.</param>
+        /// <param name="options">Extraction options.</param>
         /// <param name="progress">Optional progress reporter for tracking extraction progress.</param>
         public void WriteToDirectory(
             string destinationDirectory,
+            ExtractionOptions? options = null,
             IProgress<ProgressReport>? progress = null
         )
         {
             if (archive.IsSolid || archive.Type == ArchiveType.SevenZip)
             {
                 using var reader = archive.ExtractAllEntries();
-                reader.WriteAllToDirectory(destinationDirectory);
+                reader.WriteAllToDirectory(destinationDirectory, options);
             }
             else
             {
-                archive.WriteToDirectoryInternal(destinationDirectory, progress);
+                archive.WriteToDirectoryInternal(destinationDirectory, options, progress);
             }
         }
 
         private void WriteToDirectoryInternal(
             string destinationDirectory,
+            ExtractionOptions? options,
             IProgress<ProgressReport>? progress
         )
         {
@@ -58,7 +61,7 @@ public static class IArchiveExtensions
                     continue;
                 }
 
-                entry.WriteToDirectory(destinationDirectory);
+                entry.WriteToDirectory(destinationDirectory, options);
 
                 bytesRead += entry.Size;
                 progress?.Report(

--- a/src/SharpCompress/Archives/IAsyncArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IAsyncArchiveExtensions.cs
@@ -17,10 +17,12 @@ public static class IAsyncArchiveExtensions
         /// </summary>
         /// <param name="archive">The archive to extract.</param>
         /// <param name="destinationDirectory">The folder to extract into.</param>
+        /// <param name="options">Extraction options.</param>
         /// <param name="progress">Optional progress reporter for tracking extraction progress.</param>
         /// <param name="cancellationToken">Optional cancellation token.</param>
         public async ValueTask WriteToDirectoryAsync(
             string destinationDirectory,
+            ExtractionOptions? options = null,
             IProgress<ProgressReport>? progress = null,
             CancellationToken cancellationToken = default
         )
@@ -34,7 +36,7 @@ public static class IAsyncArchiveExtensions
                     .ExtractAllEntriesAsync()
                     .ConfigureAwait(false);
                 await reader
-                    .WriteAllToDirectoryAsync(destinationDirectory, cancellationToken)
+                    .WriteAllToDirectoryAsync(destinationDirectory, options, cancellationToken)
                     .ConfigureAwait(false);
             }
             else
@@ -42,6 +44,7 @@ public static class IAsyncArchiveExtensions
                 await archive
                     .WriteToDirectoryAsyncInternal(
                         destinationDirectory,
+                        options,
                         progress,
                         cancellationToken
                     )
@@ -51,6 +54,7 @@ public static class IAsyncArchiveExtensions
 
         private async ValueTask WriteToDirectoryAsyncInternal(
             string destinationDirectory,
+            ExtractionOptions? options,
             IProgress<ProgressReport>? progress,
             CancellationToken cancellationToken
         )
@@ -80,7 +84,7 @@ public static class IAsyncArchiveExtensions
                 }
 
                 await entry
-                    .WriteToDirectoryAsync(destinationDirectory, cancellationToken)
+                    .WriteToDirectoryAsync(destinationDirectory, options, cancellationToken)
                     .ConfigureAwait(false);
 
                 bytesRead += entry.Size;

--- a/src/SharpCompress/Common/ExtractionMethods.Async.cs
+++ b/src/SharpCompress/Common/ExtractionMethods.Async.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using SharpCompress.Readers;
 
 namespace SharpCompress.Common;
 
@@ -11,12 +10,14 @@ internal static partial class ExtractionMethods
     public static async ValueTask WriteEntryToDirectoryAsync(
         IEntry entry,
         string destinationDirectory,
+        ExtractionOptions? options,
         Func<string, CancellationToken, ValueTask> writeAsync,
         CancellationToken cancellationToken = default
     )
     {
         string destinationFileName;
         var fullDestinationDirectoryPath = Path.GetFullPath(destinationDirectory);
+        options ??= new ExtractionOptions();
 
         //check for trailing slash.
         if (
@@ -36,7 +37,7 @@ internal static partial class ExtractionMethods
 
         var file = Path.GetFileName(entry.Key.NotNull("Entry Key is null")).NotNull("File is null");
         file = Utility.ReplaceInvalidFileNameChars(file);
-        if (entry.Options.ExtractFullPath)
+        if (options.ExtractFullPath)
         {
             var folder = Path.GetDirectoryName(entry.Key.NotNull("Entry Key is null"))
                 .NotNull("Directory is null");
@@ -72,7 +73,7 @@ internal static partial class ExtractionMethods
             }
             await writeAsync(destinationFileName, cancellationToken).ConfigureAwait(false);
         }
-        else if (entry.Options.ExtractFullPath && !Directory.Exists(destinationFileName))
+        else if (options.ExtractFullPath && !Directory.Exists(destinationFileName))
         {
             Directory.CreateDirectory(destinationFileName);
         }
@@ -81,19 +82,21 @@ internal static partial class ExtractionMethods
     public static async ValueTask WriteEntryToFileAsync(
         IEntry entry,
         string destinationFileName,
+        ExtractionOptions? options,
         Func<string, FileMode, CancellationToken, ValueTask> openAndWriteAsync,
         CancellationToken cancellationToken = default
     )
     {
+        options ??= new ExtractionOptions();
         if (entry.LinkTarget != null)
         {
-            if (entry.Options.SymbolicLinkHandler is not null)
+            if (options.SymbolicLinkHandler is not null)
             {
-                entry.Options.SymbolicLinkHandler(destinationFileName, entry.LinkTarget);
+                options.SymbolicLinkHandler(destinationFileName, entry.LinkTarget);
             }
             else
             {
-                ReaderOptions.DefaultSymbolicLinkHandler(destinationFileName, entry.LinkTarget);
+                ExtractionOptions.DefaultSymbolicLinkHandler(destinationFileName, entry.LinkTarget);
             }
             return;
         }
@@ -101,14 +104,14 @@ internal static partial class ExtractionMethods
         {
             var fm = FileMode.Create;
 
-            if (!entry.Options.Overwrite)
+            if (!options.Overwrite)
             {
                 fm = FileMode.CreateNew;
             }
 
             await openAndWriteAsync(destinationFileName, fm, cancellationToken)
                 .ConfigureAwait(false);
-            entry.PreserveExtractionOptions(destinationFileName);
+            entry.PreserveExtractionOptions(destinationFileName, options);
         }
     }
 }

--- a/src/SharpCompress/Common/ExtractionMethods.cs
+++ b/src/SharpCompress/Common/ExtractionMethods.cs
@@ -1,9 +1,6 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
-using SharpCompress.Readers;
 
 namespace SharpCompress.Common;
 
@@ -24,11 +21,13 @@ internal static partial class ExtractionMethods
     public static void WriteEntryToDirectory(
         IEntry entry,
         string destinationDirectory,
+        ExtractionOptions? options,
         Action<string> write
     )
     {
         string destinationFileName;
         var fullDestinationDirectoryPath = Path.GetFullPath(destinationDirectory);
+        options ??= new ExtractionOptions();
 
         //check for trailing slash.
         if (
@@ -48,7 +47,7 @@ internal static partial class ExtractionMethods
 
         var file = Path.GetFileName(entry.Key.NotNull("Entry Key is null")).NotNull("File is null");
         file = Utility.ReplaceInvalidFileNameChars(file);
-        if (entry.Options.ExtractFullPath)
+        if (options.ExtractFullPath)
         {
             var folder = Path.GetDirectoryName(entry.Key.NotNull("Entry Key is null"))
                 .NotNull("Directory is null");
@@ -84,7 +83,7 @@ internal static partial class ExtractionMethods
             }
             write(destinationFileName);
         }
-        else if (entry.Options.ExtractFullPath && !Directory.Exists(destinationFileName))
+        else if (options.ExtractFullPath && !Directory.Exists(destinationFileName))
         {
             Directory.CreateDirectory(destinationFileName);
         }
@@ -93,18 +92,20 @@ internal static partial class ExtractionMethods
     public static void WriteEntryToFile(
         IEntry entry,
         string destinationFileName,
+        ExtractionOptions? options,
         Action<string, FileMode> openAndWrite
     )
     {
+        options ??= new ExtractionOptions();
         if (entry.LinkTarget != null)
         {
-            if (entry.Options.SymbolicLinkHandler is not null)
+            if (options.SymbolicLinkHandler is not null)
             {
-                entry.Options.SymbolicLinkHandler(destinationFileName, entry.LinkTarget);
+                options.SymbolicLinkHandler(destinationFileName, entry.LinkTarget);
             }
             else
             {
-                ReaderOptions.DefaultSymbolicLinkHandler(destinationFileName, entry.LinkTarget);
+                ExtractionOptions.DefaultSymbolicLinkHandler(destinationFileName, entry.LinkTarget);
             }
             return;
         }
@@ -112,13 +113,13 @@ internal static partial class ExtractionMethods
         {
             var fm = FileMode.Create;
 
-            if (!entry.Options.Overwrite)
+            if (!options.Overwrite)
             {
                 fm = FileMode.CreateNew;
             }
 
             openAndWrite(destinationFileName, fm);
-            entry.PreserveExtractionOptions(destinationFileName);
+            entry.PreserveExtractionOptions(destinationFileName, options);
         }
     }
 }

--- a/src/SharpCompress/Common/ExtractionOptions.cs
+++ b/src/SharpCompress/Common/ExtractionOptions.cs
@@ -1,0 +1,109 @@
+using System;
+using SharpCompress.Common.Options;
+
+namespace SharpCompress.Common;
+
+/// <summary>
+/// Options for configuring extraction behavior when extracting archive entries.
+/// </summary>
+/// <remarks>
+/// This class is immutable. Use the <c>with</c> expression to create modified copies:
+/// <code>
+/// var options = new ExtractionOptions { Overwrite = false };
+/// options = options with { PreserveFileTime = true };
+/// </code>
+/// </remarks>
+public sealed record ExtractionOptions : IExtractionOptions
+{
+    /// <summary>
+    /// Overwrite target if it exists.
+    /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
+    /// </summary>
+    public bool Overwrite { get; init; } = true;
+
+    /// <summary>
+    /// Extract with internal directory structure.
+    /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
+    /// </summary>
+    public bool ExtractFullPath { get; init; } = true;
+
+    /// <summary>
+    /// Preserve file time.
+    /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
+    /// </summary>
+    public bool PreserveFileTime { get; init; } = true;
+
+    /// <summary>
+    /// Preserve windows file attributes.
+    /// </summary>
+    public bool PreserveAttributes { get; init; }
+
+    /// <summary>
+    /// Delegate for writing symbolic links to disk.
+    /// The first parameter is the source path (where the symlink is created).
+    /// The second parameter is the target path (what the symlink refers to).
+    /// </summary>
+    /// <remarks>
+    /// <b>Breaking change:</b> Changed from field to init-only property in version 0.40.0.
+    /// The default handler logs a warning message.
+    /// </remarks>
+    public Action<string, string>? SymbolicLinkHandler { get; init; }
+
+    /// <summary>
+    /// Creates a new ExtractionOptions instance with default values.
+    /// </summary>
+    public ExtractionOptions() { }
+
+    /// <summary>
+    /// Creates a new ExtractionOptions instance with the specified overwrite behavior.
+    /// </summary>
+    /// <param name="overwrite">Whether to overwrite existing files.</param>
+    public ExtractionOptions(bool overwrite)
+    {
+        Overwrite = overwrite;
+    }
+
+    /// <summary>
+    /// Creates a new ExtractionOptions instance with the specified extraction path and overwrite behavior.
+    /// </summary>
+    /// <param name="extractFullPath">Whether to preserve directory structure.</param>
+    /// <param name="overwrite">Whether to overwrite existing files.</param>
+    public ExtractionOptions(bool extractFullPath, bool overwrite)
+    {
+        ExtractFullPath = extractFullPath;
+        Overwrite = overwrite;
+    }
+
+    /// <summary>
+    /// Creates a new ExtractionOptions instance with the specified extraction path, overwrite behavior, and file time preservation.
+    /// </summary>
+    /// <param name="extractFullPath">Whether to preserve directory structure.</param>
+    /// <param name="overwrite">Whether to overwrite existing files.</param>
+    /// <param name="preserveFileTime">Whether to preserve file modification times.</param>
+    public ExtractionOptions(bool extractFullPath, bool overwrite, bool preserveFileTime)
+    {
+        ExtractFullPath = extractFullPath;
+        Overwrite = overwrite;
+        PreserveFileTime = preserveFileTime;
+    }
+
+    /// <summary>
+    /// Gets an ExtractionOptions instance configured for safe extraction (no overwrite).
+    /// </summary>
+    public static ExtractionOptions SafeExtract => new(overwrite: false);
+
+    /// <summary>
+    /// Gets an ExtractionOptions instance configured for flat extraction (no directory structure).
+    /// </summary>
+    public static ExtractionOptions FlatExtract => new(extractFullPath: false, overwrite: true);
+
+    /// <summary>
+    /// Default symbolic link handler that logs a warning message.
+    /// </summary>
+    public static void DefaultSymbolicLinkHandler(string sourcePath, string targetPath)
+    {
+        Console.WriteLine(
+            $"Could not write symlink {sourcePath} -> {targetPath}, for more information please see https://github.com/dotnet/runtime/issues/24271"
+        );
+    }
+}

--- a/src/SharpCompress/Common/ExtractionOptions.cs
+++ b/src/SharpCompress/Common/ExtractionOptions.cs
@@ -98,6 +98,12 @@ public sealed record ExtractionOptions : IExtractionOptions
     public static ExtractionOptions FlatExtract => new(extractFullPath: false, overwrite: true);
 
     /// <summary>
+    /// Gets an ExtractionOptions instance configured to preserve timestamps and attributes.
+    /// </summary>
+    public static ExtractionOptions PreserveMetadata =>
+        new() { PreserveFileTime = true, PreserveAttributes = true };
+
+    /// <summary>
     /// Default symbolic link handler that logs a warning message.
     /// </summary>
     public static void DefaultSymbolicLinkHandler(string sourcePath, string targetPath)

--- a/src/SharpCompress/Common/IEntry.Extensions.cs
+++ b/src/SharpCompress/Common/IEntry.Extensions.cs
@@ -4,9 +4,13 @@ namespace SharpCompress.Common;
 
 internal static class EntryExtensions
 {
-    internal static void PreserveExtractionOptions(this IEntry entry, string destinationFileName)
+    internal static void PreserveExtractionOptions(
+        this IEntry entry,
+        string destinationFileName,
+        ExtractionOptions options
+    )
     {
-        if (entry.Options.PreserveFileTime || entry.Options.PreserveAttributes)
+        if (options.PreserveFileTime || options.PreserveAttributes)
         {
             var nf = new FileInfo(destinationFileName);
             if (!nf.Exists)
@@ -15,7 +19,7 @@ internal static class EntryExtensions
             }
 
             // update file time to original packed time
-            if (entry.Options.PreserveFileTime)
+            if (options.PreserveFileTime)
             {
                 if (entry.CreatedTime.HasValue)
                 {
@@ -33,7 +37,7 @@ internal static class EntryExtensions
                 }
             }
 
-            if (entry.Options.PreserveAttributes)
+            if (options.PreserveAttributes)
             {
                 if (entry.Attrib.HasValue)
                 {

--- a/src/SharpCompress/Common/Options/IReaderOptions.cs
+++ b/src/SharpCompress/Common/Options/IReaderOptions.cs
@@ -3,11 +3,7 @@ using SharpCompress.Providers;
 
 namespace SharpCompress.Common.Options;
 
-public interface IReaderOptions
-    : IStreamOptions,
-        IEncodingOptions,
-        IProgressOptions,
-        IExtractionOptions
+public interface IReaderOptions : IStreamOptions, IEncodingOptions, IProgressOptions
 {
     /// <summary>
     /// Look for RarArchive (Check for self-extracting archives or cases where RarArchive isn't at the start of the file)

--- a/src/SharpCompress/Readers/IAsyncReaderExtensions.cs
+++ b/src/SharpCompress/Readers/IAsyncReaderExtensions.cs
@@ -14,14 +14,16 @@ public static class IAsyncReaderExtensions
         /// </summary>
         public async ValueTask WriteEntryToDirectoryAsync(
             string destinationDirectory,
+            ExtractionOptions? options = null,
             CancellationToken cancellationToken = default
         ) =>
             await ExtractionMethods
                 .WriteEntryToDirectoryAsync(
                     reader.Entry,
                     destinationDirectory,
+                    options,
                     async (path, ct) =>
-                        await reader.WriteEntryToFileAsync(path, ct).ConfigureAwait(false),
+                        await reader.WriteEntryToFileAsync(path, options, ct).ConfigureAwait(false),
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -31,12 +33,14 @@ public static class IAsyncReaderExtensions
         /// </summary>
         public async ValueTask WriteEntryToFileAsync(
             string destinationFileName,
+            ExtractionOptions? options = null,
             CancellationToken cancellationToken = default
         ) =>
             await ExtractionMethods
                 .WriteEntryToFileAsync(
                     reader.Entry,
                     destinationFileName,
+                    options,
                     async (x, fm, ct) =>
                     {
                         using var fs = File.Open(destinationFileName, fm);
@@ -51,25 +55,28 @@ public static class IAsyncReaderExtensions
         /// </summary>
         public async ValueTask WriteAllToDirectoryAsync(
             string destinationDirectory,
+            ExtractionOptions? options = null,
             CancellationToken cancellationToken = default
         )
         {
             while (await reader.MoveToNextEntryAsync(cancellationToken).ConfigureAwait(false))
             {
                 await reader
-                    .WriteEntryToDirectoryAsync(destinationDirectory, cancellationToken)
+                    .WriteEntryToDirectoryAsync(destinationDirectory, options, cancellationToken)
                     .ConfigureAwait(false);
             }
         }
 
         public async ValueTask WriteEntryToAsync(
             string destinationFileName,
+            ExtractionOptions? options = null,
             CancellationToken cancellationToken = default
         ) =>
             await ExtractionMethods
                 .WriteEntryToFileAsync(
                     reader.Entry,
                     destinationFileName,
+                    options,
                     async (x, fm, ct) =>
                     {
                         using var fs = File.Open(destinationFileName, fm);
@@ -81,10 +88,11 @@ public static class IAsyncReaderExtensions
 
         public async ValueTask WriteEntryToAsync(
             FileInfo destinationFileInfo,
+            ExtractionOptions? options = null,
             CancellationToken cancellationToken = default
         ) =>
             await reader
-                .WriteEntryToAsync(destinationFileInfo.FullName, cancellationToken)
+                .WriteEntryToAsync(destinationFileInfo.FullName, options, cancellationToken)
                 .ConfigureAwait(false);
     }
 }

--- a/src/SharpCompress/Readers/IReaderExtensions.cs
+++ b/src/SharpCompress/Readers/IReaderExtensions.cs
@@ -22,31 +22,42 @@ public static class IReaderExtensions
         /// <summary>
         /// Extract all remaining unread entries to specific directory, retaining filename
         /// </summary>
-        public void WriteAllToDirectory(string destinationDirectory)
+        public void WriteAllToDirectory(
+            string destinationDirectory,
+            ExtractionOptions? options = null
+        )
         {
             while (reader.MoveToNextEntry())
             {
-                reader.WriteEntryToDirectory(destinationDirectory);
+                reader.WriteEntryToDirectory(destinationDirectory, options);
             }
         }
 
         /// <summary>
         /// Extract to specific directory, retaining filename
         /// </summary>
-        public void WriteEntryToDirectory(string destinationDirectory) =>
+        public void WriteEntryToDirectory(
+            string destinationDirectory,
+            ExtractionOptions? options = null
+        ) =>
             ExtractionMethods.WriteEntryToDirectory(
                 reader.Entry,
                 destinationDirectory,
-                (path) => reader.WriteEntryToFile(path)
+                options,
+                (path) => reader.WriteEntryToFile(path, options)
             );
 
         /// <summary>
         /// Extract to specific file
         /// </summary>
-        public void WriteEntryToFile(string destinationFileName) =>
+        public void WriteEntryToFile(
+            string destinationFileName,
+            ExtractionOptions? options = null
+        ) =>
             ExtractionMethods.WriteEntryToFile(
                 reader.Entry,
                 destinationFileName,
+                options,
                 (x, fm) =>
                 {
                     using var fs = File.Open(destinationFileName, fm);

--- a/src/SharpCompress/Readers/ReaderFactory.Async.cs
+++ b/src/SharpCompress/Readers/ReaderFactory.Async.cs
@@ -41,7 +41,7 @@ public static partial class ReaderFactory
         CancellationToken cancellationToken = default
     )
     {
-        options ??= ReaderOptions.ForOwnedFile;
+        options ??= ReaderOptions.ForFilePath;
         var stream = fileInfo.OpenAsyncReadStream(cancellationToken);
         return await OpenAsyncReader(stream, options, cancellationToken).ConfigureAwait(false);
     }

--- a/src/SharpCompress/Readers/ReaderFactory.cs
+++ b/src/SharpCompress/Readers/ReaderFactory.cs
@@ -17,7 +17,7 @@ public static partial class ReaderFactory
 
     public static IReader OpenReader(FileInfo fileInfo, ReaderOptions? options = null)
     {
-        options ??= ReaderOptions.ForOwnedFile;
+        options ??= ReaderOptions.ForFilePath;
         return OpenReader(fileInfo.OpenRead(), options);
     }
 

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -10,9 +10,9 @@ namespace SharpCompress.Readers;
 /// Options for configuring reader behavior when opening archives.
 /// </summary>
 /// <remarks>
-/// This class is immutable. Use factory presets and fluent helpers for common configurations:
+/// This class is immutable. Use preset properties and fluent helpers for common configurations:
 /// <code>
-/// var options = ReaderOptions.ForExternalStream()
+/// var options = ReaderOptions.ForExternalStream
 ///     .WithPassword("secret")
 ///     .WithLookForHeader(true);
 /// </code>

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -128,7 +128,7 @@ public sealed record ReaderOptions : IReaderOptions
     /// <summary>
     /// Gets ReaderOptions configured for file-based overloads that open their own stream.
     /// </summary>
-    public static ReaderOptions ForOwnedFile => new() { LeaveStreamOpen = false };
+    public static ReaderOptions ForFilePath => new() { LeaveStreamOpen = false };
 
     /// <summary>
     /// Creates ReaderOptions for reading encrypted archives.

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -108,40 +108,6 @@ public sealed record ReaderOptions : IReaderOptions
     public int? RewindableBufferSize { get; init; }
 
     /// <summary>
-    /// Overwrite target if it exists.
-    /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
-    /// </summary>
-    public bool Overwrite { get; init; } = true;
-
-    /// <summary>
-    /// Extract with internal directory structure.
-    /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
-    /// </summary>
-    public bool ExtractFullPath { get; init; } = true;
-
-    /// <summary>
-    /// Preserve file time.
-    /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
-    /// </summary>
-    public bool PreserveFileTime { get; init; } = true;
-
-    /// <summary>
-    /// Preserve windows file attributes.
-    /// </summary>
-    public bool PreserveAttributes { get; init; }
-
-    /// <summary>
-    /// Delegate for writing symbolic links to disk.
-    /// The first parameter is the source path (where the symlink is created).
-    /// The second parameter is the target path (what the symlink refers to).
-    /// </summary>
-    /// <remarks>
-    /// <b>Breaking change:</b> Changed from field to init-only property in version 0.40.0.
-    /// The default handler logs a warning message.
-    /// </remarks>
-    public Action<string, string>? SymbolicLinkHandler { get; init; }
-
-    /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations, such as
     /// System.IO.Compression for Deflate/GZip on modern .NET.
@@ -165,16 +131,6 @@ public sealed record ReaderOptions : IReaderOptions
     public static ReaderOptions ForOwnedFile => new() { LeaveStreamOpen = false };
 
     /// <summary>
-    /// Gets a ReaderOptions instance configured for safe extraction (no overwrite).
-    /// </summary>
-    public static ReaderOptions SafeExtract => new() { Overwrite = false };
-
-    /// <summary>
-    /// Gets a ReaderOptions instance configured for flat extraction (no directory structure).
-    /// </summary>
-    public static ReaderOptions FlatExtract => new() { ExtractFullPath = false, Overwrite = true };
-
-    /// <summary>
     /// Creates ReaderOptions for reading encrypted archives.
     /// </summary>
     /// <param name="password">The password for encrypted archives.</param>
@@ -196,16 +152,6 @@ public sealed record ReaderOptions : IReaderOptions
             .WithLookForHeader(true)
             .WithPassword(password)
             .WithRewindableBufferSize(1_048_576); // 1MB for SFX archives
-
-    /// <summary>
-    /// Default symbolic link handler that logs a warning message.
-    /// </summary>
-    public static void DefaultSymbolicLinkHandler(string sourcePath, string targetPath)
-    {
-        Console.WriteLine(
-            $"Could not write symlink {sourcePath} -> {targetPath}, for more information please see https://github.com/dotnet/runtime/issues/24271"
-        );
-    }
 
     // Note: Parameterized constructors have been removed.
     // Use fluent With*() helpers or object initializers instead:

--- a/src/SharpCompress/Readers/ReaderOptionsExtensions.cs
+++ b/src/SharpCompress/Readers/ReaderOptionsExtensions.cs
@@ -87,47 +87,6 @@ public static class ReaderOptionsExtensions
     ) => options with { RewindableBufferSize = rewindableBufferSize };
 
     /// <summary>
-    /// Creates a copy with the specified overwrite setting.
-    /// </summary>
-    public static ReaderOptions WithOverwrite(this ReaderOptions options, bool overwrite) =>
-        options with
-        {
-            Overwrite = overwrite,
-        };
-
-    /// <summary>
-    /// Creates a copy with the specified extract full path setting.
-    /// </summary>
-    public static ReaderOptions WithExtractFullPath(
-        this ReaderOptions options,
-        bool extractFullPath
-    ) => options with { ExtractFullPath = extractFullPath };
-
-    /// <summary>
-    /// Creates a copy with the specified preserve file time setting.
-    /// </summary>
-    public static ReaderOptions WithPreserveFileTime(
-        this ReaderOptions options,
-        bool preserveFileTime
-    ) => options with { PreserveFileTime = preserveFileTime };
-
-    /// <summary>
-    /// Creates a copy with the specified preserve attributes setting.
-    /// </summary>
-    public static ReaderOptions WithPreserveAttributes(
-        this ReaderOptions options,
-        bool preserveAttributes
-    ) => options with { PreserveAttributes = preserveAttributes };
-
-    /// <summary>
-    /// Creates a copy with the specified symbolic link handler.
-    /// </summary>
-    public static ReaderOptions WithSymbolicLinkHandler(
-        this ReaderOptions options,
-        Action<string, string>? handler
-    ) => options with { SymbolicLinkHandler = handler };
-
-    /// <summary>
     /// Creates a copy with the specified compression provider registry.
     /// </summary>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="providers"/> is null.</exception>

--- a/tests/SharpCompress.Test/ExtractionTests.cs
+++ b/tests/SharpCompress.Test/ExtractionTests.cs
@@ -47,7 +47,12 @@ public class ExtractionTests : TestBase
 
             // This should not throw an exception even if Path.GetFullPath returns
             // a path with different casing than the actual directory
-            var exception = Record.Exception(() => reader.WriteAllToDirectory(extractPath));
+            var exception = Record.Exception(() =>
+                reader.WriteAllToDirectory(
+                    extractPath,
+                    new ExtractionOptions { ExtractFullPath = false, Overwrite = true }
+                )
+            );
 
             Assert.Null(exception);
         }
@@ -90,7 +95,10 @@ public class ExtractionTests : TestBase
             using var reader = ReaderFactory.OpenReader(stream);
 
             var exception = Assert.Throws<ExtractionException>(() =>
-                reader.WriteAllToDirectory(extractPath)
+                reader.WriteAllToDirectory(
+                    extractPath,
+                    new ExtractionOptions { ExtractFullPath = true, Overwrite = true }
+                )
             );
 
             Assert.Contains("outside of the destination", exception.Message);

--- a/tests/SharpCompress.Test/GZip/AsyncTests.cs
+++ b/tests/SharpCompress.Test/GZip/AsyncTests.cs
@@ -144,7 +144,7 @@ public class AsyncTests : TestBase
             cancellationToken: cts.Token
         );
 
-        await reader.WriteAllToDirectoryAsync(SCRATCH_FILES_PATH, cts.Token);
+        await reader.WriteAllToDirectoryAsync(SCRATCH_FILES_PATH, cancellationToken: cts.Token);
 
         // Just verify some files were extracted
         var extractedFiles = Directory.GetFiles(

--- a/tests/SharpCompress.Test/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Test/OptionsUsabilityTests.cs
@@ -209,7 +209,7 @@ public class OptionsUsabilityTests : TestBase
         var external = ReaderOptions.ForExternalStream;
         Assert.True(external.LeaveStreamOpen);
 
-        var owned = ReaderOptions.ForOwnedFile;
+        var owned = ReaderOptions.ForFilePath;
         Assert.False(owned.LeaveStreamOpen);
     }
 
@@ -222,6 +222,10 @@ public class OptionsUsabilityTests : TestBase
         var flat = ExtractionOptions.FlatExtract;
         Assert.False(flat.ExtractFullPath);
         Assert.True(flat.Overwrite);
+
+        var preserveMetadata = ExtractionOptions.PreserveMetadata;
+        Assert.True(preserveMetadata.PreserveFileTime);
+        Assert.True(preserveMetadata.PreserveAttributes);
     }
 
     [Fact]

--- a/tests/SharpCompress.Test/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Test/OptionsUsabilityTests.cs
@@ -180,7 +180,8 @@ public class OptionsUsabilityTests : TestBase
             .WithLeaveStreamOpen(false)
             .WithPassword("secret")
             .WithLookForHeader(true)
-            .WithOverwrite(false);
+            .WithBufferSize(65536)
+            .WithDisableCheckIncomplete(true);
 
         // Object initializer approach
         var initializerApproach = new ReaderOptions
@@ -188,13 +189,18 @@ public class OptionsUsabilityTests : TestBase
             LeaveStreamOpen = false,
             Password = "secret",
             LookForHeader = true,
-            Overwrite = false,
+            BufferSize = 65536,
+            DisableCheckIncomplete = true,
         };
 
         Assert.Equal(fluentApproach.LeaveStreamOpen, initializerApproach.LeaveStreamOpen);
         Assert.Equal(fluentApproach.Password, initializerApproach.Password);
         Assert.Equal(fluentApproach.LookForHeader, initializerApproach.LookForHeader);
-        Assert.Equal(fluentApproach.Overwrite, initializerApproach.Overwrite);
+        Assert.Equal(fluentApproach.BufferSize, initializerApproach.BufferSize);
+        Assert.Equal(
+            fluentApproach.DisableCheckIncomplete,
+            initializerApproach.DisableCheckIncomplete
+        );
     }
 
     [Fact]
@@ -205,11 +211,15 @@ public class OptionsUsabilityTests : TestBase
 
         var owned = ReaderOptions.ForOwnedFile;
         Assert.False(owned.LeaveStreamOpen);
+    }
 
-        var safe = ReaderOptions.SafeExtract;
+    [Fact]
+    public void ExtractionOptions_Presets_Have_Correct_Defaults()
+    {
+        var safe = ExtractionOptions.SafeExtract;
         Assert.False(safe.Overwrite);
 
-        var flat = ReaderOptions.FlatExtract;
+        var flat = ExtractionOptions.FlatExtract;
         Assert.False(flat.ExtractFullPath);
         Assert.True(flat.Overwrite);
     }

--- a/tests/SharpCompress.Test/ReaderTests.cs
+++ b/tests/SharpCompress.Test/ReaderTests.cs
@@ -202,7 +202,10 @@ public abstract class ReaderTests : TestBase
                     Assert.Equal(expectedCompression, reader.Entry.CompressionType);
                 }
 
-                await reader.WriteEntryToDirectoryAsync(SCRATCH_FILES_PATH, cancellationToken);
+                await reader.WriteEntryToDirectoryAsync(
+                    SCRATCH_FILES_PATH,
+                    cancellationToken: cancellationToken
+                );
             }
         }
     }

--- a/tests/SharpCompress.Test/WriterTests.cs
+++ b/tests/SharpCompress.Test/WriterTests.cs
@@ -99,7 +99,10 @@ public class WriterTests : TestBase
                 readerOptions,
                 cancellationToken
             );
-            await reader.WriteAllToDirectoryAsync(SCRATCH_FILES_PATH, cancellationToken);
+            await reader.WriteAllToDirectoryAsync(
+                SCRATCH_FILES_PATH,
+                cancellationToken: cancellationToken
+            );
         }
         VerifyFiles();
     }

--- a/tests/SharpCompress.Test/Zip/ZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveAsyncTests.cs
@@ -242,7 +242,7 @@ public class ZipArchiveAsyncTests : ArchiveTests
             await using IAsyncArchive archive = await ZipArchive.OpenAsyncArchive(
                 new AsyncOnlyStream(stream)
             );
-            await archive.WriteToDirectoryAsync(SCRATCH_FILES_PATH, progress);
+            await archive.WriteToDirectoryAsync(SCRATCH_FILES_PATH, progress: progress);
         }
 
         await Task.Delay(1000);


### PR DESCRIPTION
Put back ExtractionOptions.  Was always dubious I could get rid of them anyway: https://github.com/adamhathcock/sharpcompress/issues/1228

This pull request introduces a significant improvement to the extraction API by separating open-time and extract-time behaviors, clarifying usage of `ReaderOptions` and introducing `ExtractionOptions` for extraction-specific settings. The documentation and codebase have been updated for consistency, and method signatures now explicitly accept extraction options, providing users with more granular control over extraction behavior.

**API and Extraction Behavior Refactoring**

* Introduced `ExtractionOptions` as a distinct type for extract-time settings (such as overwrite, path handling, timestamps, and attributes), and updated method signatures throughout the codebase to accept `ExtractionOptions?` instead of `ReaderOptions?` for extraction operations. This change affects methods like `WriteToDirectory` and `WriteToFile` in `IArchiveEntryExtensions`, `IArchiveExtensions`, and `IAsyncArchiveExtensions`, ensuring clearer separation of concerns between archive opening and extraction behavior. [[1]](diffhunk://#diff-61084e55d70b594ef97e944a0bc645b95f63a1854f75f17a038ab224850cfa0cL105-R142) [[2]](diffhunk://#diff-61084e55d70b594ef97e944a0bc645b95f63a1854f75f17a038ab224850cfa0cR155-R162) [[3]](diffhunk://#diff-ee44197cdbbf432a52b15007eb69738c3c36d9b5546500c9e29654bc7fd2fae0R17-R38) [[4]](diffhunk://#diff-ee44197cdbbf432a52b15007eb69738c3c36d9b5546500c9e29654bc7fd2fae0L61-R64) [[5]](diffhunk://#diff-756e4f87f658a4ed6b9665f5de836746ebe0b6a9a5e18f5728838b07777dbee4R20-R25) [[6]](diffhunk://#diff-756e4f87f658a4ed6b9665f5de836746ebe0b6a9a5e18f5728838b07777dbee4L37-R47) [[7]](diffhunk://#diff-22b8bc5a3d713f2404d058a5fddfba4cec7f175d67a00be88fe4f96da36f7d18L96-R100)

* Updated all relevant documentation (`API.md`, `USAGE.md`, `PERFORMANCE.md`, `ARCHITECTURE.md`) to reflect the new extraction options paradigm, clarifying when to use `ReaderOptions` (for open-time settings like password and encoding) versus `ExtractionOptions` (for extract-time settings like overwrite and path preservation). Examples and option matrices were revised for accuracy and clarity. [[1]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L234-R238) [[2]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L247-R254) [[3]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L300-R322) [[4]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L327-R333) [[5]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L415-R421) [[6]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L97-R104) [[7]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L134-R140) [[8]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L221-R222) [[9]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L264-R265) [[10]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L342-R343) [[11]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L93-R94)

**Default Option Changes and Consistency**

* Changed the default option for archive opening from `ReaderOptions.ForOwnedFile` to `ReaderOptions.ForFilePath` throughout the codebase, ensuring consistent and more intuitive behavior for users opening archives via file paths. [[1]](diffhunk://#diff-50da048b83ebc76ae4fa804e559576e2f212b170e66b01b0b15d199aef1837c7L46-R46) [[2]](diffhunk://#diff-50da048b83ebc76ae4fa804e559576e2f212b170e66b01b0b15d199aef1837c7L76-R76) [[3]](diffhunk://#diff-22b8bc5a3d713f2404d058a5fddfba4cec7f175d67a00be88fe4f96da36f7d18L43-R43) [[4]](diffhunk://#diff-22b8bc5a3d713f2404d058a5fddfba4cec7f175d67a00be88fe4f96da36f7d18L67-R67)

**Minor Improvements and Fixes**

* Updated method calls to use named parameters for `cancellationToken` in async extraction examples for clarity and consistency in documentation. [[1]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L193-R193) [[2]](diffhunk://#diff-39de61d88e1fa5f9ff408ff884ef974a1e1fdc7f2c19f1b862305bdb02b841c0L336-R336) [[3]](diffhunk://#diff-39de61d88e1fa5f9ff408ff884ef974a1e1fdc7f2c19f1b862305bdb02b841c0L372-R372) [[4]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L9-R9) [[5]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L264-R265) [[6]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L342-R343)

* Updated interface and documentation comments to reflect the separation of open-time and extract-time options, improving maintainability and reducing confusion.

These changes make the extraction API more robust, intuitive, and easier to use, while also improving documentation and code clarity.