### PR TITLE
Fix edge cases with 1-byte reads

### DIFF
--- a/src/SharpCompress/Compressors/Deflate/GZipStream.cs
+++ b/src/SharpCompress/Compressors/Deflate/GZipStream.cs
@@ -79,8 +79,24 @@ public partial class GZipStream : Stream
         CompressionLevel level,
         Encoding encoding
     )
+        : this(stream, mode, level, leaveOpen: false, encoding) { }
+
+    public GZipStream(
+        Stream stream,
+        CompressionMode mode,
+        CompressionLevel level,
+        bool leaveOpen,
+        Encoding encoding
+    )
     {
-        BaseStream = new ZlibBaseStream(stream, mode, level, ZlibStreamFlavor.GZIP, encoding);
+        BaseStream = new ZlibBaseStream(
+            stream,
+            mode,
+            level,
+            ZlibStreamFlavor.GZIP,
+            leaveOpen,
+            encoding
+        );
         _encoding = encoding;
     }
 

--- a/src/SharpCompress/Compressors/Deflate/ZlibBaseStream.cs
+++ b/src/SharpCompress/Compressors/Deflate/ZlibBaseStream.cs
@@ -1006,9 +1006,13 @@ internal class ZlibBaseStream : Stream, IStreamStack
             && !_wantCompress
         )
         {
-            //rewind the buffer
-            this.Rewind(z.AvailableBytesIn);
-            z.AvailableBytesIn = 0;
+            // Rewind the buffer. Only clear AvailableBytesIn if rewind succeeded.
+            // If rewind fails (e.g., non-seekable stream), the trailer bytes are
+            // still in the working buffer and will be needed by finish().
+            if (this.Rewind(z.AvailableBytesIn))
+            {
+                z.AvailableBytesIn = 0;
+            }
         }
 
         return rc;
@@ -1209,9 +1213,13 @@ internal class ZlibBaseStream : Stream, IStreamStack
             && !_wantCompress
         )
         {
-            //rewind the buffer
-            this.Rewind(z.AvailableBytesIn);
-            z.AvailableBytesIn = 0;
+            // Rewind the buffer. Only clear AvailableBytesIn if rewind succeeded.
+            // If rewind fails (e.g., non-seekable stream), the trailer bytes are
+            // still in the working buffer and will be needed by finish().
+            if (this.Rewind(z.AvailableBytesIn))
+            {
+                z.AvailableBytesIn = 0;
+            }
         }
 
         return rc;

--- a/src/SharpCompress/Compressors/Deflate/ZlibBaseStream.cs
+++ b/src/SharpCompress/Compressors/Deflate/ZlibBaseStream.cs
@@ -630,17 +630,17 @@ internal class ZlibBaseStream : Stream, IStreamStack
     //_outStream.Seek(offset, origin);
     public override void SetLength(Int64 value) => _stream.SetLength(value);
 
-#if NOT
-    public int Read()
+    public override int ReadByte()
     {
-        if (Read(_buf1, 0, 1) == 0)
-            return 0;
-        // calculate CRC after reading
-        if (crc != null)
-            crc.SlurpBlock(_buf1, 0, 1);
-        return (_buf1[0] & 0xFF);
+        var buffer = _buf1;
+        var n = Read(buffer, 0, 1);
+        if (n == 0)
+        {
+            return -1;
+        }
+
+        return buffer[0];
     }
-#endif
 
     private bool nomoreinput;
     private bool isDisposed;
@@ -987,6 +987,11 @@ internal class ZlibBaseStream : Stream, IStreamStack
             }
         }
 
+        // Save the inflate/deflate result code before overwriting rc with the
+        // byte count. Z_STREAM_END == 1, so when count == 1 and all bytes were
+        // produced, (count - AvailableBytesOut) == 1 which would falsely match
+        // Z_STREAM_END and trigger a spurious rewind.
+        var inflateResult = rc;
         rc = (count - _z.AvailableBytesOut);
 
         // calculate CRC after reading
@@ -995,7 +1000,11 @@ internal class ZlibBaseStream : Stream, IStreamStack
             crc.SlurpBlock(buffer, offset, rc);
         }
 
-        if (rc == ZlibConstants.Z_STREAM_END && z.AvailableBytesIn != 0 && !_wantCompress)
+        if (
+            inflateResult == ZlibConstants.Z_STREAM_END
+            && z.AvailableBytesIn != 0
+            && !_wantCompress
+        )
         {
             //rewind the buffer
             this.Rewind(z.AvailableBytesIn);
@@ -1181,6 +1190,11 @@ internal class ZlibBaseStream : Stream, IStreamStack
             }
         }
 
+        // Save the inflate/deflate result code before overwriting rc with the
+        // byte count. Z_STREAM_END == 1, so when count == 1 and all bytes were
+        // produced, (count - AvailableBytesOut) == 1 which would falsely match
+        // Z_STREAM_END and trigger a spurious rewind.
+        var inflateResult = rc;
         rc = (count - _z.AvailableBytesOut);
 
         // calculate CRC after reading
@@ -1189,7 +1203,11 @@ internal class ZlibBaseStream : Stream, IStreamStack
             crc.SlurpBlock(buffer, offset, rc);
         }
 
-        if (rc == ZlibConstants.Z_STREAM_END && z.AvailableBytesIn != 0 && !_wantCompress)
+        if (
+            inflateResult == ZlibConstants.Z_STREAM_END
+            && z.AvailableBytesIn != 0
+            && !_wantCompress
+        )
         {
             //rewind the buffer
             this.Rewind(z.AvailableBytesIn);

--- a/src/SharpCompress/IO/IStreamStack.cs
+++ b/src/SharpCompress/IO/IStreamStack.cs
@@ -64,8 +64,8 @@ public static class StreamStackExtensions
                 }
 
                 // Try to rewind within the buffer. If the position is outside the buffered
-                // region, silently ignore (matching release behavior where streams without
-                // buffering simply didn't rewind).
+                // region, silently ignore (non-seekable/non-buffered streams cannot rewind,
+                // but passthrough streams with seekable underlying streams can).
                 var targetPosition = sharpCompressStream.Position - count;
                 if (targetPosition >= 0)
                 {

--- a/src/SharpCompress/IO/IStreamStack.cs
+++ b/src/SharpCompress/IO/IStreamStack.cs
@@ -49,7 +49,7 @@ public static class StreamStackExtensions
         return current;
     }
 
-    internal static void Rewind(this IStreamStack stream, int count)
+    internal static bool Rewind(this IStreamStack stream, int count)
     {
         IStreamStack? current = stream;
 
@@ -57,6 +57,12 @@ public static class StreamStackExtensions
         {
             if (current is SharpCompressStream sharpCompressStream)
             {
+                // Check if stream supports seeking before attempting rewind
+                if (!sharpCompressStream.CanSeek)
+                {
+                    return false;
+                }
+
                 // Try to rewind within the buffer. If the position is outside the buffered
                 // region, silently ignore (matching release behavior where streams without
                 // buffering simply didn't rewind).
@@ -66,15 +72,18 @@ public static class StreamStackExtensions
                     try
                     {
                         sharpCompressStream.Position = targetPosition;
+                        return true;
                     }
                     catch (NotSupportedException)
                     {
                         // Cannot seek outside buffered region - silently ignore
+                        return false;
                     }
                 }
-                return;
+                return false;
             }
             current = current.BaseStream() as IStreamStack;
         }
+        return false;
     }
 }

--- a/src/SharpCompress/Providers/Default/GZipCompressionProvider.cs
+++ b/src/SharpCompress/Providers/Default/GZipCompressionProvider.cs
@@ -24,7 +24,6 @@ public sealed class GZipCompressionProvider : CompressionProviderBase
             destination,
             CompressionMode.Compress,
             level,
-            leaveOpen: true,
             Encoding.UTF8
         );
     }

--- a/src/SharpCompress/Providers/Default/GZipCompressionProvider.cs
+++ b/src/SharpCompress/Providers/Default/GZipCompressionProvider.cs
@@ -13,6 +13,16 @@ namespace SharpCompress.Providers.Default;
 /// </summary>
 public sealed class GZipCompressionProvider : CompressionProviderBase
 {
+    private readonly bool _leaveOpen;
+
+    public GZipCompressionProvider()
+        : this(leaveOpen: false) { }
+
+    public GZipCompressionProvider(bool leaveOpen)
+    {
+        _leaveOpen = leaveOpen;
+    }
+
     public override CompressionType CompressionType => CompressionType.GZip;
     public override bool SupportsCompression => true;
     public override bool SupportsDecompression => true;
@@ -24,6 +34,7 @@ public sealed class GZipCompressionProvider : CompressionProviderBase
             destination,
             CompressionMode.Compress,
             level,
+            _leaveOpen,
             Encoding.UTF8
         );
     }

--- a/src/SharpCompress/Providers/Default/GZipCompressionProvider.cs
+++ b/src/SharpCompress/Providers/Default/GZipCompressionProvider.cs
@@ -20,7 +20,13 @@ public sealed class GZipCompressionProvider : CompressionProviderBase
     public override Stream CreateCompressStream(Stream destination, int compressionLevel)
     {
         var level = (CompressionLevel)compressionLevel;
-        return new GZipStream(destination, CompressionMode.Compress, level, Encoding.UTF8);
+        return new GZipStream(
+            destination,
+            CompressionMode.Compress,
+            level,
+            leaveOpen: true,
+            Encoding.UTF8
+        );
     }
 
     public override Stream CreateDecompressStream(Stream source)

--- a/tests/SharpCompress.Test/Zip/ZipCompressionRoundtripTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipCompressionRoundtripTests.cs
@@ -12,24 +12,21 @@ namespace SharpCompress.Test.Zip;
 
 public class ZipCompressionRoundtripTests : TestBase
 {
-    private const int TESTSIZE = 1024 * 1024;
+    private const int TestSize = 1024 * 1024;
 
-    [Fact]
-    public void Zip_Deflate_Roundtrip_ArchiveApi_BufferedRead_Succeeds()
+    private static (byte[] TestSet1, byte[] TestSet2, MemoryStream Stream) CreateTestZip()
     {
-        // Create test data with specific patterns
         var testset1 = Enumerable
-            .Range(0, TESTSIZE)
+            .Range(0, TestSize)
             .Select(i => (byte)((i * 22695477) % 257))
             .ToArray();
         var testset2 = Enumerable
-            .Range(0, TESTSIZE)
+            .Range(0, TestSize)
             .Select(i => (byte)((i * 48271) % 257))
             .ToArray();
 
-        using var stream = new MemoryStream();
+        var stream = new MemoryStream();
 
-        // Compress test streams
         var writerOptions = new ZipWriterOptions(CompressionType.Deflate, compressionLevel: 9);
 
         using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
@@ -37,6 +34,15 @@ public class ZipCompressionRoundtripTests : TestBase
             writer.Write("sample1", new MemoryStream(testset1));
             writer.Write("sample2", new MemoryStream(testset2));
         }
+
+        stream.Position = 0;
+        return (testset1, testset2, stream);
+    }
+
+    [Fact]
+    public void Zip_Deflate_Roundtrip_ArchiveApi_BufferedRead_Succeeds()
+    {
+        var (testset1, testset2, stream) = CreateTestZip();
 
         // Decompress and verify using Archive API with buffered read (CopyTo)
         stream.Position = 0;
@@ -65,29 +71,7 @@ public class ZipCompressionRoundtripTests : TestBase
     [Fact]
     public void Zip_Deflate_Roundtrip_ArchiveApi_ByteByByteRead_Succeeds()
     {
-        // Create test data with specific patterns
-        var testset1 = Enumerable
-            .Range(0, TESTSIZE)
-            .Select(i => (byte)((i * 22695477) % 257))
-            .ToArray();
-        var testset2 = Enumerable
-            .Range(0, TESTSIZE)
-            .Select(i => (byte)((i * 48271) % 257))
-            .ToArray();
-
-        using var stream = new MemoryStream();
-
-        // Compress test streams
-        var writerOptions = new ZipWriterOptions(CompressionType.Deflate, compressionLevel: 9);
-
-        using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
-        {
-            writer.Write("sample1", new MemoryStream(testset1));
-            writer.Write("sample2", new MemoryStream(testset2));
-        }
-
-        // Decompress and verify using byte-by-byte read
-        stream.Position = 0;
+        var (testset1, testset2, stream) = CreateTestZip();
         using (var archive = ZipArchive.OpenArchive(stream))
         {
             var files = archive.Entries.Where(e => !e.IsDirectory).OrderBy(e => e.Key).ToList();
@@ -129,29 +113,7 @@ public class ZipCompressionRoundtripTests : TestBase
     [Fact]
     public void Zip_Deflate_Roundtrip_ReaderApi_BufferedRead_Succeeds()
     {
-        // Create test data with specific patterns
-        var testset1 = Enumerable
-            .Range(0, TESTSIZE)
-            .Select(i => (byte)((i * 22695477) % 257))
-            .ToArray();
-        var testset2 = Enumerable
-            .Range(0, TESTSIZE)
-            .Select(i => (byte)((i * 48271) % 257))
-            .ToArray();
-
-        using var stream = new MemoryStream();
-
-        // Compress test streams
-        var writerOptions = new ZipWriterOptions(CompressionType.Deflate, compressionLevel: 9);
-
-        using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
-        {
-            writer.Write("sample1", new MemoryStream(testset1));
-            writer.Write("sample2", new MemoryStream(testset2));
-        }
-
-        // Decompress and verify using Reader API with buffered read (CopyTo)
-        stream.Position = 0;
+        var (testset1, testset2, stream) = CreateTestZip();
         using (var reader = ReaderFactory.OpenReader(stream))
         {
             // Read first entry
@@ -182,29 +144,7 @@ public class ZipCompressionRoundtripTests : TestBase
     [Fact]
     public void Zip_Deflate_Roundtrip_ReaderApi_ByteByByteRead_Succeeds()
     {
-        // Create test data with specific patterns
-        var testset1 = Enumerable
-            .Range(0, TESTSIZE)
-            .Select(i => (byte)((i * 22695477) % 257))
-            .ToArray();
-        var testset2 = Enumerable
-            .Range(0, TESTSIZE)
-            .Select(i => (byte)((i * 48271) % 257))
-            .ToArray();
-
-        using var stream = new MemoryStream();
-
-        // Compress test streams
-        var writerOptions = new ZipWriterOptions(CompressionType.Deflate, compressionLevel: 9);
-
-        using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
-        {
-            writer.Write("sample1", new MemoryStream(testset1));
-            writer.Write("sample2", new MemoryStream(testset2));
-        }
-
-        // Decompress and verify using Reader API with byte-by-byte read
-        stream.Position = 0;
+        var (testset1, testset2, stream) = CreateTestZip();
         using (var reader = ReaderFactory.OpenReader(stream))
         {
             // Read first entry byte by byte

--- a/tests/SharpCompress.Test/Zip/ZipCompressionRoundtripTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipCompressionRoundtripTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.IO;
+using System.Linq;
+using SharpCompress.Archives.Zip;
+using SharpCompress.Common;
+using SharpCompress.Readers;
+using SharpCompress.Writers;
+using SharpCompress.Writers.Zip;
+using Xunit;
+
+namespace SharpCompress.Test.Zip;
+
+public class ZipCompressionRoundtripTests : TestBase
+{
+    private const int TESTSIZE = 1024 * 1024;
+
+    [Fact]
+    public void Zip_Deflate_Roundtrip_ArchiveApi_BufferedRead_Succeeds()
+    {
+        // Create test data with specific patterns
+        var testset1 = Enumerable
+            .Range(0, TESTSIZE)
+            .Select(i => (byte)((i * 22695477) % 257))
+            .ToArray();
+        var testset2 = Enumerable
+            .Range(0, TESTSIZE)
+            .Select(i => (byte)((i * 48271) % 257))
+            .ToArray();
+
+        using var stream = new MemoryStream();
+
+        // Compress test streams
+        var writerOptions = new ZipWriterOptions(CompressionType.Deflate, compressionLevel: 9);
+
+        using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
+        {
+            writer.Write("sample1", new MemoryStream(testset1));
+            writer.Write("sample2", new MemoryStream(testset2));
+        }
+
+        // Decompress and verify using Archive API with buffered read (CopyTo)
+        stream.Position = 0;
+        using (var archive = ZipArchive.OpenArchive(stream))
+        {
+            var files = archive.Entries.Where(e => !e.IsDirectory).OrderBy(e => e.Key).ToList();
+            Assert.Equal(2, files.Count);
+
+            // Read using CopyTo pattern (buffered - should succeed)
+            using (var entryStream = files[1].OpenEntryStream())
+            {
+                using var extracted = new MemoryStream();
+                entryStream.CopyTo(extracted);
+                Assert.Equal(testset2, extracted.ToArray());
+            }
+
+            using (var entryStream = files[0].OpenEntryStream())
+            {
+                using var extracted = new MemoryStream();
+                entryStream.CopyTo(extracted);
+                Assert.Equal(testset1, extracted.ToArray());
+            }
+        }
+    }
+
+    [Fact]
+    public void Zip_Deflate_Roundtrip_ArchiveApi_ByteByByteRead_Succeeds()
+    {
+        // Create test data with specific patterns
+        var testset1 = Enumerable
+            .Range(0, TESTSIZE)
+            .Select(i => (byte)((i * 22695477) % 257))
+            .ToArray();
+        var testset2 = Enumerable
+            .Range(0, TESTSIZE)
+            .Select(i => (byte)((i * 48271) % 257))
+            .ToArray();
+
+        using var stream = new MemoryStream();
+
+        // Compress test streams
+        var writerOptions = new ZipWriterOptions(CompressionType.Deflate, compressionLevel: 9);
+
+        using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
+        {
+            writer.Write("sample1", new MemoryStream(testset1));
+            writer.Write("sample2", new MemoryStream(testset2));
+        }
+
+        // Decompress and verify using byte-by-byte read
+        stream.Position = 0;
+        using (var archive = ZipArchive.OpenArchive(stream))
+        {
+            var files = archive.Entries.Where(e => !e.IsDirectory).OrderBy(e => e.Key).ToList();
+            Assert.Equal(2, files.Count);
+
+            // Read second file byte by byte
+            using (var entryStream = files[1].OpenEntryStream())
+            {
+                var buffer = new byte[testset2.Length];
+                for (var i = 0; i < buffer.Length; i++)
+                {
+                    var b = entryStream.ReadByte();
+                    if (b == -1)
+                    {
+                        throw new InvalidOperationException($"Unexpected EOF at offset {i}");
+                    }
+
+                    buffer[i] = (byte)b;
+                }
+                Assert.Equal(testset2, buffer);
+
+                // Verify EOF
+                Assert.Equal(-1, entryStream.ReadByte());
+            }
+
+            // Read first file byte by byte using All pattern
+            using (var entryStream = files[0].OpenEntryStream())
+            {
+                var match =
+                    testset1.All(b => b == entryStream.ReadByte()) && entryStream.ReadByte() == -1;
+                Assert.True(
+                    match,
+                    "Decompressed file sample1 contents do not match the source file."
+                );
+            }
+        }
+    }
+
+    [Fact]
+    public void Zip_Deflate_Roundtrip_ReaderApi_BufferedRead_Succeeds()
+    {
+        // Create test data with specific patterns
+        var testset1 = Enumerable
+            .Range(0, TESTSIZE)
+            .Select(i => (byte)((i * 22695477) % 257))
+            .ToArray();
+        var testset2 = Enumerable
+            .Range(0, TESTSIZE)
+            .Select(i => (byte)((i * 48271) % 257))
+            .ToArray();
+
+        using var stream = new MemoryStream();
+
+        // Compress test streams
+        var writerOptions = new ZipWriterOptions(CompressionType.Deflate, compressionLevel: 9);
+
+        using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
+        {
+            writer.Write("sample1", new MemoryStream(testset1));
+            writer.Write("sample2", new MemoryStream(testset2));
+        }
+
+        // Decompress and verify using Reader API with buffered read (CopyTo)
+        stream.Position = 0;
+        using (var reader = ReaderFactory.OpenReader(stream))
+        {
+            // Read first entry
+            Assert.True(reader.MoveToNextEntry());
+            Assert.Equal("sample1", reader.Entry.Key);
+            using (var entryStream = reader.OpenEntryStream())
+            {
+                using var extracted = new MemoryStream();
+                entryStream.CopyTo(extracted);
+                Assert.Equal(testset1, extracted.ToArray());
+            }
+
+            // Read second entry
+            Assert.True(reader.MoveToNextEntry());
+            Assert.Equal("sample2", reader.Entry.Key);
+            using (var entryStream = reader.OpenEntryStream())
+            {
+                using var extracted = new MemoryStream();
+                entryStream.CopyTo(extracted);
+                Assert.Equal(testset2, extracted.ToArray());
+            }
+
+            // No more entries
+            Assert.False(reader.MoveToNextEntry());
+        }
+    }
+
+    [Fact]
+    public void Zip_Deflate_Roundtrip_ReaderApi_ByteByByteRead_Succeeds()
+    {
+        // Create test data with specific patterns
+        var testset1 = Enumerable
+            .Range(0, TESTSIZE)
+            .Select(i => (byte)((i * 22695477) % 257))
+            .ToArray();
+        var testset2 = Enumerable
+            .Range(0, TESTSIZE)
+            .Select(i => (byte)((i * 48271) % 257))
+            .ToArray();
+
+        using var stream = new MemoryStream();
+
+        // Compress test streams
+        var writerOptions = new ZipWriterOptions(CompressionType.Deflate, compressionLevel: 9);
+
+        using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
+        {
+            writer.Write("sample1", new MemoryStream(testset1));
+            writer.Write("sample2", new MemoryStream(testset2));
+        }
+
+        // Decompress and verify using Reader API with byte-by-byte read
+        stream.Position = 0;
+        using (var reader = ReaderFactory.OpenReader(stream))
+        {
+            // Read first entry byte by byte
+            Assert.True(reader.MoveToNextEntry());
+            Assert.Equal("sample1", reader.Entry.Key);
+            using (var entryStream = reader.OpenEntryStream())
+            {
+                var buffer = new byte[testset1.Length];
+                for (var i = 0; i < buffer.Length; i++)
+                {
+                    var b = entryStream.ReadByte();
+                    if (b == -1)
+                    {
+                        throw new InvalidOperationException($"Unexpected EOF at offset {i}");
+                    }
+                    buffer[i] = (byte)b;
+                }
+                Assert.Equal(testset1, buffer);
+                Assert.Equal(-1, entryStream.ReadByte());
+            }
+
+            // Read second entry byte by byte
+            Assert.True(reader.MoveToNextEntry());
+            Assert.Equal("sample2", reader.Entry.Key);
+            using (var entryStream = reader.OpenEntryStream())
+            {
+                var buffer = new byte[testset2.Length];
+                for (var i = 0; i < buffer.Length; i++)
+                {
+                    var b = entryStream.ReadByte();
+                    if (b == -1)
+                    {
+                        throw new InvalidOperationException($"Unexpected EOF at offset {i}");
+                    }
+                    buffer[i] = (byte)b;
+                }
+                Assert.Equal(testset2, buffer);
+                Assert.Equal(-1, entryStream.ReadByte());
+            }
+
+            // No more entries
+            Assert.False(reader.MoveToNextEntry());
+        }
+    }
+}

--- a/tests/SharpCompress.Test/Zip/ZipCompressionRoundtripTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipCompressionRoundtripTests.cs
@@ -12,17 +12,13 @@ namespace SharpCompress.Test.Zip;
 
 public class ZipCompressionRoundtripTests : TestBase
 {
-    private const int TestSize = 1024 * 1024;
+    private const int TestSize = 1024 * 100;
 
-    private static (byte[] TestSet1, byte[] TestSet2, MemoryStream Stream) CreateTestZip()
+    private static (byte[] TestSet, MemoryStream Stream) CreateTestZip()
     {
-        var testset1 = Enumerable
+        var testset = Enumerable
             .Range(0, TestSize)
             .Select(i => (byte)((i * 22695477) % 257))
-            .ToArray();
-        var testset2 = Enumerable
-            .Range(0, TestSize)
-            .Select(i => (byte)((i * 48271) % 257))
             .ToArray();
 
         var stream = new MemoryStream();
@@ -31,39 +27,30 @@ public class ZipCompressionRoundtripTests : TestBase
 
         using (var writer = WriterFactory.OpenWriter(stream, ArchiveType.Zip, writerOptions))
         {
-            writer.Write("sample1", new MemoryStream(testset1));
-            writer.Write("sample2", new MemoryStream(testset2));
+            writer.Write("sample1", new MemoryStream(testset));
         }
 
         stream.Position = 0;
-        return (testset1, testset2, stream);
+        return (testset, stream);
     }
 
     [Fact]
     public void Zip_Deflate_Roundtrip_ArchiveApi_BufferedRead_Succeeds()
     {
-        var (testset1, testset2, stream) = CreateTestZip();
+        var (testset, stream) = CreateTestZip();
 
         // Decompress and verify using Archive API with buffered read (CopyTo)
         stream.Position = 0;
         using (var archive = ZipArchive.OpenArchive(stream))
         {
-            var files = archive.Entries.Where(e => !e.IsDirectory).OrderBy(e => e.Key).ToList();
-            Assert.Equal(2, files.Count);
-
-            // Read using CopyTo pattern (buffered - should succeed)
-            using (var entryStream = files[1].OpenEntryStream())
-            {
-                using var extracted = new MemoryStream();
-                entryStream.CopyTo(extracted);
-                Assert.Equal(testset2, extracted.ToArray());
-            }
+            var files = archive.Entries.Where(e => !e.IsDirectory).ToList();
+            Assert.Single(files);
 
             using (var entryStream = files[0].OpenEntryStream())
             {
                 using var extracted = new MemoryStream();
                 entryStream.CopyTo(extracted);
-                Assert.Equal(testset1, extracted.ToArray());
+                Assert.Equal(testset, extracted.ToArray());
             }
         }
     }
@@ -71,16 +58,15 @@ public class ZipCompressionRoundtripTests : TestBase
     [Fact]
     public void Zip_Deflate_Roundtrip_ArchiveApi_ByteByByteRead_Succeeds()
     {
-        var (testset1, testset2, stream) = CreateTestZip();
+        var (testset, stream) = CreateTestZip();
         using (var archive = ZipArchive.OpenArchive(stream))
         {
-            var files = archive.Entries.Where(e => !e.IsDirectory).OrderBy(e => e.Key).ToList();
-            Assert.Equal(2, files.Count);
+            var files = archive.Entries.Where(e => !e.IsDirectory).ToList();
+            Assert.Single(files);
 
-            // Read second file byte by byte
-            using (var entryStream = files[1].OpenEntryStream())
+            using (var entryStream = files[0].OpenEntryStream())
             {
-                var buffer = new byte[testset2.Length];
+                var buffer = new byte[testset.Length];
                 for (var i = 0; i < buffer.Length; i++)
                 {
                     var b = entryStream.ReadByte();
@@ -91,21 +77,10 @@ public class ZipCompressionRoundtripTests : TestBase
 
                     buffer[i] = (byte)b;
                 }
-                Assert.Equal(testset2, buffer);
+                Assert.Equal(testset, buffer);
 
                 // Verify EOF
                 Assert.Equal(-1, entryStream.ReadByte());
-            }
-
-            // Read first file byte by byte using All pattern
-            using (var entryStream = files[0].OpenEntryStream())
-            {
-                var match =
-                    testset1.All(b => b == entryStream.ReadByte()) && entryStream.ReadByte() == -1;
-                Assert.True(
-                    match,
-                    "Decompressed file sample1 contents do not match the source file."
-                );
             }
         }
     }
@@ -113,7 +88,7 @@ public class ZipCompressionRoundtripTests : TestBase
     [Fact]
     public void Zip_Deflate_Roundtrip_ReaderApi_BufferedRead_Succeeds()
     {
-        var (testset1, testset2, stream) = CreateTestZip();
+        var (testset, stream) = CreateTestZip();
         using (var reader = ReaderFactory.OpenReader(stream))
         {
             // Read first entry
@@ -123,17 +98,7 @@ public class ZipCompressionRoundtripTests : TestBase
             {
                 using var extracted = new MemoryStream();
                 entryStream.CopyTo(extracted);
-                Assert.Equal(testset1, extracted.ToArray());
-            }
-
-            // Read second entry
-            Assert.True(reader.MoveToNextEntry());
-            Assert.Equal("sample2", reader.Entry.Key);
-            using (var entryStream = reader.OpenEntryStream())
-            {
-                using var extracted = new MemoryStream();
-                entryStream.CopyTo(extracted);
-                Assert.Equal(testset2, extracted.ToArray());
+                Assert.Equal(testset, extracted.ToArray());
             }
 
             // No more entries
@@ -144,7 +109,7 @@ public class ZipCompressionRoundtripTests : TestBase
     [Fact]
     public void Zip_Deflate_Roundtrip_ReaderApi_ByteByByteRead_Succeeds()
     {
-        var (testset1, testset2, stream) = CreateTestZip();
+        var (testset, stream) = CreateTestZip();
         using (var reader = ReaderFactory.OpenReader(stream))
         {
             // Read first entry byte by byte
@@ -152,7 +117,7 @@ public class ZipCompressionRoundtripTests : TestBase
             Assert.Equal("sample1", reader.Entry.Key);
             using (var entryStream = reader.OpenEntryStream())
             {
-                var buffer = new byte[testset1.Length];
+                var buffer = new byte[testset.Length];
                 for (var i = 0; i < buffer.Length; i++)
                 {
                     var b = entryStream.ReadByte();
@@ -162,26 +127,7 @@ public class ZipCompressionRoundtripTests : TestBase
                     }
                     buffer[i] = (byte)b;
                 }
-                Assert.Equal(testset1, buffer);
-                Assert.Equal(-1, entryStream.ReadByte());
-            }
-
-            // Read second entry byte by byte
-            Assert.True(reader.MoveToNextEntry());
-            Assert.Equal("sample2", reader.Entry.Key);
-            using (var entryStream = reader.OpenEntryStream())
-            {
-                var buffer = new byte[testset2.Length];
-                for (var i = 0; i < buffer.Length; i++)
-                {
-                    var b = entryStream.ReadByte();
-                    if (b == -1)
-                    {
-                        throw new InvalidOperationException($"Unexpected EOF at offset {i}");
-                    }
-                    buffer[i] = (byte)b;
-                }
-                Assert.Equal(testset2, buffer);
+                Assert.Equal(testset, buffer);
                 Assert.Equal(-1, entryStream.ReadByte());
             }
 


### PR DESCRIPTION
This PR fixes a missing overload for `ReadByte()` that caused the library to return incorrect results when reading a stream with `ReadByte()`.

As the use of `ReadByte()` on a compressed stream is arguably seldom used, I opted for a simple "read into 1-byte array" solution that is not terribly resource efficient, but prevents having code replicated from the main `Read()` method into `ReadByte()`.

Unfortunately, the main `Read()` method also had issues when reading into a 1-byte array, so that was fixed as well.

Added a set of tests that explain the issue and fail before the fix, but succeeds after.

These are clearly edge case, but if anyone passes a compressed stream to another library, even these edge cases should work correctly.