### PR TITLE
fix: Change LeaveStreamOpen default from true to false

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,8 @@ SharpCompress supports multiple archive and compression formats:
 
 ### Stream Handling Rules
 - **Disposal**: As of version 0.21, SharpCompress **closes wrapped streams by default** (`LeaveStreamOpen = false`)
-  - File-based overloads (e.g., `OpenArchive(string filePath)`) use `ReaderOptions.ForFilePath` automatically
+  - File-based overloads (e.g., `OpenArchive(string filePath)`) open the file internally and own that stream, so it is closed by default with the archive/reader
+    - Do **not** rely on a specific `ReaderOptions` preset being used internally; some implementations may use `ReaderOptions.ForFilePath`, while others may use default `ReaderOptions` with the same ownership semantics
     - Do **not** assume every stream-based overload defaults to `ReaderOptions.ForExternalStream`; some APIs require you to pass stream ownership options explicitly
 - **For caller-provided streams**: Pass `ReaderOptions.ForExternalStream` or use `ReaderOptions` with `LeaveStreamOpen = true` whenever the caller must retain ownership of the stream
   - Example: `var options = new ReaderOptions { LeaveStreamOpen = true };`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,11 +128,11 @@ SharpCompress supports multiple archive and compression formats:
 ### Stream Handling Rules
 - **Disposal**: As of version 0.21, SharpCompress **closes wrapped streams by default** (`LeaveStreamOpen = false`)
   - File-based overloads (e.g., `OpenArchive(string filePath)`) use `ReaderOptions.ForFilePath` automatically
-  - Stream-based overloads (e.g., `OpenArchive(Stream stream)`) use `ReaderOptions.ForExternalStream` by default, which sets `LeaveStreamOpen = true`
-- **For caller-provided streams**: Use `ReaderOptions` with `LeaveStreamOpen = true` or the `ForExternalStream` preset to prevent automatic disposal
-  - Example: `var options = new ReaderOptions { LeaveStreamOpen = true };`
-  - Or: `var options = ReaderOptions.ForExternalStream;`
-- **For file paths**: SharpCompress manages the stream lifecycle; no manual disposal needed beyond the archive/reader itself
+    - Do **not** assume every stream-based overload defaults to `ReaderOptions.ForExternalStream`; some APIs require you to pass stream ownership options explicitly
+ - **For caller-provided streams**: Pass `ReaderOptions.ForExternalStream` or use `ReaderOptions` with `LeaveStreamOpen = true` whenever the caller must retain ownership of the stream
+   - Example: `var options = new ReaderOptions { LeaveStreamOpen = true };`
+   - Or: `var options = ReaderOptions.ForExternalStream;`
+ - **For file paths**: SharpCompress manages the stream lifecycle for the internally opened file stream; no manual disposal is neededbeyond the archive/reader itself
 - Use `NonDisposingStream` wrapper when working with compression streams directly to prevent disposal
 - Always dispose of readers, writers, and archives in `using` / `await using` blocks
 - For forward-only operations, use Reader/Writer APIs; for random access, use Archive APIs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ SharpCompress supports multiple archive and compression formats:
  - **For caller-provided streams**: Pass `ReaderOptions.ForExternalStream` or use `ReaderOptions` with `LeaveStreamOpen = true` whenever the caller must retain ownership of the stream
    - Example: `var options = new ReaderOptions { LeaveStreamOpen = true };`
    - Or: `var options = ReaderOptions.ForExternalStream;`
- - **For file paths**: SharpCompress manages the stream lifecycle for the internally opened file stream; no manual disposal is neededbeyond the archive/reader itself
+ - **For file paths**: SharpCompress manages the stream lifecycle for the internally opened file stream; no manual disposal is needed beyond the archive/reader itself
 - Use `NonDisposingStream` wrapper when working with compression streams directly to prevent disposal
 - Always dispose of readers, writers, and archives in `using` / `await using` blocks
 - For forward-only operations, use Reader/Writer APIs; for random access, use Archive APIs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,15 @@ SharpCompress supports multiple archive and compression formats:
 - See [docs/FORMATS.md](docs/FORMATS.md) for complete format support matrix
 
 ### Stream Handling Rules
-- **Disposal**: As of version 0.21, SharpCompress closes wrapped streams by default
-- Use `ReaderOptions` or `WriterOptions` with `LeaveStreamOpen = true` to control stream disposal
+- **Disposal**: As of version 0.21, SharpCompress **closes wrapped streams by default** (`LeaveStreamOpen = false`)
+  - File-based overloads (e.g., `OpenArchive(string filePath)`) use `ReaderOptions.ForFilePath` automatically
+  - Stream-based overloads (e.g., `OpenArchive(Stream stream)`) use `ReaderOptions.ForExternalStream` by default, which sets `LeaveStreamOpen = true`
+- **For caller-provided streams**: Use `ReaderOptions` with `LeaveStreamOpen = true` or the `ForExternalStream` preset to prevent automatic disposal
+  - Example: `var options = new ReaderOptions { LeaveStreamOpen = true };`
+  - Or: `var options = ReaderOptions.ForExternalStream;`
+- **For file paths**: SharpCompress manages the stream lifecycle; no manual disposal needed beyond the archive/reader itself
 - Use `NonDisposingStream` wrapper when working with compression streams directly to prevent disposal
-- Always dispose of readers, writers, and archives in `using` blocks
+- Always dispose of readers, writers, and archives in `using` / `await using` blocks
 - For forward-only operations, use Reader/Writer APIs; for random access, use Archive APIs
 
 ### Async/Await Patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,10 +129,10 @@ SharpCompress supports multiple archive and compression formats:
 - **Disposal**: As of version 0.21, SharpCompress **closes wrapped streams by default** (`LeaveStreamOpen = false`)
   - File-based overloads (e.g., `OpenArchive(string filePath)`) use `ReaderOptions.ForFilePath` automatically
     - Do **not** assume every stream-based overload defaults to `ReaderOptions.ForExternalStream`; some APIs require you to pass stream ownership options explicitly
- - **For caller-provided streams**: Pass `ReaderOptions.ForExternalStream` or use `ReaderOptions` with `LeaveStreamOpen = true` whenever the caller must retain ownership of the stream
-   - Example: `var options = new ReaderOptions { LeaveStreamOpen = true };`
-   - Or: `var options = ReaderOptions.ForExternalStream;`
- - **For file paths**: SharpCompress manages the stream lifecycle for the internally opened file stream; no manual disposal is needed beyond the archive/reader itself
+- **For caller-provided streams**: Pass `ReaderOptions.ForExternalStream` or use `ReaderOptions` with `LeaveStreamOpen = true` whenever the caller must retain ownership of the stream
+  - Example: `var options = new ReaderOptions { LeaveStreamOpen = true };`
+  - Or: `var options = ReaderOptions.ForExternalStream;`
+- **For file paths**: SharpCompress manages the stream lifecycle for the internally opened file stream; no manual disposal is needed beyond the archive/reader itself
 - Use `NonDisposingStream` wrapper when working with compression streams directly to prevent disposal
 - Always dispose of readers, writers, and archives in `using` / `await using` blocks
 - For forward-only operations, use Reader/Writer APIs; for random access, use Archive APIs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,11 +126,12 @@ SharpCompress supports multiple archive and compression formats:
 - See [docs/FORMATS.md](docs/FORMATS.md) for complete format support matrix
 
 ### Stream Handling Rules
-- **Disposal**: As of version 0.21, SharpCompress **closes wrapped streams by default** (`LeaveStreamOpen = false`)
+- **Disposal semantics**: The default `ReaderOptions.LeaveStreamOpen` value is `false`, but effective stream ownership depends on which API overload you call
   - File-based overloads (e.g., `OpenArchive(string filePath)`) open the file internally and own that stream, so it is closed by default with the archive/reader
     - Do **not** rely on a specific `ReaderOptions` preset being used internally; some implementations may use `ReaderOptions.ForFilePath`, while others may use default `ReaderOptions` with the same ownership semantics
-    - Do **not** assume every stream-based overload defaults to `ReaderOptions.ForExternalStream`; some APIs require you to pass stream ownership options explicitly
-- **For caller-provided streams**: Pass `ReaderOptions.ForExternalStream` or use `ReaderOptions` with `LeaveStreamOpen = true` whenever the caller must retain ownership of the stream
+  - Several high-level overloads that accept a caller-provided `Stream` use external-stream semantics by default (for example, `ReaderFactory.OpenReader(Stream)` / `ArchiveFactory.OpenArchive(Stream)`), so the caller's stream is typically left open unless you opt into different ownership behavior
+    - Do **not** assume every stream-based overload behaves identically; some APIs require you to pass stream ownership options explicitly
+- **For caller-provided streams**: When the overload accepts `ReaderOptions`, pass `ReaderOptions.ForExternalStream` or use `ReaderOptions` with `LeaveStreamOpen = true` whenever the caller must retain ownership of the stream
   - Example: `var options = new ReaderOptions { LeaveStreamOpen = true };`
   - Or: `var options = ReaderOptions.ForExternalStream;`
 - **For file paths**: SharpCompress manages the stream lifecycle for the internally opened file stream; no manual disposal is needed beyond the archive/reader itself

--- a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
@@ -57,7 +57,7 @@ public partial class ZipArchive
             new SourceStream(
                 files[0],
                 i => i < files.Count ? files[i] : null,
-                readerOptions ?? new ReaderOptions()
+                readerOptions ?? ReaderOptions.ForFilePath
             )
         );
     }

--- a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
@@ -41,7 +41,7 @@ public partial class ZipArchive
             new SourceStream(
                 fileInfo,
                 i => ZipArchiveVolumeFactory.GetFilePart(i, fileInfo),
-                readerOptions ?? new ReaderOptions()
+                readerOptions ?? ReaderOptions.ForFilePath
             )
         );
     }

--- a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
@@ -41,7 +41,7 @@ public partial class ZipArchive
             new SourceStream(
                 fileInfo,
                 i => ZipArchiveVolumeFactory.GetFilePart(i, fileInfo),
-                readerOptions ?? new ReaderOptions() { LeaveStreamOpen = false }
+                readerOptions ?? new ReaderOptions()
             )
         );
     }
@@ -57,7 +57,7 @@ public partial class ZipArchive
             new SourceStream(
                 files[0],
                 i => i < files.Count ? files[i] : null,
-                readerOptions ?? new ReaderOptions() { LeaveStreamOpen = false }
+                readerOptions ?? new ReaderOptions()
             )
         );
     }

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -24,9 +24,36 @@ namespace SharpCompress.Readers;
 public sealed record ReaderOptions : IReaderOptions
 {
     /// <summary>
-    /// SharpCompress will keep the supplied streams open.  Default is true.
+    /// SharpCompress will keep the supplied streams open.
+    /// Default is false as of v0.21: streams are closed when the archive/reader is disposed.
+    /// Set to true when passing caller-owned streams that should not be disposed.
     /// </summary>
-    public bool LeaveStreamOpen { get; init; } = true;
+    /// <remarks>
+    /// <para>
+    /// <b>Default behavior (LeaveStreamOpen = false):</b>
+    /// When you open an archive from a file path (e.g., <c>GZipArchive.OpenArchive(filePath)</c>),
+    /// SharpCompress manages the stream lifetime and closes it on Dispose.
+    /// </para>
+    /// <para>
+    /// <b>Caller-provided streams (LeaveStreamOpen = true):</b>
+    /// When you pass a stream you created (FileStream, MemoryStream, NetworkStream, etc.),
+    /// set LeaveStreamOpen = true to prevent SharpCompress from disposing it.
+    /// Use <see cref="ForExternalStream"/> preset for convenience.
+    /// </para>
+    /// <para>
+    /// <b>Example:</b>
+    /// <code>
+    /// // File-based: stream managed by library
+    /// using var archive = GZipArchive.OpenArchive(filePath); // LeaveStreamOpen = false
+    ///
+    /// // Caller-provided stream: caller manages lifetime
+    /// using var stream = File.OpenRead(filePath);
+    /// var options = new ReaderOptions { LeaveStreamOpen = true };
+    /// using var archive = GZipArchive.OpenArchive(stream, options);
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public bool LeaveStreamOpen { get; init; } = false;
 
     /// <summary>
     /// Encoding to use for archive entry names.

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -24,7 +24,7 @@ namespace SharpCompress.Readers;
 public sealed record ReaderOptions : IReaderOptions
 {
     /// <summary>
-    /// SharpCompress will keep the supplied streams open.
+    /// Whether SharpCompress leaves the supplied streams open when the reader/archive is disposed.
     /// Default is false as of v0.21: streams are closed when the archive/reader is disposed.
     /// Set to true when passing caller-owned streams that should not be disposed.
     /// </summary>

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -25,7 +25,7 @@ public sealed record ReaderOptions : IReaderOptions
 {
     /// <summary>
     /// Whether SharpCompress leaves the supplied streams open when the reader/archive is disposed.
-    /// Default is false as of v0.21: streams are closed when the archive/reader is disposed.
+    /// As of v0.21, the library is documented to close streams by default; this option now defaults to false.
     /// Set to true when passing caller-owned streams that should not be disposed.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
As of v0.21, the library is documented to close wrapped streams by default. However, the ReaderOptions.LeaveStreamOpen property defaulted to true, which contradicted the documented behavior and caused file locks when deleting archives after extraction.

Changes:
- Set LeaveStreamOpen = false as the default (consistent with v0.21 design)
- Updated ReaderOptions.cs with comprehensive documentation explaining:
  * File-based vs caller-provided stream handling
  * When to use LeaveStreamOpen = true
  * Usage examples for both scenarios
- Updated AGENTS.md Stream Handling Rules section with:
  * Clear explanation of default disposal behavior
  * Overload differences (file-based vs stream-based)
  * Guidance on using ForExternalStream preset

This ensures the implementation matches the documented behavior and prevents unexpected file locking issues during archive deletion.

Fixes: File deletion failures after archive extraction

---

Please note that while this change aligns with the documented specification, it is a breaking change that may affect existing code.
The removal of the explicit `LeaveStreamOpen=false` override in `ZipArchive` was motivated by the fact that `false` is now the default. However, since other Archive types originally relied on the default value of `true`, existing code that does not explicitly specify ReaderOptions may behave differently than before.
Breaking changes of this nature should be documented somewhere. That said, since I'm not familiar enough with where exactly the documentation should be updated, I've opted not to include those changes in this pull request.