### PR TITLE
Fix usage of ReaderOptions and pre-defined values

### DIFF
--- a/src/SharpCompress/Archives/AbstractArchive.cs
+++ b/src/SharpCompress/Archives/AbstractArchive.cs
@@ -40,7 +40,7 @@ public abstract partial class AbstractArchive<TEntry, TVolume> : IArchive, IAsyn
     internal AbstractArchive(ArchiveType type)
     {
         Type = type;
-        ReaderOptions = new();
+        ReaderOptions = ReaderOptions.Default;
         _lazyVolumes = new LazyReadOnlyCollection<TVolume>(Enumerable.Empty<TVolume>());
         _lazyEntries = new LazyReadOnlyCollection<TEntry>(Enumerable.Empty<TEntry>());
         _lazyVolumesAsync = new LazyAsyncReadOnlyCollection<TVolume>(

--- a/src/SharpCompress/Archives/ArchiveFactory.Async.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.Async.cs
@@ -33,7 +33,11 @@ public static partial class ArchiveFactory
     )
     {
         filePath.NotNullOrEmpty(nameof(filePath));
-        return OpenAsyncArchive(new FileInfo(filePath), options, cancellationToken);
+        return OpenAsyncArchive(
+            new FileInfo(filePath),
+            options ?? ReaderOptions.ForFilePath,
+            cancellationToken
+        );
     }
 
     public static async ValueTask<IAsyncArchive> OpenAsyncArchive(

--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -37,7 +37,7 @@ public static partial class ArchiveFactory
     public static IArchive OpenArchive(string filePath, ReaderOptions? options = null)
     {
         filePath.NotNullOrEmpty(nameof(filePath));
-        return OpenArchive(new FileInfo(filePath), options);
+        return OpenArchive(new FileInfo(filePath), options ?? ReaderOptions.ForFilePath);
     }
 
     public static IArchive OpenArchive(FileInfo fileInfo, ReaderOptions? options = null)

--- a/src/SharpCompress/Archives/Rar/FileInfoRarArchiveVolume.cs
+++ b/src/SharpCompress/Archives/Rar/FileInfoRarArchiveVolume.cs
@@ -15,16 +15,15 @@ namespace SharpCompress.Archives.Rar;
 internal class FileInfoRarArchiveVolume : RarVolume
 {
     internal FileInfoRarArchiveVolume(FileInfo fileInfo, ReaderOptions options, int index)
-        : base(StreamingMode.Seekable, fileInfo.OpenRead(), FixOptions(options), index)
+        : base(
+            StreamingMode.Seekable,
+            fileInfo.OpenRead(),
+            options.WithLeaveStreamOpen(false),
+            index
+        )
     {
         FileInfo = fileInfo;
         FileParts = GetVolumeFileParts().ToArray().ToReadOnly();
-    }
-
-    private static ReaderOptions FixOptions(ReaderOptions options)
-    {
-        //make sure we're closing streams with fileinfo
-        return options with { LeaveStreamOpen = false };
     }
 
     internal ReadOnlyCollection<RarFilePart> FileParts { get; }

--- a/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
@@ -51,7 +51,7 @@ public partial class RarArchive
             new SourceStream(
                 fileInfo,
                 i => RarArchiveVolumeFactory.GetFilePart(i, fileInfo),
-                readerOptions ?? new ReaderOptions()
+                readerOptions ?? ReaderOptions.ForFilePath
             )
         );
     }
@@ -66,7 +66,7 @@ public partial class RarArchive
         }
 
         return new RarArchive(
-            new SourceStream(stream, _ => null, readerOptions ?? new ReaderOptions())
+            new SourceStream(stream, _ => null, readerOptions ?? ReaderOptions.ForExternalStream)
         );
     }
 

--- a/src/SharpCompress/Archives/Zip/ZipArchive.Async.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.Async.cs
@@ -45,7 +45,7 @@ public partial class ZipArchive
                                 s = new SourceStream(
                                     v[0].Stream,
                                     i => i < v.Length ? v[i].Stream : null,
-                                    new ReaderOptions() { LeaveStreamOpen = true }
+                                    ReaderOptions.ForExternalStream
                                 );
                             }
                             else

--- a/src/SharpCompress/Archives/Zip/ZipArchive.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.cs
@@ -86,7 +86,7 @@ public partial class ZipArchive
                                 s = new SourceStream(
                                     v[0].Stream,
                                     i => i < v.Length ? v[i].Stream : null,
-                                    new ReaderOptions() { LeaveStreamOpen = true }
+                                    ReaderOptions.ForExternalStream
                                 );
                             }
                             else

--- a/src/SharpCompress/Common/ExtractionMethods.Async.cs
+++ b/src/SharpCompress/Common/ExtractionMethods.Async.cs
@@ -90,15 +90,7 @@ internal static partial class ExtractionMethods
         options ??= new ExtractionOptions();
         if (entry.LinkTarget != null)
         {
-            if (options.SymbolicLinkHandler is not null)
-            {
-                options.SymbolicLinkHandler(destinationFileName, entry.LinkTarget);
-            }
-            else
-            {
-                ExtractionOptions.DefaultSymbolicLinkHandler(destinationFileName, entry.LinkTarget);
-            }
-            return;
+            options.SymbolicLinkHandler?.Invoke(destinationFileName, entry.LinkTarget);
         }
         else
         {

--- a/src/SharpCompress/Common/ExtractionMethods.cs
+++ b/src/SharpCompress/Common/ExtractionMethods.cs
@@ -99,15 +99,7 @@ internal static partial class ExtractionMethods
         options ??= new ExtractionOptions();
         if (entry.LinkTarget != null)
         {
-            if (options.SymbolicLinkHandler is not null)
-            {
-                options.SymbolicLinkHandler(destinationFileName, entry.LinkTarget);
-            }
-            else
-            {
-                ExtractionOptions.DefaultSymbolicLinkHandler(destinationFileName, entry.LinkTarget);
-            }
-            return;
+            options.SymbolicLinkHandler?.Invoke(destinationFileName, entry.LinkTarget);
         }
         else
         {

--- a/src/SharpCompress/Common/ExtractionOptions.cs
+++ b/src/SharpCompress/Common/ExtractionOptions.cs
@@ -58,10 +58,7 @@ public sealed record ExtractionOptions : IExtractionOptions
     /// Creates a new ExtractionOptions instance with the specified overwrite behavior.
     /// </summary>
     /// <param name="overwrite">Whether to overwrite existing files.</param>
-    public ExtractionOptions(bool overwrite)
-    {
-        Overwrite = overwrite;
-    }
+    public ExtractionOptions(bool overwrite) => Overwrite = overwrite;
 
     /// <summary>
     /// Creates a new ExtractionOptions instance with the specified extraction path and overwrite behavior.
@@ -102,14 +99,4 @@ public sealed record ExtractionOptions : IExtractionOptions
     /// </summary>
     public static ExtractionOptions PreserveMetadata =>
         new() { PreserveFileTime = true, PreserveAttributes = true };
-
-    /// <summary>
-    /// Default symbolic link handler that logs a warning message.
-    /// </summary>
-    public static void DefaultSymbolicLinkHandler(string sourcePath, string targetPath)
-    {
-        Console.WriteLine(
-            $"Could not write symlink {sourcePath} -> {targetPath}, for more information please see https://github.com/dotnet/runtime/issues/24271"
-        );
-    }
 }

--- a/src/SharpCompress/Common/ExtractionOptions.cs
+++ b/src/SharpCompress/Common/ExtractionOptions.cs
@@ -45,7 +45,7 @@ public sealed record ExtractionOptions : IExtractionOptions
     /// </summary>
     /// <remarks>
     /// <b>Breaking change:</b> Changed from field to init-only property in version 0.40.0.
-    /// The default handler logs a warning message.
+    /// If no handler is provided, symbolic links are silently skipped during extraction.
     /// </remarks>
     public Action<string, string>? SymbolicLinkHandler { get; init; }
 

--- a/src/SharpCompress/Common/GZip/GZipVolume.cs
+++ b/src/SharpCompress/Common/GZip/GZipVolume.cs
@@ -5,7 +5,7 @@ namespace SharpCompress.Common.GZip;
 
 public class GZipVolume : Volume
 {
-    public GZipVolume(Stream stream, ReaderOptions? options, int index)
+    public GZipVolume(Stream stream, ReaderOptions options, int index)
         : base(stream, options, index) { }
 
     public GZipVolume(FileInfo fileInfo, ReaderOptions options)

--- a/src/SharpCompress/Common/GZip/GZipVolume.cs
+++ b/src/SharpCompress/Common/GZip/GZipVolume.cs
@@ -9,7 +9,7 @@ public class GZipVolume : Volume
         : base(stream, options, index) { }
 
     public GZipVolume(FileInfo fileInfo, ReaderOptions options)
-        : base(fileInfo.OpenRead(), options with { LeaveStreamOpen = false }) { }
+        : base(fileInfo.OpenRead(), options.WithLeaveStreamOpen(false)) { }
 
     public override bool IsFirstVolume => true;
 

--- a/src/SharpCompress/Common/Lzw/LzwVolume.cs
+++ b/src/SharpCompress/Common/Lzw/LzwVolume.cs
@@ -5,7 +5,7 @@ namespace SharpCompress.Common.Lzw;
 
 public class LzwVolume : Volume
 {
-    public LzwVolume(Stream stream, ReaderOptions? options, int index)
+    public LzwVolume(Stream stream, ReaderOptions options, int index)
         : base(stream, options, index) { }
 
     public LzwVolume(FileInfo fileInfo, ReaderOptions options)

--- a/src/SharpCompress/Common/Lzw/LzwVolume.cs
+++ b/src/SharpCompress/Common/Lzw/LzwVolume.cs
@@ -9,7 +9,7 @@ public class LzwVolume : Volume
         : base(stream, options, index) { }
 
     public LzwVolume(FileInfo fileInfo, ReaderOptions options)
-        : base(fileInfo.OpenRead(), options with { LeaveStreamOpen = false }) { }
+        : base(fileInfo.OpenRead(), options.WithLeaveStreamOpen(false)) { }
 
     public override bool IsFirstVolume => true;
 

--- a/src/SharpCompress/Common/Volume.cs
+++ b/src/SharpCompress/Common/Volume.cs
@@ -11,10 +11,10 @@ public abstract partial class Volume : IVolume, IAsyncDisposable
     private readonly Stream _baseStream;
     private readonly Stream _actualStream;
 
-    internal Volume(Stream stream, ReaderOptions? readerOptions, int index = 0)
+    internal Volume(Stream stream, ReaderOptions readerOptions, int index = 0)
     {
         Index = index;
-        ReaderOptions = readerOptions ?? new ReaderOptions();
+        ReaderOptions = readerOptions;
         _baseStream = stream;
 
         // Only rewind if it's a buffered SharpCompressStream (not passthrough)

--- a/src/SharpCompress/Factories/TarFactory.cs
+++ b/src/SharpCompress/Factories/TarFactory.cs
@@ -317,7 +317,7 @@ public class TarFactory
     /// <inheritdoc/>
     public IReader OpenReader(Stream stream, ReaderOptions? options)
     {
-        options ??= new ReaderOptions();
+        options ??= ReaderOptions.ForExternalStream;
         var sharpCompressStream = new SharpCompressStream(stream);
         sharpCompressStream.StartRecording(TarWrapper.MaximumRewindBufferSize);
         foreach (var wrapper in TarWrapper.Wrappers)
@@ -350,7 +350,7 @@ public class TarFactory
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        options ??= new ReaderOptions();
+        options ??= ReaderOptions.ForExternalStream;
         var sharpCompressStream = new SharpCompressStream(stream);
         sharpCompressStream.StartRecording(TarWrapper.MaximumRewindBufferSize);
         foreach (var wrapper in TarWrapper.Wrappers)

--- a/src/SharpCompress/Readers/Ace/AceReader.Factory.cs
+++ b/src/SharpCompress/Readers/Ace/AceReader.Factory.cs
@@ -20,7 +20,7 @@ public partial class AceReader
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
         stream.NotNull(nameof(stream));
-        return new SingleVolumeAceReader(stream, readerOptions ?? new ReaderOptions());
+        return new SingleVolumeAceReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public partial class AceReader
     public static IReader OpenReader(IEnumerable<Stream> streams, ReaderOptions? options = null)
     {
         streams.NotNull(nameof(streams));
-        return new MultiVolumeAceReader(streams, options ?? new ReaderOptions());
+        return new MultiVolumeAceReader(streams, options ?? ReaderOptions.ForExternalStream);
     }
 
     public static ValueTask<IAsyncReader> OpenAsyncReader(
@@ -62,7 +62,7 @@ public partial class AceReader
     )
     {
         streams.NotNull(nameof(streams));
-        return new MultiVolumeAceReader(streams, options ?? new ReaderOptions());
+        return new MultiVolumeAceReader(streams, options ?? ReaderOptions.ForExternalStream);
     }
 
     public static ValueTask<IAsyncReader> OpenAsyncReader(

--- a/src/SharpCompress/Readers/Arc/ArcReader.cs
+++ b/src/SharpCompress/Readers/Arc/ArcReader.cs
@@ -25,7 +25,7 @@ public partial class ArcReader : AbstractReader<ArcEntry, ArcVolume>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
         stream.NotNull(nameof(stream));
-        return new ArcReader(stream, readerOptions ?? new ReaderOptions());
+        return new ArcReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
     protected override IEnumerable<ArcEntry> GetEntries(Stream stream)

--- a/src/SharpCompress/Readers/Arj/ArjReader.cs
+++ b/src/SharpCompress/Readers/Arj/ArjReader.cs
@@ -32,7 +32,7 @@ public abstract partial class ArjReader : AbstractReader<ArjEntry, ArjVolume>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
         stream.NotNull(nameof(stream));
-        return new SingleVolumeArjReader(stream, readerOptions ?? new ReaderOptions());
+        return new SingleVolumeArjReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public abstract partial class ArjReader : AbstractReader<ArjEntry, ArjVolume>
     public static IReader OpenReader(IEnumerable<Stream> streams, ReaderOptions? options = null)
     {
         streams.NotNull(nameof(streams));
-        return new MultiVolumeArjReader(streams, options ?? new ReaderOptions());
+        return new MultiVolumeArjReader(streams, options ?? ReaderOptions.ForExternalStream);
     }
 
     protected abstract void ValidateArchive(ArjVolume archive);

--- a/src/SharpCompress/Readers/GZip/GZipReader.Factory.cs
+++ b/src/SharpCompress/Readers/GZip/GZipReader.Factory.cs
@@ -56,6 +56,6 @@ public partial class GZipReader
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
         stream.NotNull(nameof(stream));
-        return new GZipReader(stream, readerOptions ?? new ReaderOptions());
+        return new GZipReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 }

--- a/src/SharpCompress/Readers/Lzw/LzwReader.Factory.cs
+++ b/src/SharpCompress/Readers/Lzw/LzwReader.Factory.cs
@@ -56,6 +56,6 @@ public partial class LzwReader
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
         stream.NotNull(nameof(stream));
-        return new LzwReader(stream, readerOptions ?? new ReaderOptions());
+        return new LzwReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 }

--- a/src/SharpCompress/Readers/Rar/RarReader.cs
+++ b/src/SharpCompress/Readers/Rar/RarReader.cs
@@ -72,7 +72,7 @@ public abstract partial class RarReader : AbstractReader<RarReaderEntry, RarVolu
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
         stream.NotNull(nameof(stream));
-        return new SingleVolumeRarReader(stream, readerOptions ?? new ReaderOptions());
+        return new SingleVolumeRarReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ public abstract partial class RarReader : AbstractReader<RarReaderEntry, RarVolu
     public static IReader OpenReader(IEnumerable<Stream> streams, ReaderOptions? options = null)
     {
         streams.NotNull(nameof(streams));
-        return new MultiVolumeRarReader(streams, options ?? new ReaderOptions());
+        return new MultiVolumeRarReader(streams, options ?? ReaderOptions.ForExternalStream);
     }
 
     protected override IEnumerable<RarReaderEntry> GetEntries(Stream stream)

--- a/src/SharpCompress/Readers/ReaderFactory.Async.cs
+++ b/src/SharpCompress/Readers/ReaderFactory.Async.cs
@@ -25,7 +25,11 @@ public static partial class ReaderFactory
     )
     {
         filePath.NotNullOrEmpty(nameof(filePath));
-        return OpenAsyncReader(new FileInfo(filePath), options, cancellationToken);
+        return OpenAsyncReader(
+            new FileInfo(filePath),
+            options ?? ReaderOptions.ForFilePath,
+            cancellationToken
+        );
     }
 
     /// <summary>

--- a/src/SharpCompress/Readers/ReaderFactory.cs
+++ b/src/SharpCompress/Readers/ReaderFactory.cs
@@ -12,7 +12,7 @@ public static partial class ReaderFactory
     public static IReader OpenReader(string filePath, ReaderOptions? options = null)
     {
         filePath.NotNullOrEmpty(nameof(filePath));
-        return OpenReader(new FileInfo(filePath), options);
+        return OpenReader(new FileInfo(filePath), options ?? ReaderOptions.ForFilePath);
     }
 
     public static IReader OpenReader(FileInfo fileInfo, ReaderOptions? options = null)

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -151,35 +151,34 @@ public sealed record ReaderOptions : IReaderOptions
     /// <summary>
     /// Gets ReaderOptions configured for caller-provided streams.
     /// </summary>
-    public static ReaderOptions ForExternalStream => new() { LeaveStreamOpen = true };
+    internal static ReaderOptions Default => new();
+
+    public static ReaderOptions ForExternalStream => Default with { LeaveStreamOpen = true };
 
     /// <summary>
     /// Gets ReaderOptions configured for file-based overloads that open their own stream.
     /// </summary>
-    public static ReaderOptions ForFilePath => new() { LeaveStreamOpen = false };
+    public static ReaderOptions ForFilePath => Default;
 
     /// <summary>
     /// Creates ReaderOptions for reading encrypted archives.
     /// </summary>
     /// <param name="password">The password for encrypted archives.</param>
     public static ReaderOptions ForEncryptedArchive(string? password = null) =>
-        new ReaderOptions().WithPassword(password);
+        Default.WithPassword(password);
 
     /// <summary>
     /// Creates ReaderOptions for archives with custom character encoding.
     /// </summary>
     /// <param name="encoding">The encoding for archive entry names.</param>
     public static ReaderOptions ForEncoding(IArchiveEncoding encoding) =>
-        new ReaderOptions().WithArchiveEncoding(encoding);
+        Default.WithArchiveEncoding(encoding);
 
     /// <summary>
     /// Creates ReaderOptions for self-extracting archives that require header search.
     /// </summary>
     public static ReaderOptions ForSelfExtractingArchive(string? password = null) =>
-        new ReaderOptions()
-            .WithLookForHeader(true)
-            .WithPassword(password)
-            .WithRewindableBufferSize(1_048_576); // 1MB for SFX archives
+        Default.WithLookForHeader(true).WithPassword(password).WithRewindableBufferSize(1_048_576); // 1MB for SFX archives
 
     // Note: Parameterized constructors have been removed.
     // Use fluent With*() helpers or object initializers instead:

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -153,7 +153,7 @@ public sealed record ReaderOptions : IReaderOptions
     /// </summary>
     internal static ReaderOptions Default => new();
 
-    public static ReaderOptions ForExternalStream => Default with { LeaveStreamOpen = true };
+    public static ReaderOptions ForExternalStream => Default.WithLeaveStreamOpen(true);
 
     /// <summary>
     /// Gets ReaderOptions configured for file-based overloads that open their own stream.

--- a/src/SharpCompress/Readers/Tar/TarReader.Factory.cs
+++ b/src/SharpCompress/Readers/Tar/TarReader.Factory.cs
@@ -89,7 +89,7 @@ public partial class TarReader
     {
         cancellationToken.ThrowIfCancellationRequested();
         stream.NotNull(nameof(stream));
-        readerOptions ??= new ReaderOptions();
+        readerOptions ??= ReaderOptions.ForExternalStream;
         var sharpCompressStream = SharpCompressStream.Create(
             stream,
             bufferSize: Math.Max(
@@ -171,7 +171,7 @@ public partial class TarReader
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
         stream.NotNull(nameof(stream));
-        readerOptions ??= new ReaderOptions();
+        readerOptions ??= ReaderOptions.ForExternalStream;
         var sharpCompressStream = SharpCompressStream.Create(
             stream,
             bufferSize: Math.Max(

--- a/src/SharpCompress/Readers/Zip/ZipReader.cs
+++ b/src/SharpCompress/Readers/Zip/ZipReader.cs
@@ -48,7 +48,7 @@ public partial class ZipReader : AbstractReader<ZipEntry, ZipVolume>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
         stream.NotNull(nameof(stream));
-        return new ZipReader(stream, readerOptions ?? new ReaderOptions());
+        return new ZipReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
     public static IReader OpenReader(
@@ -58,7 +58,7 @@ public partial class ZipReader : AbstractReader<ZipEntry, ZipVolume>
     )
     {
         stream.NotNull(nameof(stream));
-        return new ZipReader(stream, options ?? new ReaderOptions(), entries);
+        return new ZipReader(stream, options ?? ReaderOptions.ForExternalStream, entries);
     }
 
     #endregion Open

--- a/src/SharpCompress/Writers/WriterOptions.cs
+++ b/src/SharpCompress/Writers/WriterOptions.cs
@@ -1,7 +1,6 @@
 using System;
 using SharpCompress.Common;
 using SharpCompress.Common.Options;
-using SharpCompress.Compressors;
 using SharpCompress.Providers;
 using D = SharpCompress.Compressors.Deflate;
 
@@ -18,17 +17,10 @@ namespace SharpCompress.Writers;
 /// </remarks>
 public sealed record WriterOptions : IWriterOptions
 {
-    private CompressionType _compressionType;
-    private int _compressionLevel;
-
     /// <summary>
     /// The compression type to use for the archive.
     /// </summary>
-    public CompressionType CompressionType
-    {
-        get => _compressionType;
-        init => _compressionType = value;
-    }
+    public CompressionType CompressionType { get; init; }
 
     /// <summary>
     /// The compression level to be used when the compression type supports variable levels.
@@ -40,11 +32,11 @@ public sealed record WriterOptions : IWriterOptions
     /// </summary>
     public int CompressionLevel
     {
-        get => _compressionLevel;
+        get;
         init
         {
             CompressionLevelValidation.Validate(CompressionType, value);
-            _compressionLevel = value;
+            field = value;
         }
     }
 

--- a/src/SharpCompress/packages.lock.json
+++ b/src/SharpCompress/packages.lock.json
@@ -268,9 +268,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "QKuvS0LWX4fjFqeDkyM7Kqt8P3wYTiPD4nwU+9y59n0sCiG714fxDgbbN82vDnzq89AF/PiHl92TP2C4aFDUQA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
@@ -400,9 +400,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.26, )",
+        "resolved": "8.0.26",
+        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",

--- a/src/SharpCompress/packages.lock.json
+++ b/src/SharpCompress/packages.lock.json
@@ -268,9 +268,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
@@ -400,9 +400,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.25, )",
-        "resolved": "8.0.25",
-        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",

--- a/src/SharpCompress/packages.lock.json
+++ b/src/SharpCompress/packages.lock.json
@@ -268,9 +268,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.6, )",
-        "resolved": "10.0.6",
-        "contentHash": "QKuvS0LWX4fjFqeDkyM7Kqt8P3wYTiPD4nwU+9y59n0sCiG714fxDgbbN82vDnzq89AF/PiHl92TP2C4aFDUQA=="
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "A+5ZuQ0f449tM+MQrhf6R9ZX7lYpjk/ODEwLYKrnF6111rtARx8fVsm4YznUnQiKnnXfaXNBqgxmil6RW3L3SA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
@@ -400,9 +400,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.26, )",
-        "resolved": "8.0.26",
-        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
+        "requested": "[8.0.25, )",
+        "resolved": "8.0.25",
+        "contentHash": "sqX4nmBft05ivqKvUT4nxaN8rT3apCLt9SWFkfRrQPwra1zPwFknQAw1lleuMCKOCLvVmOWwrC2iPSm9RiXZUg=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",

--- a/tests/SharpCompress.Performance/Benchmarks/TarBenchmarks.cs
+++ b/tests/SharpCompress.Performance/Benchmarks/TarBenchmarks.cs
@@ -70,7 +70,7 @@ public class TarBenchmarks : ArchiveBenchmarkBase
         using var stream = new MemoryStream(_tarBytes);
         using var archive = TarArchive.OpenArchive(
             stream,
-            new ReaderOptions().WithProviders(
+            ReaderOptions.ForExternalStream.WithProviders(
                 CompressionProviderRegistry.Empty.With(new SystemGZipCompressionProvider())
             )
         );
@@ -87,7 +87,7 @@ public class TarBenchmarks : ArchiveBenchmarkBase
         using var stream = new MemoryStream(_tarBytes);
         using var reader = ReaderFactory.OpenReader(
             stream,
-            new ReaderOptions().WithProviders(
+            ReaderOptions.ForExternalStream.WithProviders(
                 CompressionProviderRegistry.Empty.With(new SystemGZipCompressionProvider())
             )
         );

--- a/tests/SharpCompress.Performance/Benchmarks/ZipBenchmarks.cs
+++ b/tests/SharpCompress.Performance/Benchmarks/ZipBenchmarks.cs
@@ -32,7 +32,7 @@ public class ZipBenchmarks : ArchiveBenchmarkBase
         using var stream = new MemoryStream(_archiveBytes);
         using var archive = ZipArchive.OpenArchive(
             stream,
-            new ReaderOptions().WithProviders(
+            ReaderOptions.ForExternalStream.WithProviders(
                 CompressionProviderRegistry.Empty.With(new SystemDeflateCompressionProvider())
             )
         );
@@ -73,7 +73,7 @@ public class ZipBenchmarks : ArchiveBenchmarkBase
         using var stream = new MemoryStream(_archiveBytes);
         using var reader = ReaderFactory.OpenReader(
             stream,
-            new ReaderOptions().WithProviders(
+            ReaderOptions.ForExternalStream.WithProviders(
                 CompressionProviderRegistry.Empty.With(new SystemDeflateCompressionProvider())
             )
         );

--- a/tests/SharpCompress.Test/Ace/AceReaderAsyncTests.cs
+++ b/tests/SharpCompress.Test/Ace/AceReaderAsyncTests.cs
@@ -73,7 +73,7 @@ public class AceReaderAsyncTests : ReaderTests
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
-            new ReaderOptions()
+            ReaderOptions.ForExternalStream
         );
         while (await reader.MoveToNextEntryAsync())
         {
@@ -95,7 +95,10 @@ public class AceReaderAsyncTests : ReaderTests
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
-            new ReaderOptions { LookForHeader = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LookForHeader = true,
+            }
         );
         while (await reader.MoveToNextEntryAsync())
         {

--- a/tests/SharpCompress.Test/Arj/ArjReaderAsyncTests.cs
+++ b/tests/SharpCompress.Test/Arj/ArjReaderAsyncTests.cs
@@ -94,7 +94,7 @@ public class ArjReaderAsyncTests : ReaderTests
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
-            new ReaderOptions()
+            ReaderOptions.ForExternalStream
         );
         while (await reader.MoveToNextEntryAsync())
         {
@@ -119,7 +119,10 @@ public class ArjReaderAsyncTests : ReaderTests
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
-            new ReaderOptions() { LookForHeader = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LookForHeader = true,
+            }
         );
         while (await reader.MoveToNextEntryAsync())
         {

--- a/tests/SharpCompress.Test/CompressionProviderTests.cs
+++ b/tests/SharpCompress.Test/CompressionProviderTests.cs
@@ -436,7 +436,7 @@ public class CompressionProviderTests
         archiveStream.Position = 0;
         var customProvider = new GZipCompressionProvider();
         var registry = CompressionProviderRegistry.Default.With(customProvider);
-        var readOptions = ReaderOptions.ForExternalStream with { Providers = registry };
+        var readOptions = ReaderOptions.ForExternalStream.WithProviders(registry);
 
         using var reader = TarReader.OpenReader(archiveStream, readOptions);
         reader.MoveToNextEntry().Should().BeTrue();
@@ -465,7 +465,7 @@ public class CompressionProviderTests
 
         archiveStream.Position = 0;
         var registry = CompressionProviderRegistry.Default.With(new ContextRequiredGZipProvider());
-        var readOptions = ReaderOptions.ForExternalStream with { Providers = registry };
+        var readOptions = ReaderOptions.ForExternalStream.WithProviders(registry);
 
         using var reader = TarReader.OpenReader(archiveStream, readOptions);
         reader.MoveToNextEntry().Should().BeTrue();
@@ -540,7 +540,7 @@ public class CompressionProviderTests
 
         var trackingProvider = new TrackingCompressionProvider(new GZipCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
-        var readOptions = ReaderOptions.ForExternalStream with { Providers = registry };
+        var readOptions = ReaderOptions.ForExternalStream.WithProviders(registry);
 
         archiveStream.Position = 0;
         using var archive = TarArchive.OpenArchive(archiveStream, readOptions);
@@ -569,7 +569,7 @@ public class CompressionProviderTests
 
         var trackingProvider = new TrackingCompressionProvider(new GZipCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
-        var readOptions = ReaderOptions.ForExternalStream with { Providers = registry };
+        var readOptions = ReaderOptions.ForExternalStream.WithProviders(registry);
 
         archiveStream.Position = 0;
         await using var archive = await TarArchive.OpenAsyncArchive(archiveStream, readOptions);
@@ -607,7 +607,7 @@ public class CompressionProviderTests
 
         var trackingProvider = new TrackingCompressionProvider(new DeflateCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
-        var options = ReaderOptions.ForExternalStream with { Providers = registry };
+        var options = ReaderOptions.ForExternalStream.WithProviders(registry);
 
         zipStream.Position = 0;
         await using var reader = await ReaderFactory.OpenAsyncReader(zipStream, options);
@@ -625,7 +625,7 @@ public class CompressionProviderTests
         var archivePath = Path.Combine(TestBase.TEST_ARCHIVES_PATH, "Tar.tar.Z");
         var trackingProvider = new TrackingCompressionProvider(new LzwCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
-        var options = ReaderOptions.ForExternalStream with { Providers = registry };
+        var options = ReaderOptions.ForExternalStream.WithProviders(registry);
 
         using var stream = File.OpenRead(archivePath);
         using var reader = ReaderFactory.OpenReader(stream, options);

--- a/tests/SharpCompress.Test/CompressionProviderTests.cs
+++ b/tests/SharpCompress.Test/CompressionProviderTests.cs
@@ -332,7 +332,10 @@ public class CompressionProviderTests
         );
 
         compressedStream.Position = 0;
-        var readerOptions = new ReaderOptions { ArchiveEncoding = archiveEncoding };
+        var readerOptions = ReaderOptions.ForExternalStream with
+        {
+            ArchiveEncoding = archiveEncoding,
+        };
         var context = CompressionContext.FromStream(compressedStream) with
         {
             ReaderOptions = readerOptions,
@@ -433,7 +436,7 @@ public class CompressionProviderTests
         archiveStream.Position = 0;
         var customProvider = new GZipCompressionProvider();
         var registry = CompressionProviderRegistry.Default.With(customProvider);
-        var readOptions = new ReaderOptions { Providers = registry };
+        var readOptions = ReaderOptions.ForExternalStream with { Providers = registry };
 
         using var reader = TarReader.OpenReader(archiveStream, readOptions);
         reader.MoveToNextEntry().Should().BeTrue();
@@ -462,7 +465,7 @@ public class CompressionProviderTests
 
         archiveStream.Position = 0;
         var registry = CompressionProviderRegistry.Default.With(new ContextRequiredGZipProvider());
-        var readOptions = new ReaderOptions { Providers = registry };
+        var readOptions = ReaderOptions.ForExternalStream with { Providers = registry };
 
         using var reader = TarReader.OpenReader(archiveStream, readOptions);
         reader.MoveToNextEntry().Should().BeTrue();
@@ -504,7 +507,11 @@ public class CompressionProviderTests
         var customProvider = new DeflateCompressionProvider();
         var registry = CompressionProviderRegistry.Default.With(customProvider);
 
-        var original = new ReaderOptions { Providers = registry, LeaveStreamOpen = false };
+        var original = ReaderOptions.ForExternalStream with
+        {
+            Providers = registry,
+            LeaveStreamOpen = false,
+        };
 
         // Clone using 'with' expression
         var clone = original with
@@ -533,7 +540,7 @@ public class CompressionProviderTests
 
         var trackingProvider = new TrackingCompressionProvider(new GZipCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
-        var readOptions = new ReaderOptions { Providers = registry };
+        var readOptions = ReaderOptions.ForExternalStream with { Providers = registry };
 
         archiveStream.Position = 0;
         using var archive = TarArchive.OpenArchive(archiveStream, readOptions);
@@ -562,7 +569,7 @@ public class CompressionProviderTests
 
         var trackingProvider = new TrackingCompressionProvider(new GZipCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
-        var readOptions = new ReaderOptions { Providers = registry };
+        var readOptions = ReaderOptions.ForExternalStream with { Providers = registry };
 
         archiveStream.Position = 0;
         await using var archive = await TarArchive.OpenAsyncArchive(archiveStream, readOptions);
@@ -600,7 +607,7 @@ public class CompressionProviderTests
 
         var trackingProvider = new TrackingCompressionProvider(new DeflateCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
-        var options = new ReaderOptions { Providers = registry };
+        var options = ReaderOptions.ForExternalStream with { Providers = registry };
 
         zipStream.Position = 0;
         await using var reader = await ReaderFactory.OpenAsyncReader(zipStream, options);
@@ -618,7 +625,7 @@ public class CompressionProviderTests
         var archivePath = Path.Combine(TestBase.TEST_ARCHIVES_PATH, "Tar.tar.Z");
         var trackingProvider = new TrackingCompressionProvider(new LzwCompressionProvider());
         var registry = CompressionProviderRegistry.Default.With(trackingProvider);
-        var options = new ReaderOptions { Providers = registry };
+        var options = ReaderOptions.ForExternalStream with { Providers = registry };
 
         using var stream = File.OpenRead(archivePath);
         using var reader = ReaderFactory.OpenReader(stream, options);
@@ -809,7 +816,7 @@ public class CompressionProviderTests
 
         // Read back using internal provider (should be compatible)
         archiveStream.Position = 0;
-        var readOptions = new ReaderOptions();
+        var readOptions = ReaderOptions.ForExternalStream;
         using var reader = TarReader.OpenReader(archiveStream, readOptions);
         reader.MoveToNextEntry().Should().BeTrue();
         using var entryStream = reader.OpenEntryStream();

--- a/tests/SharpCompress.Test/Lzw/LzwReaderTests.cs
+++ b/tests/SharpCompress.Test/Lzw/LzwReaderTests.cs
@@ -37,7 +37,10 @@ public class LzwReaderTests : ReaderTests
         using Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.Z"));
         using var reader = ReaderFactory.OpenReader(
             stream,
-            new ReaderOptions { LeaveStreamOpen = false }
+            ReaderOptions.ForExternalStream with
+            {
+                LeaveStreamOpen = false,
+            }
         );
 
         // Should detect as Tar archive with Lzw compression

--- a/tests/SharpCompress.Test/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Test/OptionsUsabilityTests.cs
@@ -160,8 +160,8 @@ public class OptionsUsabilityTests : TestBase
     [Fact]
     public void ReaderOptions_Fluent_Methods_Modify_Correctly()
     {
-        var options = new ReaderOptions()
-            .WithLeaveStreamOpen(false)
+        var options = ReaderOptions
+            .ForExternalStream.WithLeaveStreamOpen(false)
             .WithPassword("secret")
             .WithLookForHeader(true)
             .WithBufferSize(65536);
@@ -176,15 +176,15 @@ public class OptionsUsabilityTests : TestBase
     public void ReaderOptions_Fluent_And_Initializer_Equivalent()
     {
         // Fluent approach
-        var fluentApproach = new ReaderOptions()
-            .WithLeaveStreamOpen(false)
+        var fluentApproach = ReaderOptions
+            .ForExternalStream.WithLeaveStreamOpen(false)
             .WithPassword("secret")
             .WithLookForHeader(true)
             .WithBufferSize(65536)
             .WithDisableCheckIncomplete(true);
 
-        // Object initializer approach
-        var initializerApproach = new ReaderOptions
+        // Preset + with-expression approach
+        var initializerApproach = ReaderOptions.ForExternalStream with
         {
             LeaveStreamOpen = false,
             Password = "secret",

--- a/tests/SharpCompress.Test/ProgressReportTests.cs
+++ b/tests/SharpCompress.Test/ProgressReportTests.cs
@@ -108,7 +108,7 @@ public class ProgressReportTests : TestBase
 
         // Now read it with progress reporting
         archiveStream.Position = 0;
-        var readerOptions = new ReaderOptions { Progress = progress };
+        var readerOptions = ReaderOptions.ForExternalStream with { Progress = progress };
 
         using (var reader = ReaderFactory.OpenReader(archiveStream, readerOptions))
         {
@@ -234,7 +234,7 @@ public class ProgressReportTests : TestBase
 
         // Read without progress
         archiveStream.Position = 0;
-        var readerOptions = new ReaderOptions();
+        var readerOptions = ReaderOptions.ForExternalStream;
         Assert.Null(readerOptions.Progress);
 
         using (var reader = ReaderFactory.OpenReader(archiveStream, readerOptions))
@@ -324,7 +324,7 @@ public class ProgressReportTests : TestBase
 
         // Now read it with progress reporting
         archiveStream.Position = 0;
-        var readerOptions = new ReaderOptions { Progress = progress };
+        var readerOptions = ReaderOptions.ForExternalStream with { Progress = progress };
 
         using (var reader = ReaderFactory.OpenReader(archiveStream, readerOptions))
         {
@@ -445,7 +445,7 @@ public class ProgressReportTests : TestBase
 
         // Now read it with progress reporting
         archiveStream.Position = 0;
-        var readerOptions = new ReaderOptions { Progress = progress };
+        var readerOptions = ReaderOptions.ForExternalStream with { Progress = progress };
 
         using (var reader = ReaderFactory.OpenReader(archiveStream, readerOptions))
         {
@@ -538,7 +538,7 @@ public class ProgressReportTests : TestBase
 
         // Now read it with progress reporting
         archiveStream.Position = 0;
-        var readerOptions = new ReaderOptions { Progress = progress };
+        var readerOptions = ReaderOptions.ForExternalStream with { Progress = progress };
 
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(

--- a/tests/SharpCompress.Test/ProgressReportTests.cs
+++ b/tests/SharpCompress.Test/ProgressReportTests.cs
@@ -108,7 +108,7 @@ public class ProgressReportTests : TestBase
 
         // Now read it with progress reporting
         archiveStream.Position = 0;
-        var readerOptions = ReaderOptions.ForExternalStream with { Progress = progress };
+        var readerOptions = ReaderOptions.ForExternalStream.WithProgress(progress);
 
         using (var reader = ReaderFactory.OpenReader(archiveStream, readerOptions))
         {
@@ -324,7 +324,7 @@ public class ProgressReportTests : TestBase
 
         // Now read it with progress reporting
         archiveStream.Position = 0;
-        var readerOptions = ReaderOptions.ForExternalStream with { Progress = progress };
+        var readerOptions = ReaderOptions.ForExternalStream.WithProgress(progress);
 
         using (var reader = ReaderFactory.OpenReader(archiveStream, readerOptions))
         {
@@ -445,7 +445,7 @@ public class ProgressReportTests : TestBase
 
         // Now read it with progress reporting
         archiveStream.Position = 0;
-        var readerOptions = ReaderOptions.ForExternalStream with { Progress = progress };
+        var readerOptions = ReaderOptions.ForExternalStream.WithProgress(progress);
 
         using (var reader = ReaderFactory.OpenReader(archiveStream, readerOptions))
         {
@@ -538,7 +538,7 @@ public class ProgressReportTests : TestBase
 
         // Now read it with progress reporting
         archiveStream.Position = 0;
-        var readerOptions = ReaderOptions.ForExternalStream with { Progress = progress };
+        var readerOptions = ReaderOptions.ForExternalStream.WithProgress(progress);
 
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(

--- a/tests/SharpCompress.Test/Rar/RarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarArchiveAsyncTests.cs
@@ -71,7 +71,11 @@ public class RarArchiveAsyncTests : ArchiveTests
         await using (
             var archive = await RarArchive.OpenAsyncArchive(
                 stream,
-                new ReaderOptions { Password = password, LeaveStreamOpen = true }
+                ReaderOptions.ForExternalStream with
+                {
+                    Password = password,
+                    LeaveStreamOpen = true,
+                }
             )
         )
         {
@@ -98,7 +102,11 @@ public class RarArchiveAsyncTests : ArchiveTests
         using (
             var archive = RarArchive.OpenArchive(
                 Path.Combine(TEST_ARCHIVES_PATH, archiveName),
-                new ReaderOptions { Password = password, LeaveStreamOpen = true }
+                ReaderOptions.ForFilePath with
+                {
+                    Password = password,
+                    LeaveStreamOpen = true,
+                }
             )
         )
         {
@@ -144,7 +152,13 @@ public class RarArchiveAsyncTests : ArchiveTests
     {
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"));
         using (
-            var archive = RarArchive.OpenArchive(stream, new ReaderOptions { LookForHeader = true })
+            var archive = RarArchive.OpenArchive(
+                stream,
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = true,
+                }
+            )
         )
         {
             foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
@@ -316,7 +330,10 @@ public class RarArchiveAsyncTests : ArchiveTests
         using (
             var archive = RarArchive.OpenArchive(
                 Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"),
-                new ReaderOptions { LookForHeader = true }
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = true,
+                }
             )
         )
         {

--- a/tests/SharpCompress.Test/Rar/RarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarArchiveAsyncTests.cs
@@ -330,7 +330,7 @@ public class RarArchiveAsyncTests : ArchiveTests
         using (
             var archive = RarArchive.OpenArchive(
                 Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"),
-                ReaderOptions.ForExternalStream with
+                ReaderOptions.ForFilePath with
                 {
                     LookForHeader = true,
                 }

--- a/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
@@ -768,7 +768,7 @@ public class RarArchiveTests : ArchiveTests
     public void Rar_MalformedArchive_NoInfiniteLoop()
     {
         var testFile = "Rar.malformed_512byte.rar";
-        var readerOptions = ReaderOptions.ForExternalStream with { LookForHeader = true };
+        var readerOptions = ReaderOptions.ForExternalStream.WithLookForHeader(true);
 
         // This should throw InvalidOperationException, not hang in an infinite loop
         var exception = Assert.Throws<ArchiveOperationException>(() =>

--- a/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
@@ -316,7 +316,7 @@ public class RarArchiveTests : ArchiveTests
         using (
             var archive = RarArchive.OpenArchive(
                 Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"),
-                ReaderOptions.ForExternalStream with
+                ReaderOptions.ForFilePath with
                 {
                     LookForHeader = true,
                 }

--- a/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
@@ -66,7 +66,11 @@ public class RarArchiveTests : ArchiveTests
         using (
             var archive = RarArchive.OpenArchive(
                 stream,
-                new ReaderOptions { Password = password, LeaveStreamOpen = true }
+                ReaderOptions.ForExternalStream with
+                {
+                    Password = password,
+                    LeaveStreamOpen = true,
+                }
             )
         )
         {
@@ -93,7 +97,11 @@ public class RarArchiveTests : ArchiveTests
         using (
             var archive = RarArchive.OpenArchive(
                 Path.Combine(TEST_ARCHIVES_PATH, archiveName),
-                new ReaderOptions { Password = password, LeaveStreamOpen = true }
+                ReaderOptions.ForFilePath with
+                {
+                    Password = password,
+                    LeaveStreamOpen = true,
+                }
             )
         )
         {
@@ -136,7 +144,13 @@ public class RarArchiveTests : ArchiveTests
     {
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"));
         using (
-            var archive = RarArchive.OpenArchive(stream, new ReaderOptions { LookForHeader = true })
+            var archive = RarArchive.OpenArchive(
+                stream,
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = true,
+                }
+            )
         )
         {
             foreach (var entry in archive.Entries.Where(entry => !entry.IsDirectory))
@@ -302,7 +316,10 @@ public class RarArchiveTests : ArchiveTests
         using (
             var archive = RarArchive.OpenArchive(
                 Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg"),
-                new ReaderOptions { LookForHeader = true }
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = true,
+                }
             )
         )
         {
@@ -751,7 +768,7 @@ public class RarArchiveTests : ArchiveTests
     public void Rar_MalformedArchive_NoInfiniteLoop()
     {
         var testFile = "Rar.malformed_512byte.rar";
-        var readerOptions = new ReaderOptions { LookForHeader = true };
+        var readerOptions = ReaderOptions.ForExternalStream with { LookForHeader = true };
 
         // This should throw InvalidOperationException, not hang in an infinite loop
         var exception = Assert.Throws<ArchiveOperationException>(() =>

--- a/tests/SharpCompress.Test/Rar/RarHeaderFactoryTest.cs
+++ b/tests/SharpCompress.Test/Rar/RarHeaderFactoryTest.cs
@@ -16,7 +16,10 @@ public class RarHeaderFactoryTest : TestBase
     public RarHeaderFactoryTest() =>
         _rarHeaderFactory = new RarHeaderFactory(
             StreamingMode.Seekable,
-            new ReaderOptions { LeaveStreamOpen = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LeaveStreamOpen = true,
+            }
         );
 
     [Fact]

--- a/tests/SharpCompress.Test/Rar/RarReaderAsyncTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarReaderAsyncTests.cs
@@ -73,7 +73,10 @@ public class RarReaderAsyncTests : ReaderTests
                     archives
                         .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
                         .Select(p => File.OpenRead(p)),
-                    new ReaderOptions { Password = "test" }
+                    ReaderOptions.ForExternalStream with
+                    {
+                        Password = "test",
+                    }
                 )
             )
             {
@@ -187,7 +190,10 @@ public class RarReaderAsyncTests : ReaderTests
         await ReadAsync(
             testArchive,
             CompressionType.Rar,
-            new ReaderOptions { Password = password }
+            ReaderOptions.ForFilePath with
+            {
+                Password = password,
+            }
         );
 
     [Fact]
@@ -248,7 +254,10 @@ public class RarReaderAsyncTests : ReaderTests
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(
                 new AsyncOnlyStream(stream),
-                new ReaderOptions { LookForHeader = true }
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = true,
+                }
             )
         )
         {
@@ -271,7 +280,10 @@ public class RarReaderAsyncTests : ReaderTests
         using (
             IReader baseReader = RarReader.OpenReader(
                 stream,
-                new ReaderOptions { LookForHeader = true }
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = true,
+                }
             )
         )
         {
@@ -314,7 +326,10 @@ public class RarReaderAsyncTests : ReaderTests
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
-            new ReaderOptions { LookForHeader = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LookForHeader = true,
+            }
         );
         while (await reader.MoveToNextEntryAsync())
         {
@@ -337,7 +352,10 @@ public class RarReaderAsyncTests : ReaderTests
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
-            new ReaderOptions { LookForHeader = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LookForHeader = true,
+            }
         );
         while (await reader.MoveToNextEntryAsync())
         {
@@ -359,7 +377,7 @@ public class RarReaderAsyncTests : ReaderTests
         using Stream stream = File.OpenRead(testArchive);
         await using var reader = await ReaderFactory.OpenAsyncReader(
             new AsyncOnlyStream(stream),
-            readerOptions ?? new ReaderOptions()
+            readerOptions ?? ReaderOptions.ForExternalStream
         );
         while (await reader.MoveToNextEntryAsync())
         {

--- a/tests/SharpCompress.Test/Rar/RarReaderTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarReaderTests.cs
@@ -71,7 +71,10 @@ public class RarReaderTests : ReaderTests
                     archives
                         .Select(s => Path.Combine(TEST_ARCHIVES_PATH, s))
                         .Select(p => File.OpenRead(p)),
-                    new ReaderOptions { Password = "test" }
+                    ReaderOptions.ForExternalStream with
+                    {
+                        Password = "test",
+                    }
                 )
             )
             {
@@ -173,7 +176,14 @@ public class RarReaderTests : ReaderTests
     public void Rar5_Encrypted_Reader() => ReadRar("Rar5.encrypted_filesOnly.rar", "test");
 
     private void ReadRar(string testArchive, string password) =>
-        Read(testArchive, CompressionType.Rar, new ReaderOptions { Password = password });
+        Read(
+            testArchive,
+            CompressionType.Rar,
+            ReaderOptions.ForFilePath with
+            {
+                Password = password,
+            }
+        );
 
     [Fact]
     public void Rar_Entry_Stream() => DoRar_Entry_Stream("Rar.rar");
@@ -222,7 +232,10 @@ public class RarReaderTests : ReaderTests
         using (
             var reader = ReaderFactory.OpenReader(
                 stream,
-                new ReaderOptions { LookForHeader = true }
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = true,
+                }
             )
         )
         {
@@ -243,7 +256,13 @@ public class RarReaderTests : ReaderTests
     {
         using (var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Rar.jpeg.jpg")))
         using (
-            var reader = RarReader.OpenReader(stream, new ReaderOptions { LookForHeader = true })
+            var reader = RarReader.OpenReader(
+                stream,
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = true,
+                }
+            )
         )
         {
             while (reader.MoveToNextEntry())
@@ -278,7 +297,10 @@ public class RarReaderTests : ReaderTests
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
         using var reader = ReaderFactory.OpenReader(
             stream,
-            new ReaderOptions { LookForHeader = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LookForHeader = true,
+            }
         );
         while (reader.MoveToNextEntry())
         {
@@ -301,7 +323,10 @@ public class RarReaderTests : ReaderTests
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, filename));
         using var reader = ReaderFactory.OpenReader(
             stream,
-            new ReaderOptions { LookForHeader = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LookForHeader = true,
+            }
         );
         while (reader.MoveToNextEntry())
         {
@@ -321,7 +346,10 @@ public class RarReaderTests : ReaderTests
         );
         using var reader = ReaderFactory.OpenReader(
             stream,
-            new ReaderOptions { LookForHeader = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LookForHeader = true,
+            }
         );
         while (reader.MoveToNextEntry())
         {

--- a/tests/SharpCompress.Test/ReaderTests.cs
+++ b/tests/SharpCompress.Test/ReaderTests.cs
@@ -32,7 +32,7 @@ public abstract class ReaderTests : TestBase
     )
     {
         testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
-        options ??= new ReaderOptions { BufferSize = 0x20000 };
+        options ??= ReaderOptions.ForFilePath with { BufferSize = 0x20000 };
 
         var optionsWithStreamOpen = options with { LeaveStreamOpen = true };
         readImpl(testArchive, optionsWithStreamOpen);
@@ -128,7 +128,7 @@ public abstract class ReaderTests : TestBase
     {
         testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
 
-        options ??= new ReaderOptions() { BufferSize = 0x20000 };
+        options ??= ReaderOptions.ForExternalStream with { BufferSize = 0x20000 };
 
         var optionsWithStreamOpen = options with { LeaveStreamOpen = true };
         await ReadImplAsync(
@@ -215,7 +215,10 @@ public abstract class ReaderTests : TestBase
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, fileName));
         using var reader = ReaderFactory.OpenReader(
             stream,
-            new ReaderOptions { LookForHeader = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LookForHeader = true,
+            }
         );
 
         while (reader.MoveToNextEntry())

--- a/tests/SharpCompress.Test/ReaderTests.cs
+++ b/tests/SharpCompress.Test/ReaderTests.cs
@@ -32,12 +32,12 @@ public abstract class ReaderTests : TestBase
     )
     {
         testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
-        options ??= ReaderOptions.ForFilePath with { BufferSize = 0x20000 };
+        options ??= ReaderOptions.ForFilePath.WithBufferSize(0x20000);
 
-        var optionsWithStreamOpen = options with { LeaveStreamOpen = true };
+        var optionsWithStreamOpen = options.WithLeaveStreamOpen(true);
         readImpl(testArchive, optionsWithStreamOpen);
 
-        var optionsWithStreamClosed = options with { LeaveStreamOpen = false };
+        var optionsWithStreamClosed = options.WithLeaveStreamOpen(false);
         readImpl(testArchive, optionsWithStreamClosed);
 
         VerifyFiles();
@@ -128,9 +128,9 @@ public abstract class ReaderTests : TestBase
     {
         testArchive = Path.Combine(TEST_ARCHIVES_PATH, testArchive);
 
-        options ??= ReaderOptions.ForExternalStream with { BufferSize = 0x20000 };
+        options ??= ReaderOptions.ForExternalStream.WithBufferSize(0x20000);
 
-        var optionsWithStreamOpen = options with { LeaveStreamOpen = true };
+        var optionsWithStreamOpen = options.WithLeaveStreamOpen(true);
         await ReadImplAsync(
             testArchive,
             expectedCompression,
@@ -138,7 +138,7 @@ public abstract class ReaderTests : TestBase
             cancellationToken
         );
 
-        var optionsWithStreamClosed = options with { LeaveStreamOpen = false };
+        var optionsWithStreamClosed = options.WithLeaveStreamOpen(false);
         await ReadImplAsync(
             testArchive,
             expectedCompression,

--- a/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
@@ -48,7 +48,7 @@ public class SevenZipArchiveTests : ArchiveTests
     [Fact]
     public void SevenZipArchive_LZMAAES_NoPasswordExceptionTest() =>
         Assert.Throws<CryptographicException>(() =>
-            ArchiveFileRead("7Zip.LZMA.Aes.7z", ReaderOptions.ForFilePath with { Password = null })
+            ArchiveFileRead("7Zip.LZMA.Aes.7z", ReaderOptions.ForFilePath.WithPassword(null))
         ); //was failing with ArgumentNullException not CryptographicException like rar
 
     [Fact]
@@ -69,11 +69,19 @@ public class SevenZipArchiveTests : ArchiveTests
 
     [Fact]
     public void SevenZipArchive_LZMA2_EXE_StreamRead() =>
-        ArchiveStreamRead(new SevenZipFactory(), "7Zip.LZMA2.exe", ReaderOptions.ForExternalStream.WithLookForHeader(true));
+        ArchiveStreamRead(
+            new SevenZipFactory(),
+            "7Zip.LZMA2.exe",
+            ReaderOptions.ForExternalStream.WithLookForHeader(true)
+        );
 
     [Fact]
     public void SevenZipArchive_LZMA2_EXE_PathRead() =>
-        ArchiveFileRead("7Zip.LZMA2.exe", ReaderOptions.ForFilePath.WithLookForHeader(true), new SevenZipFactory());
+        ArchiveFileRead(
+            "7Zip.LZMA2.exe",
+            ReaderOptions.ForFilePath.WithLookForHeader(true),
+            new SevenZipFactory()
+        );
 
     [Fact]
     public void SevenZipArchive_LZMA2AES_StreamRead() =>

--- a/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
@@ -69,11 +69,11 @@ public class SevenZipArchiveTests : ArchiveTests
 
     [Fact]
     public void SevenZipArchive_LZMA2_EXE_StreamRead() =>
-        ArchiveStreamRead(new SevenZipFactory(), "7Zip.LZMA2.exe", new() { LookForHeader = true });
+        ArchiveStreamRead(new SevenZipFactory(), "7Zip.LZMA2.exe", ReaderOptions.ForExternalStream.WithLookForHeader(true));
 
     [Fact]
     public void SevenZipArchive_LZMA2_EXE_PathRead() =>
-        ArchiveFileRead("7Zip.LZMA2.exe", new() { LookForHeader = true }, new SevenZipFactory());
+        ArchiveFileRead("7Zip.LZMA2.exe", ReaderOptions.ForFilePath.WithLookForHeader(true), new SevenZipFactory());
 
     [Fact]
     public void SevenZipArchive_LZMA2AES_StreamRead() =>

--- a/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
@@ -27,16 +27,28 @@ public class SevenZipArchiveTests : ArchiveTests
 
     [Fact]
     public void SevenZipArchive_LZMAAES_StreamRead() =>
-        ArchiveStreamRead("7Zip.LZMA.Aes.7z", new ReaderOptions { Password = "testpassword" });
+        ArchiveStreamRead(
+            "7Zip.LZMA.Aes.7z",
+            ReaderOptions.ForExternalStream with
+            {
+                Password = "testpassword",
+            }
+        );
 
     [Fact]
     public void SevenZipArchive_LZMAAES_PathRead() =>
-        ArchiveFileRead("7Zip.LZMA.Aes.7z", new ReaderOptions { Password = "testpassword" });
+        ArchiveFileRead(
+            "7Zip.LZMA.Aes.7z",
+            ReaderOptions.ForFilePath with
+            {
+                Password = "testpassword",
+            }
+        );
 
     [Fact]
     public void SevenZipArchive_LZMAAES_NoPasswordExceptionTest() =>
         Assert.Throws<CryptographicException>(() =>
-            ArchiveFileRead("7Zip.LZMA.Aes.7z", new ReaderOptions { Password = null })
+            ArchiveFileRead("7Zip.LZMA.Aes.7z", ReaderOptions.ForFilePath with { Password = null })
         ); //was failing with ArgumentNullException not CryptographicException like rar
 
     [Fact]
@@ -65,11 +77,23 @@ public class SevenZipArchiveTests : ArchiveTests
 
     [Fact]
     public void SevenZipArchive_LZMA2AES_StreamRead() =>
-        ArchiveStreamRead("7Zip.LZMA2.Aes.7z", new ReaderOptions { Password = "testpassword" });
+        ArchiveStreamRead(
+            "7Zip.LZMA2.Aes.7z",
+            ReaderOptions.ForExternalStream with
+            {
+                Password = "testpassword",
+            }
+        );
 
     [Fact]
     public void SevenZipArchive_LZMA2AES_PathRead() =>
-        ArchiveFileRead("7Zip.LZMA2.Aes.7z", new ReaderOptions { Password = "testpassword" });
+        ArchiveFileRead(
+            "7Zip.LZMA2.Aes.7z",
+            ReaderOptions.ForFilePath with
+            {
+                Password = "testpassword",
+            }
+        );
 
     [Fact]
     public void SevenZipArchive_BZip2_StreamRead() => ArchiveStreamRead("7Zip.BZip2.7z");

--- a/tests/SharpCompress.Test/Streams/DisposalTests.cs
+++ b/tests/SharpCompress.Test/Streams/DisposalTests.cs
@@ -76,7 +76,10 @@ public class DisposalTests
                 new SourceStream(
                     stream,
                     i => null,
-                    new ReaderOptions { LeaveStreamOpen = leaveOpen }
+                    ReaderOptions.ForExternalStream with
+                    {
+                        LeaveStreamOpen = leaveOpen,
+                    }
                 )
         );
     }

--- a/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
@@ -57,7 +57,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         await using (
             var archive2 = await TarArchive.OpenAsyncArchive(
                 new AsyncOnlyStream(File.OpenRead(unmodified)),
-                new ReaderOptions() { LeaveStreamOpen = false }
+                ReaderOptions.ForExternalStream.WithLeaveStreamOpen(false)
             )
         )
         {
@@ -115,7 +115,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         await using (
             var archive2 = await TarArchive.OpenAsyncArchive(
                 new AsyncOnlyStream(File.OpenRead(unmodified)),
-                new ReaderOptions() { LeaveStreamOpen = false }
+                ReaderOptions.ForExternalStream.WithLeaveStreamOpen(false)
             )
         )
         {
@@ -213,7 +213,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         }
         using (var inputMemory = new MemoryStream(mstm.ToArray()))
         {
-            var tropt = new ReaderOptions { ArchiveEncoding = enc };
+            var tropt = ReaderOptions.ForExternalStream with { ArchiveEncoding = enc };
             await using (
                 var tr = await ReaderFactory.OpenAsyncReader(
                     new AsyncOnlyStream(inputMemory),

--- a/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
@@ -213,7 +213,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         }
         using (var inputMemory = new MemoryStream(mstm.ToArray()))
         {
-            var tropt = ReaderOptions.ForExternalStream with { ArchiveEncoding = enc };
+            var tropt = ReaderOptions.ForExternalStream.WithArchiveEncoding(enc);
             await using (
                 var tr = await ReaderFactory.OpenAsyncReader(
                     new AsyncOnlyStream(inputMemory),

--- a/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
@@ -262,7 +262,7 @@ public class TarArchiveTests : ArchiveTests
         }
         using (var inputMemory = new MemoryStream(mstm.ToArray()))
         {
-            var tropt = ReaderOptions.ForExternalStream with { ArchiveEncoding = enc };
+            var tropt = ReaderOptions.ForExternalStream.WithArchiveEncoding(enc);
             using (var tr = TarReader.OpenReader(inputMemory, tropt))
             {
                 while (tr.MoveToNextEntry())

--- a/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
@@ -262,7 +262,7 @@ public class TarArchiveTests : ArchiveTests
         }
         using (var inputMemory = new MemoryStream(mstm.ToArray()))
         {
-            var tropt = new ReaderOptions { ArchiveEncoding = enc };
+            var tropt = ReaderOptions.ForExternalStream with { ArchiveEncoding = enc };
             using (var tr = TarReader.OpenReader(inputMemory, tropt))
             {
                 while (tr.MoveToNextEntry())

--- a/tests/SharpCompress.Test/TestBase.cs
+++ b/tests/SharpCompress.Test/TestBase.cs
@@ -255,7 +255,7 @@ public class TestBase : IAsyncDisposable
 
     protected void CompareArchivesByPath(string file1, string file2, Encoding? encoding = null)
     {
-        var readerOptions = ReaderOptions.ForExternalStream with { LeaveStreamOpen = false };
+        var readerOptions = ReaderOptions.ForExternalStream.WithLeaveStreamOpen(false);
         readerOptions.ArchiveEncoding.Default = encoding ?? Encoding.Default;
 
         //don't compare the order.  OS X reads files from the file system in a different order therefore makes the archive ordering different

--- a/tests/SharpCompress.Test/TestBase.cs
+++ b/tests/SharpCompress.Test/TestBase.cs
@@ -255,7 +255,7 @@ public class TestBase : IAsyncDisposable
 
     protected void CompareArchivesByPath(string file1, string file2, Encoding? encoding = null)
     {
-        var readerOptions = new ReaderOptions { LeaveStreamOpen = false };
+        var readerOptions = ReaderOptions.ForExternalStream with { LeaveStreamOpen = false };
         readerOptions.ArchiveEncoding.Default = encoding ?? Encoding.Default;
 
         //don't compare the order.  OS X reads files from the file system in a different order therefore makes the archive ordering different

--- a/tests/SharpCompress.Test/WriterTests.cs
+++ b/tests/SharpCompress.Test/WriterTests.cs
@@ -39,7 +39,7 @@ public class WriterTests : TestBase
 
         using (Stream stream = File.OpenRead(Path.Combine(SCRATCH2_FILES_PATH, archive)))
         {
-            var readerOptions = new ReaderOptions();
+            var readerOptions = ReaderOptions.ForExternalStream;
 
             readerOptions.ArchiveEncoding.Default = encoding ?? Encoding.Default;
 
@@ -90,7 +90,7 @@ public class WriterTests : TestBase
 
         using (Stream stream = File.OpenRead(Path.Combine(SCRATCH2_FILES_PATH, archive)))
         {
-            var readerOptions = new ReaderOptions();
+            var readerOptions = ReaderOptions.ForExternalStream;
 
             readerOptions.ArchiveEncoding.Default = encoding ?? Encoding.Default;
 

--- a/tests/SharpCompress.Test/Zip/Zip64AsyncTests.cs
+++ b/tests/SharpCompress.Test/Zip/Zip64AsyncTests.cs
@@ -201,7 +201,10 @@ public class Zip64AsyncTests : WriterTests
         {
             await using var rd = await ReaderFactory.OpenAsyncReader(
                 new AsyncOnlyStream(fs),
-                new ReaderOptions { LookForHeader = false }
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = false,
+                }
             );
             while (await rd.MoveToNextEntryAsync())
             {

--- a/tests/SharpCompress.Test/Zip/Zip64Tests.cs
+++ b/tests/SharpCompress.Test/Zip/Zip64Tests.cs
@@ -182,7 +182,15 @@ public class Zip64Tests : WriterTests
         long size = 0;
         IEntry? prev = null;
         using (var fs = File.OpenRead(filename))
-        using (var rd = ZipReader.OpenReader(fs, new ReaderOptions { LookForHeader = false }))
+        using (
+            var rd = ZipReader.OpenReader(
+                fs,
+                ReaderOptions.ForExternalStream with
+                {
+                    LookForHeader = false,
+                }
+            )
+        )
         {
             while (rd.MoveToNextEntry())
             {

--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -622,7 +622,7 @@ public class ZipArchiveTests : ArchiveTests
     {
         using var reader = ZipArchive.OpenArchive(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.zip64.zip"),
-            ReaderOptions.ForExternalStream with
+            ReaderOptions.ForFilePath with
             {
                 Password = "test",
             }

--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -465,7 +465,10 @@ public class ZipArchiveTests : ArchiveTests
         using (
             var reader = ZipArchive.OpenArchive(
                 Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"),
-                new ReaderOptions { Password = "test" }
+                ReaderOptions.ForFilePath with
+                {
+                    Password = "test",
+                }
             )
         )
         {
@@ -482,7 +485,10 @@ public class ZipArchiveTests : ArchiveTests
     {
         using var reader = ZipArchive.OpenArchive(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES2.zip"),
-            new ReaderOptions { Password = "test" }
+            ReaderOptions.ForFilePath with
+            {
+                Password = "test",
+            }
         );
         foreach (var entry in reader.Entries.Where(x => !x.IsDirectory))
         {
@@ -499,7 +505,10 @@ public class ZipArchiveTests : ArchiveTests
         // Test that WinZip AES encrypted entries correctly report their compression type
         using var deflateArchive = ZipArchive.OpenArchive(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip"),
-            new ReaderOptions { Password = "test" }
+            ReaderOptions.ForFilePath with
+            {
+                Password = "test",
+            }
         );
         foreach (var entry in deflateArchive.Entries.Where(x => !x.IsDirectory))
         {
@@ -509,7 +518,10 @@ public class ZipArchiveTests : ArchiveTests
 
         using var lzmaArchive = ZipArchive.OpenArchive(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.lzma.WinzipAES.zip"),
-            new ReaderOptions { Password = "test" }
+            ReaderOptions.ForFilePath with
+            {
+                Password = "test",
+            }
         );
         foreach (var entry in lzmaArchive.Entries.Where(x => !x.IsDirectory))
         {
@@ -523,7 +535,10 @@ public class ZipArchiveTests : ArchiveTests
     {
         using var archive = ZipArchive.OpenArchive(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.zstd.WinzipAES.mixed.zip"),
-            new ReaderOptions { Password = "test" }
+            ReaderOptions.ForFilePath with
+            {
+                Password = "test",
+            }
         );
 
         VerifyMixedZstandardArchive(archive);
@@ -535,7 +550,13 @@ public class ZipArchiveTests : ArchiveTests
         using var stream = File.OpenRead(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.zstd.WinzipAES.mixed.zip")
         );
-        using var archive = ZipArchive.OpenArchive(stream, new ReaderOptions { Password = "test" });
+        using var archive = ZipArchive.OpenArchive(
+            stream,
+            ReaderOptions.ForExternalStream with
+            {
+                Password = "test",
+            }
+        );
 
         VerifyMixedZstandardArchive(archive);
     }
@@ -571,7 +592,10 @@ public class ZipArchiveTests : ArchiveTests
         // Test that Pkware encrypted entries correctly report their compression type
         using var deflateArchive = ZipArchive.OpenArchive(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.pkware.zip"),
-            new ReaderOptions { Password = "test" }
+            ReaderOptions.ForFilePath with
+            {
+                Password = "test",
+            }
         );
         foreach (var entry in deflateArchive.Entries.Where(x => !x.IsDirectory))
         {
@@ -581,7 +605,10 @@ public class ZipArchiveTests : ArchiveTests
 
         using var bzip2Archive = ZipArchive.OpenArchive(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"),
-            new ReaderOptions { Password = "test" }
+            ReaderOptions.ForFilePath with
+            {
+                Password = "test",
+            }
         );
         foreach (var entry in bzip2Archive.Entries.Where(x => !x.IsDirectory))
         {
@@ -595,7 +622,10 @@ public class ZipArchiveTests : ArchiveTests
     {
         using var reader = ZipArchive.OpenArchive(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.zip64.zip"),
-            new ReaderOptions { Password = "test" }
+            ReaderOptions.ForExternalStream with
+            {
+                Password = "test",
+            }
         );
         var isComplete = reader.IsComplete;
         Assert.Equal(1, reader.Volumes.Count());
@@ -611,7 +641,10 @@ public class ZipArchiveTests : ArchiveTests
         using (
             var reader = ZipArchive.OpenArchive(
                 Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"),
-                new ReaderOptions { Password = "test" }
+                ReaderOptions.ForFilePath with
+                {
+                    Password = "test",
+                }
             )
         )
         {
@@ -673,7 +706,10 @@ public class ZipArchiveTests : ArchiveTests
         using var fileStream = File.OpenRead(zipFile);
         using var archive = ArchiveFactory.OpenArchive(
             fileStream,
-            new ReaderOptions { Password = "12345678" }
+            ReaderOptions.ForExternalStream with
+            {
+                Password = "12345678",
+            }
         );
         var entries = archive.Entries.Where(entry => !entry.IsDirectory);
         foreach (var entry in entries)
@@ -881,7 +917,7 @@ public class ZipArchiveTests : ArchiveTests
         {
             var reader = ReaderFactory.OpenReader(
                 stream,
-                new ReaderOptions
+                ReaderOptions.ForExternalStream with
                 {
                     ArchiveEncoding = new ArchiveEncoding
                     {
@@ -896,7 +932,7 @@ public class ZipArchiveTests : ArchiveTests
         {
             var reader = ReaderFactory.OpenReader(
                 stream,
-                new ReaderOptions
+                ReaderOptions.ForExternalStream with
                 {
                     ArchiveEncoding = new ArchiveEncoding
                     {

--- a/tests/SharpCompress.Test/Zip/ZipReaderAsyncTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipReaderAsyncTests.cs
@@ -143,7 +143,10 @@ public class ZipReaderAsyncTests : ReaderTests
         using (
             IReader baseReader = ZipReader.OpenReader(
                 stream,
-                new ReaderOptions { Password = "test" }
+                ReaderOptions.ForExternalStream with
+                {
+                    Password = "test",
+                }
             )
         )
         {
@@ -169,7 +172,7 @@ public class ZipReaderAsyncTests : ReaderTests
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(
                 new AsyncOnlyStream(stream),
-                new ReaderOptions().WithLeaveStreamOpen(false)
+                ReaderOptions.ForExternalStream.WithLeaveStreamOpen(false)
             )
         )
         {
@@ -215,7 +218,10 @@ public class ZipReaderAsyncTests : ReaderTests
             using (
                 IReader baseReader = ZipReader.OpenReader(
                     stream,
-                    new ReaderOptions { Password = "test" }
+                    ReaderOptions.ForExternalStream with
+                    {
+                        Password = "test",
+                    }
                 )
             )
             {
@@ -244,7 +250,10 @@ public class ZipReaderAsyncTests : ReaderTests
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(
                 stream,
-                new ReaderOptions { Password = "test" }
+                ReaderOptions.ForExternalStream with
+                {
+                    Password = "test",
+                }
             )
         )
         {
@@ -272,7 +281,10 @@ public class ZipReaderAsyncTests : ReaderTests
         await using (
             var reader = await ReaderFactory.OpenAsyncReader(
                 stream,
-                new ReaderOptions { Password = "test" }
+                ReaderOptions.ForExternalStream with
+                {
+                    Password = "test",
+                }
             )
         )
         {

--- a/tests/SharpCompress.Test/Zip/ZipReaderTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipReaderTests.cs
@@ -129,7 +129,15 @@ public class ZipReaderTests : ReaderTests
         using (
             Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Zip.bzip2.pkware.zip"))
         )
-        using (var reader = ZipReader.OpenReader(stream, new ReaderOptions { Password = "test" }))
+        using (
+            var reader = ZipReader.OpenReader(
+                stream,
+                ReaderOptions.ForExternalStream with
+                {
+                    Password = "test",
+                }
+            )
+        )
         {
             while (reader.MoveToNextEntry())
             {
@@ -152,7 +160,7 @@ public class ZipReaderTests : ReaderTests
         using (
             var reader = ReaderFactory.OpenReader(
                 stream,
-                new ReaderOptions().WithLeaveStreamOpen(false)
+                ReaderOptions.ForExternalStream.WithLeaveStreamOpen(false)
             )
         )
         {
@@ -194,7 +202,13 @@ public class ZipReaderTests : ReaderTests
                 )
             )
             using (
-                var reader = ZipReader.OpenReader(stream, new ReaderOptions { Password = "test" })
+                var reader = ZipReader.OpenReader(
+                    stream,
+                    ReaderOptions.ForExternalStream with
+                    {
+                        Password = "test",
+                    }
+                )
             )
             {
                 while (reader.MoveToNextEntry())
@@ -217,7 +231,15 @@ public class ZipReaderTests : ReaderTests
                 Path.Combine(TEST_ARCHIVES_PATH, "Zip.deflate.WinzipAES.zip")
             )
         )
-        using (var reader = ZipReader.OpenReader(stream, new ReaderOptions { Password = "test" }))
+        using (
+            var reader = ZipReader.OpenReader(
+                stream,
+                ReaderOptions.ForExternalStream with
+                {
+                    Password = "test",
+                }
+            )
+        )
         {
             while (reader.MoveToNextEntry())
             {
@@ -236,7 +258,15 @@ public class ZipReaderTests : ReaderTests
     {
         var count = 0;
         using (Stream stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "zipcrypto.zip")))
-        using (var reader = ZipReader.OpenReader(stream, new ReaderOptions { Password = "test" }))
+        using (
+            var reader = ZipReader.OpenReader(
+                stream,
+                ReaderOptions.ForExternalStream with
+                {
+                    Password = "test",
+                }
+            )
+        )
         {
             while (reader.MoveToNextEntry())
             {
@@ -402,7 +432,10 @@ public class ZipReaderTests : ReaderTests
     {
         using var reader = ReaderFactory.OpenReader(
             Path.Combine(TEST_ARCHIVES_PATH, "Zip.none.encrypted.zip"),
-            new ReaderOptions { Password = "test" }
+            ReaderOptions.ForFilePath with
+            {
+                Password = "test",
+            }
         );
         reader.MoveToNextEntry();
         Assert.Equal("first.txt", reader.Entry.Key);

--- a/tests/SharpCompress.Test/Zip/ZipShortReadTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipShortReadTests.cs
@@ -99,7 +99,10 @@ public class ZipShortReadTests : ReaderTests
         var names = new List<string>();
         using var reader = ReaderFactory.OpenReader(
             stream,
-            new ReaderOptions { LeaveStreamOpen = true }
+            ReaderOptions.ForExternalStream with
+            {
+                LeaveStreamOpen = true,
+            }
         );
 
         while (reader.MoveToNextEntry())


### PR DESCRIPTION
This pull request makes significant improvements to how `ReaderOptions` are handled throughout the codebase, aiming for more consistent and explicit defaults, especially when dealing with file paths and external streams. It also simplifies the symbolic link extraction logic and removes unnecessary default handlers. The changes should improve maintainability, reduce potential resource leaks, and clarify intent when opening archives or extracting files.

Key changes include:

**ReaderOptions Consistency and Defaults**

* Standardized the defaulting of `ReaderOptions` across archive and reader factory methods: now, `ReaderOptions.ForFilePath` is used when opening archives from file paths, and `ReaderOptions.ForExternalStream` is used for streams, replacing previous ad-hoc or implicit defaults. This affects many archive and reader classes, including RAR, ZIP, ACE, ARC, ARJ, GZip, LZW, and TAR. [[1]](diffhunk://#diff-22b8bc5a3d713f2404d058a5fddfba4cec7f175d67a00be88fe4f96da36f7d18L40-R40) [[2]](diffhunk://#diff-50da048b83ebc76ae4fa804e559576e2f212b170e66b01b0b15d199aef1837c7L36-R40) [[3]](diffhunk://#diff-c917224df3ff936ef99480cb13f4d79d64db4bac3abba0c377b716a24c209c69L54-R54) [[4]](diffhunk://#diff-c917224df3ff936ef99480cb13f4d79d64db4bac3abba0c377b716a24c209c69L69-R69) [[5]](diffhunk://#diff-33297086ebc4be1ea2c10cf7c86afaddf6c71db9e56d7a4b9df97bd6db7dafa5L18-L29) [[6]](diffhunk://#diff-c4be5588df81b930e092a9c2309ec58c45831fe3a5faab2a86305a1fd5418740L48-R48) [[7]](diffhunk://#diff-fdeace22df51f39be3461b03ffceb3ae6b63a006fa2f3428c3a4df6728354dc8L89-R89) [[8]](diffhunk://#diff-427819bd6e62926e10f46ac47acd569eab506b83e9d46bb3d729779a931238a6L320-R320) [[9]](diffhunk://#diff-427819bd6e62926e10f46ac47acd569eab506b83e9d46bb3d729779a931238a6L353-R353) [[10]](diffhunk://#diff-36c5e206881333661f2ea6e09a848bf6cb5584a4d84d1c6cbb55d507e13a70e9L23-R23) [[11]](diffhunk://#diff-36c5e206881333661f2ea6e09a848bf6cb5584a4d84d1c6cbb55d507e13a70e9L35-R35) [[12]](diffhunk://#diff-36c5e206881333661f2ea6e09a848bf6cb5584a4d84d1c6cbb55d507e13a70e9L65-R65) [[13]](diffhunk://#diff-b89d27bb10d3d36ecb43d6adbefa80131674b22c28b502dcb3b8a70105ab4a6dL28-R28) [[14]](diffhunk://#diff-63cfd5595cd2ad29617248bf92035208f8e33465e1d5f6ab81f6f1e1a9a09e9aL35-R35) [[15]](diffhunk://#diff-63cfd5595cd2ad29617248bf92035208f8e33465e1d5f6ab81f6f1e1a9a09e9aL47-R47) [[16]](diffhunk://#diff-1a36d82da139bc01740b501de6967d79d1ffc4a0eb56a58891e87365888ece57L59-R59) [[17]](diffhunk://#diff-ba87c31176443e1722f05a6cbc941d5f23d5408c6b9bafa857b72b090d18237cL59-R59) [[18]](diffhunk://#diff-df9100aa68bb12fa74c9d9887fa55e104337a48cc9dc7470f61f02ead44d13d2L75-R75) [[19]](diffhunk://#diff-df9100aa68bb12fa74c9d9887fa55e104337a48cc9dc7470f61f02ead44d13d2L87-R87)

* Updated constructors and internal logic to require non-null `ReaderOptions`, removing unnecessary null checks and ensuring explicit intent when creating volumes. [[1]](diffhunk://#diff-e1a63a7812ff91a285c0001c763aab786e0569692473065f221e1a5ec08e04b8L14-R17) [[2]](diffhunk://#diff-fefadbdc57a1876642fa1af617c84dc2f8c054f41b0153df1f66fc6624ee760dL8-R12) [[3]](diffhunk://#diff-80bc261b9f89ebc28aaa829d1da8fbe0ce1668f8982c738528a6eec219ebee86L8-R12) [[4]](diffhunk://#diff-628683fbef185403c5464b90bb2562672e3d38873b30b0d66c1fc7a435332426L43-R43)

**Resource Management Improvements**

* Replaced the use of C# record `with` expressions for setting `LeaveStreamOpen` with a new `WithLeaveStreamOpen` method, making the intent clearer and avoiding unnecessary object creation. [[1]](diffhunk://#diff-fefadbdc57a1876642fa1af617c84dc2f8c054f41b0153df1f66fc6624ee760dL8-R12) [[2]](diffhunk://#diff-80bc261b9f89ebc28aaa829d1da8fbe0ce1668f8982c738528a6eec219ebee86L8-R12) [[3]](diffhunk://#diff-33297086ebc4be1ea2c10cf7c86afaddf6c71db9e56d7a4b9df97bd6db7dafa5L18-L29)

**Symbolic Link Extraction Simplification**

* Simplified the symbolic link extraction logic in `ExtractionMethods` by removing the default symbolic link handler and only invoking a handler if one is provided. This reduces unexpected side effects (like logging) and clarifies behavior. [[1]](diffhunk://#diff-051fe06f09a5869ac520af5fd29e6f52193d414394e870cf093230587b6d8938L93-R93) [[2]](diffhunk://#diff-4fb897fa3b73542bd45300fcf5aa1784029a1e5c0f17e0352559279c44ff0931L102-R102) [[3]](diffhunk://#diff-c039d222cbe3e827d844a6543e03fc0d1815484a851496ec8e89e9b52ae56adaL105-L114)

**Minor Codebase Cleanups**

* Refactored constructors for brevity and clarity, such as using expression-bodied constructors for `ExtractionOptions`.

These changes collectively improve the clarity, safety, and maintainability of archive handling and extraction throughout the codebase.