### PR TITLE
Add PAX format support for long filenames in tar files.

### DIFF
--- a/src/SharpCompress/Common/Tar/Headers/EntryType.cs
+++ b/src/SharpCompress/Common/Tar/Headers/EntryType.cs
@@ -15,4 +15,5 @@ internal enum EntryType : byte
     SparseFile = (byte)'S',
     VolumeHeader = (byte)'V',
     GlobalExtendedHeader = (byte)'g',
+    ExtendedHeader = (byte)'x',
 }

--- a/src/SharpCompress/Common/Tar/Headers/TarHeader.Async.cs
+++ b/src/SharpCompress/Common/Tar/Headers/TarHeader.Async.cs
@@ -231,6 +231,15 @@ internal sealed partial class TarHeader
                 longLinkName = await ReadLongNameAsync(reader, buffer).ConfigureAwait(false);
                 continue;
             }
+            else if (entryType == EntryType.ExtendedHeader || entryType == EntryType.GlobalExtendedHeader)
+            {
+                await ReadPaxHeaderAsync(reader, buffer, (k, v) =>
+                {
+                    if (k == "path") longName = v;
+                    else if (k == "linkpath") longLinkName = v;
+                }).ConfigureAwait(false);
+                continue;
+            }
 
             hasLongValue = false;
         } while (hasLongValue);
@@ -344,6 +353,58 @@ internal sealed partial class TarHeader
         finally
         {
             ArrayPool<byte>.Shared.Return(nameBytes);
+        }
+    }
+
+    private async ValueTask ReadPaxHeaderAsync(AsyncBinaryReader reader, byte[] buffer, Action<string, string> onEntry)
+    {
+        var size = ReadSize(buffer);
+        if (size < 0 || size > MAX_LONG_NAME_SIZE)
+        {
+            throw new InvalidFormatException(
+                $"PAX header size {size} is invalid or exceeds maximum allowed size of {MAX_LONG_NAME_SIZE} bytes"
+            );
+        }
+        var dataLength = (int)size;
+        var dataBytes = ArrayPool<byte>.Shared.Rent(dataLength);
+        try
+        {
+            await reader.ReadBytesAsync(dataBytes, 0, dataLength).ConfigureAwait(false);
+            var remainingBytesToRead = BLOCK_SIZE - (dataLength % BLOCK_SIZE);
+            if (remainingBytesToRead < BLOCK_SIZE)
+            {
+                var remainingBytes = ArrayPool<byte>.Shared.Rent(remainingBytesToRead);
+                try
+                {
+                    await reader.ReadBytesAsync(remainingBytes, 0, remainingBytesToRead).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(remainingBytes);
+                }
+            }
+            var text = ArchiveEncoding.Decode(dataBytes, 0, dataLength);
+            var pos = 0;
+            while (pos < text.Length)
+            {
+                var spaceIdx = text.IndexOf(' ', pos);
+                if (spaceIdx < 0) break;
+                if (!int.TryParse(text.AsSpan(pos, spaceIdx - pos), out var lineLen) || lineLen <= 0) break;
+                var contentStart = spaceIdx + 1;
+                var contentLen = lineLen - (spaceIdx - pos) - 2;
+                if (contentStart + contentLen > text.Length || contentLen < 0) break;
+                var content = text.Substring(contentStart, contentLen);
+                var eqIdx = content.IndexOf('=');
+                if (eqIdx > 0)
+                {
+                    onEntry(content[..eqIdx], content[(eqIdx + 1)..]);
+                }
+                pos += lineLen;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(dataBytes);
         }
     }
 }

--- a/src/SharpCompress/Common/Tar/Headers/TarHeader.cs
+++ b/src/SharpCompress/Common/Tar/Headers/TarHeader.cs
@@ -264,6 +264,11 @@ internal sealed partial class TarHeader
                 longLinkName = ReadLongName(reader, buffer);
                 continue;
             }
+            else if (entryType == EntryType.ExtendedHeader || entryType == EntryType.GlobalExtendedHeader)
+            {
+                ReadPaxHeader(reader, buffer, ref longName, ref longLinkName);
+                continue;
+            }
 
             hasLongValue = false;
         } while (hasLongValue);
@@ -339,6 +344,60 @@ internal sealed partial class TarHeader
             reader.ReadBytes(remainingBytesToRead);
         }
         return ArchiveEncoding.Decode(nameBytes, 0, nameBytes.Length).TrimNulls();
+    }
+
+    private void ReadPaxHeader(BinaryReader reader, byte[] buffer, ref string? longName, ref string? longLinkName)
+    {
+        var size = ReadSize(buffer);
+        if (size < 0 || size > MAX_LONG_NAME_SIZE)
+        {
+            throw new InvalidFormatException(
+                $"PAX header size {size} is invalid or exceeds maximum allowed size of {MAX_LONG_NAME_SIZE} bytes"
+            );
+        }
+        var dataLength = (int)size;
+        var dataBytes = reader.ReadBytes(dataLength);
+        var remainingBytesToRead = BLOCK_SIZE - (dataLength % BLOCK_SIZE);
+        if (remainingBytesToRead < BLOCK_SIZE)
+        {
+            reader.ReadBytes(remainingBytesToRead);
+        }
+        var text = ArchiveEncoding.Decode(dataBytes, 0, dataLength);
+        var pos = 0;
+        while (pos < text.Length)
+        {
+            var spaceIdx = text.IndexOf(' ', pos);
+            if (spaceIdx < 0)
+            {
+                break;
+            }
+            if (!int.TryParse(text.AsSpan(pos, spaceIdx - pos), out var lineLen) || lineLen <= 0)
+            {
+                break;
+            }
+            var contentStart = spaceIdx + 1;
+            var contentLen = lineLen - (spaceIdx - pos) - 2; // subtract "<len> " and trailing \n
+            if (contentStart + contentLen > text.Length || contentLen < 0)
+            {
+                break;
+            }
+            var content = text.Substring(contentStart, contentLen);
+            var eqIdx = content.IndexOf('=');
+            if (eqIdx > 0)
+            {
+                var key = content[..eqIdx];
+                var value = content[(eqIdx + 1)..];
+                if (key == "path")
+                {
+                    longName = value;
+                }
+                else if (key == "linkpath")
+                {
+                    longLinkName = value;
+                }
+            }
+            pos += lineLen;
+        }
     }
 
     private static EntryType ReadEntryType(byte[] buffer) => (EntryType)buffer[156];

--- a/src/SharpCompress/Factories/TarFactory.cs
+++ b/src/SharpCompress/Factories/TarFactory.cs
@@ -51,7 +51,7 @@ public class TarFactory
     public override bool IsArchive(Stream stream, string? password = null)
     {
         var providers = CompressionProviderRegistry.Default;
-        var sharpCompressStream = new SharpCompressStream(stream);
+        var sharpCompressStream = SharpCompressStream.Create(stream);
         sharpCompressStream.StartRecording();
         foreach (var wrapper in TarWrapper.Wrappers)
         {
@@ -83,7 +83,7 @@ public class TarFactory
     )
     {
         var providers = CompressionProviderRegistry.Default;
-        var sharpCompressStream = new SharpCompressStream(stream);
+        var sharpCompressStream = SharpCompressStream.Create(stream);
         sharpCompressStream.StartRecording();
         foreach (var wrapper in TarWrapper.Wrappers)
         {
@@ -318,7 +318,7 @@ public class TarFactory
     public IReader OpenReader(Stream stream, ReaderOptions? options)
     {
         options ??= new ReaderOptions();
-        var sharpCompressStream = new SharpCompressStream(stream);
+        var sharpCompressStream = SharpCompressStream.Create(stream);
         sharpCompressStream.StartRecording();
         foreach (var wrapper in TarWrapper.Wrappers)
         {
@@ -351,7 +351,7 @@ public class TarFactory
     {
         cancellationToken.ThrowIfCancellationRequested();
         options ??= new ReaderOptions();
-        var sharpCompressStream = new SharpCompressStream(stream);
+        var sharpCompressStream = SharpCompressStream.Create(stream);
         sharpCompressStream.StartRecording();
         foreach (var wrapper in TarWrapper.Wrappers)
         {

--- a/src/SharpCompress/IO/SeekableSharpCompressStream.cs
+++ b/src/SharpCompress/IO/SeekableSharpCompressStream.cs
@@ -82,7 +82,14 @@ internal sealed partial class SeekableSharpCompressStream : SharpCompressStream
 
     public override void StartRecording() => _recordedPosition = _stream.Position;
 
-    public override void StopRecording() => _recordedPosition = null;
+    public override void StopRecording()
+    {
+        if (_recordedPosition.HasValue)
+        {
+            _stream.Seek(_recordedPosition.Value, SeekOrigin.Begin);
+        }
+        _recordedPosition = null;
+    }
 
     protected override void Dispose(bool disposing)
     {


### PR DESCRIPTION
I found when trying to extract https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-4.1.0/mbedtls-4.1.0.tar.bz2

one filename gets truncated as it uses the PAX format (POSIX extended headers, type x) for long paths — not the GNU LongName format SharpCompress already handled. The PAX header carries the full path in a path=... key-value record that was being silently ignored.

- SeekableSharpCompressStream.cs:85 - StopRecording now seeks back before nulling _recordedPosition 
- TarFactory.cs - use SharpCompressStream.Create to avoid ring buffer overflow on seekable streams 
- EntryType.cs + TarHeader.cs + TarHeader.Async.cs - PAX extended header parsing