### PR TITLE
Fix setting invalid access time fails extraction

### DIFF
--- a/src/SharpCompress/Common/IEntry.Extensions.cs
+++ b/src/SharpCompress/Common/IEntry.Extensions.cs
@@ -23,17 +23,38 @@ internal static class EntryExtensions
             {
                 if (entry.CreatedTime.HasValue)
                 {
-                    nf.CreationTime = entry.CreatedTime.Value;
+                    try
+                    {
+                        nf.CreationTime = entry.CreatedTime.Value;
+                    }
+                    catch
+                    {
+                        // Invalid time or the OS rejected
+                    }
                 }
 
                 if (entry.LastModifiedTime.HasValue)
                 {
-                    nf.LastWriteTime = entry.LastModifiedTime.Value;
+                    try
+                    {
+                        nf.LastWriteTime = entry.LastModifiedTime.Value;
+                    }
+                    catch
+                    {
+                        // Invalid time or the OS rejected
+                    }
                 }
 
                 if (entry.LastAccessedTime.HasValue)
                 {
-                    nf.LastAccessTime = entry.LastAccessedTime.Value;
+                    try
+                    {
+                        nf.LastAccessTime = entry.LastAccessedTime.Value;
+                    }
+                    catch
+                    {
+                        // Invalid time or the OS rejected
+                    }
                 }
             }
 


### PR DESCRIPTION
Ignore exceptions when setting the access time as the time might be invalid or the OS rejected it and we should not fail the extraction because of it.

Did not end up writing tests for this as this is region / time / historical data / OS specific issue. The archive I was inspecting had dates with leap seconds that did not line up correctly.
