### PR TITLE
Enforce seekable, readable and writable on streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ profiler-snapshots/
 .DS_Store
 *.snupkg
 benchmark-results/
+/.opencode

--- a/src/SharpCompress/Archives/ArchiveFactory.Async.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.Async.cs
@@ -92,14 +92,12 @@ public static partial class ArchiveFactory
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        streams.NotNull(nameof(streams));
-        var streamsArray = streams;
+        var streamsArray = streams.RequireReadable();
+        streamsArray.RequireSeekable();
         if (streamsArray.Count == 0)
         {
             throw new ArchiveOperationException("No streams");
         }
-
-        streamsArray.RequireSeekable();
 
         var firstStream = streamsArray[0];
         if (streamsArray.Count == 1)

--- a/src/SharpCompress/Archives/ArchiveFactory.Async.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.Async.cs
@@ -99,6 +99,8 @@ public static partial class ArchiveFactory
             throw new ArchiveOperationException("No streams");
         }
 
+        EnsureSeekable(streamsArray);
+
         var firstStream = streamsArray[0];
         if (streamsArray.Count == 1)
         {

--- a/src/SharpCompress/Archives/ArchiveFactory.Async.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.Async.cs
@@ -99,7 +99,7 @@ public static partial class ArchiveFactory
             throw new ArchiveOperationException("No streams");
         }
 
-        EnsureSeekable(streamsArray);
+        streamsArray.RequireSeekable();
 
         var firstStream = streamsArray[0];
         if (streamsArray.Count == 1)
@@ -145,11 +145,8 @@ public static partial class ArchiveFactory
     )
         where T : IFactory
     {
-        stream.NotNull(nameof(stream));
-        if (!stream.CanRead || !stream.CanSeek)
-        {
-            throw new ArgumentException("Stream should be readable and seekable");
-        }
+        stream.RequireReadable();
+        stream.RequireSeekable();
 
         var factories = Factory.Factories.OfType<T>();
 

--- a/src/SharpCompress/Archives/ArchiveFactory.Async.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.Async.cs
@@ -92,13 +92,7 @@ public static partial class ArchiveFactory
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var streamsArray = streams.RequireReadable();
-        streamsArray.RequireSeekable();
-        if (streamsArray.Count == 0)
-        {
-            throw new ArchiveOperationException("No streams");
-        }
-
+        var streamsArray = streams.RequireReadable().RequireSeekable().ToList();
         var firstStream = streamsArray[0];
         if (streamsArray.Count == 1)
         {

--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -73,14 +73,12 @@ public static partial class ArchiveFactory
 
     public static IArchive OpenArchive(IReadOnlyList<Stream> streams, ReaderOptions? options = null)
     {
-        streams.NotNull(nameof(streams));
-        var streamsArray = streams;
+        var streamsArray = streams.RequireReadable();
+        streamsArray.RequireSeekable();
         if (streamsArray.Count == 0)
         {
             throw new ArchiveOperationException("No streams");
         }
-
-        streamsArray.RequireSeekable();
 
         var firstStream = streamsArray[0];
         if (streamsArray.Count == 1)

--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -13,6 +13,22 @@ namespace SharpCompress.Archives;
 
 public static partial class ArchiveFactory
 {
+    internal static void EnsureSeekable(Stream stream)
+    {
+        if (stream is null || !stream.CanSeek)
+        {
+            throw new ArgumentException("Stream must be seekable", nameof(stream));
+        }
+    }
+
+    internal static void EnsureSeekable(IReadOnlyList<Stream> streams)
+    {
+        foreach (var stream in streams)
+        {
+            EnsureSeekable(stream);
+        }
+    }
+
     public static IArchive OpenArchive(Stream stream, ReaderOptions? readerOptions = null)
     {
         readerOptions ??= ReaderOptions.ForExternalStream;
@@ -79,6 +95,8 @@ public static partial class ArchiveFactory
         {
             throw new ArchiveOperationException("No streams");
         }
+
+        EnsureSeekable(streamsArray);
 
         var firstStream = streamsArray[0];
         if (streamsArray.Count == 1)

--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -13,22 +13,6 @@ namespace SharpCompress.Archives;
 
 public static partial class ArchiveFactory
 {
-    internal static void EnsureSeekable(Stream stream)
-    {
-        if (stream is null || !stream.CanSeek)
-        {
-            throw new ArgumentException("Stream must be seekable", nameof(stream));
-        }
-    }
-
-    internal static void EnsureSeekable(IReadOnlyList<Stream> streams)
-    {
-        foreach (var stream in streams)
-        {
-            EnsureSeekable(stream);
-        }
-    }
-
     public static IArchive OpenArchive(Stream stream, ReaderOptions? readerOptions = null)
     {
         readerOptions ??= ReaderOptions.ForExternalStream;
@@ -96,7 +80,7 @@ public static partial class ArchiveFactory
             throw new ArchiveOperationException("No streams");
         }
 
-        EnsureSeekable(streamsArray);
+        streamsArray.RequireSeekable();
 
         var firstStream = streamsArray[0];
         if (streamsArray.Count == 1)
@@ -139,11 +123,8 @@ public static partial class ArchiveFactory
     public static T FindFactory<T>(Stream stream)
         where T : IFactory
     {
-        stream.NotNull(nameof(stream));
-        if (!stream.CanRead || !stream.CanSeek)
-        {
-            throw new ArgumentException("Stream should be readable and seekable");
-        }
+        stream.RequireReadable();
+        stream.RequireSeekable();
 
         var factories = Factory.Factories.OfType<T>();
 
@@ -178,12 +159,8 @@ public static partial class ArchiveFactory
     public static bool IsArchive(Stream stream, out ArchiveType? type)
     {
         type = null;
-        stream.NotNull(nameof(stream));
-
-        if (!stream.CanRead || !stream.CanSeek)
-        {
-            throw new ArgumentException("Stream should be readable and seekable");
-        }
+        stream.RequireReadable();
+        stream.RequireSeekable();
 
         var startPosition = stream.Position;
 
@@ -217,12 +194,8 @@ public static partial class ArchiveFactory
         CancellationToken cancellationToken = default
     )
     {
-        stream.NotNull(nameof(stream));
-
-        if (!stream.CanRead || !stream.CanSeek)
-        {
-            throw new ArgumentException("Stream should be readable and seekable");
-        }
+        stream.RequireReadable();
+        stream.RequireSeekable();
 
         var startPosition = stream.Position;
 

--- a/src/SharpCompress/Archives/ArchiveFactory.cs
+++ b/src/SharpCompress/Archives/ArchiveFactory.cs
@@ -73,8 +73,7 @@ public static partial class ArchiveFactory
 
     public static IArchive OpenArchive(IReadOnlyList<Stream> streams, ReaderOptions? options = null)
     {
-        var streamsArray = streams.RequireReadable();
-        streamsArray.RequireSeekable();
+        var streamsArray = streams.RequireReadable().RequireSeekable().ToList();
         if (streamsArray.Count == 0)
         {
             throw new ArchiveOperationException("No streams");

--- a/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
@@ -76,8 +76,7 @@ public partial class GZipArchive
         ReaderOptions? readerOptions = null
     )
     {
-        var strms = streams.RequireReadable();
-        strms.RequireSeekable();
+        var strms = streams.RequireReadable().RequireSeekable().ToList();
         return new GZipArchive(
             new SourceStream(
                 strms[0],

--- a/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
@@ -77,7 +77,7 @@ public partial class GZipArchive
     )
     {
         streams.NotNull(nameof(streams));
-        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
+        streams.RequireSeekable();
         var strms = streams;
         return new GZipArchive(
             new SourceStream(
@@ -93,12 +93,7 @@ public partial class GZipArchive
         ReaderOptions? readerOptions = null
     )
     {
-        stream.NotNull(nameof(stream));
-
-        if (stream is not { CanSeek: true })
-        {
-            throw new ArgumentException("Stream must be seekable", nameof(stream));
-        }
+        stream.RequireSeekable();
 
         return new GZipArchive(
             new SourceStream(stream, _ => null, readerOptions ?? ReaderOptions.ForExternalStream)

--- a/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
@@ -77,6 +77,7 @@ public partial class GZipArchive
     )
     {
         streams.NotNull(nameof(streams));
+        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
         var strms = streams;
         return new GZipArchive(
             new SourceStream(

--- a/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchive.Factory.cs
@@ -76,9 +76,8 @@ public partial class GZipArchive
         ReaderOptions? readerOptions = null
     )
     {
-        streams.NotNull(nameof(streams));
-        streams.RequireSeekable();
-        var strms = streams;
+        var strms = streams.RequireReadable();
+        strms.RequireSeekable();
         return new GZipArchive(
             new SourceStream(
                 strms[0],
@@ -93,6 +92,7 @@ public partial class GZipArchive
         ReaderOptions? readerOptions = null
     )
     {
+        stream.RequireReadable();
         stream.RequireSeekable();
 
         return new GZipArchive(

--- a/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
@@ -58,6 +58,7 @@ public partial class RarArchive
 
     public static IRarArchive OpenArchive(Stream stream, ReaderOptions? readerOptions = null)
     {
+        stream.RequireReadable();
         stream.RequireSeekable();
 
         return new RarArchive(
@@ -86,9 +87,8 @@ public partial class RarArchive
         ReaderOptions? readerOptions = null
     )
     {
-        streams.NotNull(nameof(streams));
-        streams.RequireSeekable();
-        var strms = streams;
+        var strms = streams.RequireReadable();
+        strms.RequireSeekable();
         return new RarArchive(
             new SourceStream(
                 strms[0],

--- a/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
@@ -87,8 +87,7 @@ public partial class RarArchive
         ReaderOptions? readerOptions = null
     )
     {
-        var strms = streams.RequireReadable();
-        strms.RequireSeekable();
+        var strms = streams.RequireReadable().RequireSeekable().ToList();
         return new RarArchive(
             new SourceStream(
                 strms[0],

--- a/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
@@ -92,6 +92,7 @@ public partial class RarArchive
     )
     {
         streams.NotNull(nameof(streams));
+        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
         var strms = streams;
         return new RarArchive(
             new SourceStream(

--- a/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Rar/RarArchive.Factory.cs
@@ -58,12 +58,7 @@ public partial class RarArchive
 
     public static IRarArchive OpenArchive(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
-
-        if (stream is not { CanSeek: true })
-        {
-            throw new ArgumentException("Stream must be seekable", nameof(stream));
-        }
+        stream.RequireSeekable();
 
         return new RarArchive(
             new SourceStream(stream, _ => null, readerOptions ?? ReaderOptions.ForExternalStream)
@@ -92,7 +87,7 @@ public partial class RarArchive
     )
     {
         streams.NotNull(nameof(streams));
-        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
+        streams.RequireSeekable();
         var strms = streams;
         return new RarArchive(
             new SourceStream(

--- a/src/SharpCompress/Archives/SevenZip/SevenZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/SevenZip/SevenZipArchive.Factory.cs
@@ -71,8 +71,7 @@ public partial class SevenZipArchive
         ReaderOptions? readerOptions = null
     )
     {
-        var strms = streams.RequireReadable();
-        strms.RequireSeekable();
+        var strms = streams.RequireReadable().RequireSeekable().ToList();
         return new SevenZipArchive(
             new SourceStream(
                 strms[0],

--- a/src/SharpCompress/Archives/SevenZip/SevenZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/SevenZip/SevenZipArchive.Factory.cs
@@ -72,6 +72,7 @@ public partial class SevenZipArchive
     )
     {
         streams.NotNull(nameof(streams));
+        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
         var strms = streams;
         return new SevenZipArchive(
             new SourceStream(

--- a/src/SharpCompress/Archives/SevenZip/SevenZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/SevenZip/SevenZipArchive.Factory.cs
@@ -71,9 +71,8 @@ public partial class SevenZipArchive
         ReaderOptions? readerOptions = null
     )
     {
-        streams.NotNull(nameof(streams));
-        streams.RequireSeekable();
-        var strms = streams;
+        var strms = streams.RequireReadable();
+        strms.RequireSeekable();
         return new SevenZipArchive(
             new SourceStream(
                 strms[0],
@@ -85,6 +84,7 @@ public partial class SevenZipArchive
 
     public static IArchive OpenArchive(Stream stream, ReaderOptions? readerOptions = null)
     {
+        stream.RequireReadable();
         stream.RequireSeekable();
 
         return new SevenZipArchive(

--- a/src/SharpCompress/Archives/SevenZip/SevenZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/SevenZip/SevenZipArchive.Factory.cs
@@ -72,7 +72,7 @@ public partial class SevenZipArchive
     )
     {
         streams.NotNull(nameof(streams));
-        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
+        streams.RequireSeekable();
         var strms = streams;
         return new SevenZipArchive(
             new SourceStream(
@@ -85,12 +85,7 @@ public partial class SevenZipArchive
 
     public static IArchive OpenArchive(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
-
-        if (stream is not { CanSeek: true })
-        {
-            throw new ArgumentException("Stream must be seekable", nameof(stream));
-        }
+        stream.RequireSeekable();
 
         return new SevenZipArchive(
             new SourceStream(stream, _ => null, readerOptions ?? ReaderOptions.ForExternalStream)

--- a/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
@@ -66,8 +66,7 @@ public partial class TarArchive
         ReaderOptions? readerOptions = null
     )
     {
-        var strms = streams.RequireReadable();
-        strms.RequireSeekable();
+        var strms = streams.RequireReadable().RequireSeekable().ToList();
         var sourceStream = new SourceStream(
             strms[0],
             i => i < strms.Count ? strms[i] : null,
@@ -155,8 +154,7 @@ public partial class TarArchive
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var strms = streams.RequireReadable();
-        strms.RequireSeekable();
+        var strms = streams.RequireReadable().RequireSeekable().ToList();
         var sourceStream = new SourceStream(
             strms[0],
             i => i < strms.Count ? strms[i] : null,

--- a/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
@@ -67,7 +67,7 @@ public partial class TarArchive
     )
     {
         streams.NotNull(nameof(streams));
-        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
+        streams.RequireSeekable();
         var strms = streams;
         var sourceStream = new SourceStream(
             strms[0],
@@ -87,12 +87,7 @@ public partial class TarArchive
         ReaderOptions? readerOptions = null
     )
     {
-        stream.NotNull(nameof(stream));
-
-        if (stream is not { CanSeek: true })
-        {
-            throw new ArgumentException("Stream must be seekable", nameof(stream));
-        }
+        stream.RequireSeekable();
 
         return OpenArchive([stream], readerOptions);
     }
@@ -104,10 +99,7 @@ public partial class TarArchive
     )
     {
         stream.NotNull(nameof(stream));
-        if (!stream.CanSeek)
-        {
-            throw new ArgumentException("Stream must be seekable", nameof(stream));
-        }
+        stream.RequireSeekable();
         var sourceStream = new SourceStream(
             stream,
             i => null,
@@ -164,7 +156,7 @@ public partial class TarArchive
     {
         cancellationToken.ThrowIfCancellationRequested();
         streams.NotNull(nameof(streams));
-        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
+        streams.RequireSeekable();
         var strms = streams;
         var sourceStream = new SourceStream(
             strms[0],

--- a/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
@@ -66,9 +66,8 @@ public partial class TarArchive
         ReaderOptions? readerOptions = null
     )
     {
-        streams.NotNull(nameof(streams));
-        streams.RequireSeekable();
-        var strms = streams;
+        var strms = streams.RequireReadable();
+        strms.RequireSeekable();
         var sourceStream = new SourceStream(
             strms[0],
             i => i < strms.Count ? strms[i] : null,
@@ -87,6 +86,7 @@ public partial class TarArchive
         ReaderOptions? readerOptions = null
     )
     {
+        stream.RequireReadable();
         stream.RequireSeekable();
 
         return OpenArchive([stream], readerOptions);
@@ -98,7 +98,7 @@ public partial class TarArchive
         CancellationToken cancellationToken = default
     )
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         stream.RequireSeekable();
         var sourceStream = new SourceStream(
             stream,
@@ -155,9 +155,8 @@ public partial class TarArchive
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        streams.NotNull(nameof(streams));
-        streams.RequireSeekable();
-        var strms = streams;
+        var strms = streams.RequireReadable();
+        strms.RequireSeekable();
         var sourceStream = new SourceStream(
             strms[0],
             i => i < strms.Count ? strms[i] : null,

--- a/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Tar/TarArchive.Factory.cs
@@ -67,6 +67,7 @@ public partial class TarArchive
     )
     {
         streams.NotNull(nameof(streams));
+        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
         var strms = streams;
         var sourceStream = new SourceStream(
             strms[0],
@@ -103,6 +104,10 @@ public partial class TarArchive
     )
     {
         stream.NotNull(nameof(stream));
+        if (!stream.CanSeek)
+        {
+            throw new ArgumentException("Stream must be seekable", nameof(stream));
+        }
         var sourceStream = new SourceStream(
             stream,
             i => null,
@@ -159,6 +164,7 @@ public partial class TarArchive
     {
         cancellationToken.ThrowIfCancellationRequested();
         streams.NotNull(nameof(streams));
+        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
         var strms = streams;
         var sourceStream = new SourceStream(
             strms[0],

--- a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
@@ -68,6 +68,7 @@ public partial class ZipArchive
     )
     {
         streams.NotNull(nameof(streams));
+        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
         var strms = streams;
         return new ZipArchive(
             new SourceStream(
@@ -132,6 +133,7 @@ public partial class ZipArchive
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
         return new((IWritableAsyncArchive<ZipWriterOptions>)OpenArchive(streams, readerOptions));
     }
 

--- a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
@@ -67,8 +67,7 @@ public partial class ZipArchive
         ReaderOptions? readerOptions = null
     )
     {
-        var strms = streams.RequireReadable();
-        strms.RequireSeekable();
+        var strms = streams.RequireReadable().RequireSeekable().ToList();
         return new ZipArchive(
             new SourceStream(
                 strms[0],

--- a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
@@ -67,9 +67,8 @@ public partial class ZipArchive
         ReaderOptions? readerOptions = null
     )
     {
-        streams.NotNull(nameof(streams));
-        streams.RequireSeekable();
-        var strms = streams;
+        var strms = streams.RequireReadable();
+        strms.RequireSeekable();
         return new ZipArchive(
             new SourceStream(
                 strms[0],
@@ -84,6 +83,7 @@ public partial class ZipArchive
         ReaderOptions? readerOptions = null
     )
     {
+        stream.RequireReadable();
         stream.RequireSeekable();
 
         return new ZipArchive(
@@ -128,7 +128,6 @@ public partial class ZipArchive
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        streams.RequireSeekable();
         return new((IWritableAsyncArchive<ZipWriterOptions>)OpenArchive(streams, readerOptions));
     }
 

--- a/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
+++ b/src/SharpCompress/Archives/Zip/ZipArchive.Factory.cs
@@ -68,7 +68,7 @@ public partial class ZipArchive
     )
     {
         streams.NotNull(nameof(streams));
-        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
+        streams.RequireSeekable();
         var strms = streams;
         return new ZipArchive(
             new SourceStream(
@@ -84,12 +84,7 @@ public partial class ZipArchive
         ReaderOptions? readerOptions = null
     )
     {
-        stream.NotNull(nameof(stream));
-
-        if (stream is not { CanSeek: true })
-        {
-            throw new ArgumentException("Stream must be seekable", nameof(stream));
-        }
+        stream.RequireSeekable();
 
         return new ZipArchive(
             new SourceStream(stream, i => null, readerOptions ?? ReaderOptions.ForExternalStream)
@@ -133,7 +128,7 @@ public partial class ZipArchive
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
-        SharpCompress.Archives.ArchiveFactory.EnsureSeekable(streams);
+        streams.RequireSeekable();
         return new((IWritableAsyncArchive<ZipWriterOptions>)OpenArchive(streams, readerOptions));
     }
 

--- a/src/SharpCompress/Readers/Ace/AceReader.Factory.cs
+++ b/src/SharpCompress/Readers/Ace/AceReader.Factory.cs
@@ -19,7 +19,7 @@ public partial class AceReader
     /// <returns>An AceReader instance.</returns>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         return new SingleVolumeAceReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
@@ -31,8 +31,8 @@ public partial class AceReader
     /// <returns></returns>
     public static IReader OpenReader(IEnumerable<Stream> streams, ReaderOptions? options = null)
     {
-        streams.NotNull(nameof(streams));
-        return new MultiVolumeAceReader(streams, options ?? ReaderOptions.ForExternalStream);
+        var streamArray = streams.RequireReadable();
+        return new MultiVolumeAceReader(streamArray, options ?? ReaderOptions.ForExternalStream);
     }
 
     public static ValueTask<IAsyncReader> OpenAsyncReader(
@@ -61,8 +61,8 @@ public partial class AceReader
         ReaderOptions? options = null
     )
     {
-        streams.NotNull(nameof(streams));
-        return new MultiVolumeAceReader(streams, options ?? ReaderOptions.ForExternalStream);
+        var streamArray = streams.RequireReadable();
+        return new MultiVolumeAceReader(streamArray, options ?? ReaderOptions.ForExternalStream);
     }
 
     public static ValueTask<IAsyncReader> OpenAsyncReader(

--- a/src/SharpCompress/Readers/Ace/SingleVolumeAceReader.cs
+++ b/src/SharpCompress/Readers/Ace/SingleVolumeAceReader.cs
@@ -12,7 +12,7 @@ internal class SingleVolumeAceReader : AceReader
     internal SingleVolumeAceReader(Stream stream, ReaderOptions options)
         : base(options)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         _stream = stream;
     }
 

--- a/src/SharpCompress/Readers/Arc/ArcReader.cs
+++ b/src/SharpCompress/Readers/Arc/ArcReader.cs
@@ -24,7 +24,7 @@ public partial class ArcReader : AbstractReader<ArcEntry, ArcVolume>
     /// <returns></returns>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         return new ArcReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 

--- a/src/SharpCompress/Readers/Arj/ArjReader.cs
+++ b/src/SharpCompress/Readers/Arj/ArjReader.cs
@@ -31,7 +31,7 @@ public abstract partial class ArjReader : AbstractReader<ArjEntry, ArjVolume>
     /// <returns></returns>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         return new SingleVolumeArjReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
@@ -43,8 +43,8 @@ public abstract partial class ArjReader : AbstractReader<ArjEntry, ArjVolume>
     /// <returns></returns>
     public static IReader OpenReader(IEnumerable<Stream> streams, ReaderOptions? options = null)
     {
-        streams.NotNull(nameof(streams));
-        return new MultiVolumeArjReader(streams, options ?? ReaderOptions.ForExternalStream);
+        var streamArray = streams.RequireReadable();
+        return new MultiVolumeArjReader(streamArray, options ?? ReaderOptions.ForExternalStream);
     }
 
     protected abstract void ValidateArchive(ArjVolume archive);

--- a/src/SharpCompress/Readers/Arj/SingleVolumeArjReader.cs
+++ b/src/SharpCompress/Readers/Arj/SingleVolumeArjReader.cs
@@ -12,7 +12,7 @@ internal class SingleVolumeArjReader : ArjReader
     internal SingleVolumeArjReader(Stream stream, ReaderOptions options)
         : base(options)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         _stream = stream;
     }
 

--- a/src/SharpCompress/Readers/GZip/GZipReader.Factory.cs
+++ b/src/SharpCompress/Readers/GZip/GZipReader.Factory.cs
@@ -55,7 +55,7 @@ public partial class GZipReader
 
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         return new GZipReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 }

--- a/src/SharpCompress/Readers/Lzw/LzwReader.Factory.cs
+++ b/src/SharpCompress/Readers/Lzw/LzwReader.Factory.cs
@@ -55,7 +55,7 @@ public partial class LzwReader
 
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         return new LzwReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 }

--- a/src/SharpCompress/Readers/Rar/RarReader.cs
+++ b/src/SharpCompress/Readers/Rar/RarReader.cs
@@ -71,7 +71,7 @@ public abstract partial class RarReader : AbstractReader<RarReaderEntry, RarVolu
     /// <returns></returns>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         return new SingleVolumeRarReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
@@ -83,8 +83,8 @@ public abstract partial class RarReader : AbstractReader<RarReaderEntry, RarVolu
     /// <returns></returns>
     public static IReader OpenReader(IEnumerable<Stream> streams, ReaderOptions? options = null)
     {
-        streams.NotNull(nameof(streams));
-        return new MultiVolumeRarReader(streams, options ?? ReaderOptions.ForExternalStream);
+        var streamArray = streams.RequireReadable();
+        return new MultiVolumeRarReader(streamArray, options ?? ReaderOptions.ForExternalStream);
     }
 
     protected override IEnumerable<RarReaderEntry> GetEntries(Stream stream)

--- a/src/SharpCompress/Readers/ReaderFactory.Async.cs
+++ b/src/SharpCompress/Readers/ReaderFactory.Async.cs
@@ -56,7 +56,7 @@ public static partial class ReaderFactory
         CancellationToken cancellationToken = default
     )
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         options ??= ReaderOptions.ForExternalStream;
 
         var sharpCompressStream = SharpCompressStream.Create(

--- a/src/SharpCompress/Readers/ReaderFactory.cs
+++ b/src/SharpCompress/Readers/ReaderFactory.cs
@@ -29,7 +29,7 @@ public static partial class ReaderFactory
     /// <returns></returns>
     public static IReader OpenReader(Stream stream, ReaderOptions? options = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         options ??= ReaderOptions.ForExternalStream;
 
         var sharpCompressStream = SharpCompressStream.Create(

--- a/src/SharpCompress/Readers/Tar/TarReader.Factory.cs
+++ b/src/SharpCompress/Readers/Tar/TarReader.Factory.cs
@@ -170,7 +170,7 @@ public partial class TarReader
     /// <returns></returns>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         readerOptions ??= ReaderOptions.ForExternalStream;
         var sharpCompressStream = SharpCompressStream.Create(
             stream,

--- a/src/SharpCompress/Readers/Zip/ZipReader.cs
+++ b/src/SharpCompress/Readers/Zip/ZipReader.cs
@@ -47,7 +47,7 @@ public partial class ZipReader : AbstractReader<ZipEntry, ZipVolume>
     /// <returns></returns>
     public static IReader OpenReader(Stream stream, ReaderOptions? readerOptions = null)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         return new ZipReader(stream, readerOptions ?? ReaderOptions.ForExternalStream);
     }
 
@@ -57,7 +57,7 @@ public partial class ZipReader : AbstractReader<ZipEntry, ZipVolume>
         IEnumerable<ZipEntry> entries
     )
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireReadable();
         return new ZipReader(stream, options ?? ReaderOptions.ForExternalStream, entries);
     }
 

--- a/src/SharpCompress/StreamValidationExtensions.cs
+++ b/src/SharpCompress/StreamValidationExtensions.cs
@@ -31,6 +31,18 @@ internal static class StreamValidationExtensions
         return stream;
     }
 
+    internal static Stream RequireWritable(this Stream stream)
+    {
+        stream.NotNull(nameof(stream));
+
+        if (!stream.CanWrite)
+        {
+            throw new ArgumentException("Stream must be writable", nameof(stream));
+        }
+
+        return stream;
+    }
+
     internal static IReadOnlyList<Stream> RequireSeekable(this IReadOnlyList<Stream> streams)
     {
         streams.NotNull(nameof(streams));

--- a/src/SharpCompress/StreamValidationExtensions.cs
+++ b/src/SharpCompress/StreamValidationExtensions.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SharpCompress;
+
+internal static class StreamValidationExtensions
+{
+    internal static Stream RequireReadable(this Stream stream)
+    {
+        stream.NotNull(nameof(stream));
+
+        if (!stream.CanRead)
+        {
+            throw new ArgumentException("Stream must be readable", nameof(stream));
+        }
+
+        return stream;
+    }
+
+    internal static Stream RequireSeekable(this Stream stream)
+    {
+        stream.NotNull(nameof(stream));
+
+        if (!stream.CanSeek)
+        {
+            throw new ArgumentException("Stream must be seekable", nameof(stream));
+        }
+
+        return stream;
+    }
+
+    internal static IReadOnlyList<Stream> RequireSeekable(this IReadOnlyList<Stream> streams)
+    {
+        streams.NotNull(nameof(streams));
+
+        foreach (var stream in streams)
+        {
+            stream.RequireSeekable();
+        }
+
+        return streams;
+    }
+
+    internal static IReadOnlyList<Stream> RequireReadable(this IEnumerable<Stream> streams)
+    {
+        streams.NotNull(nameof(streams));
+
+        var streamArray = streams as IReadOnlyList<Stream> ?? streams.ToArray();
+        foreach (var stream in streamArray)
+        {
+            stream.RequireReadable();
+        }
+
+        return streamArray;
+    }
+}

--- a/src/SharpCompress/StreamValidationExtensions.cs
+++ b/src/SharpCompress/StreamValidationExtensions.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace SharpCompress;
 
 internal static class StreamValidationExtensions
 {
-    internal static Stream RequireReadable(this Stream stream)
+    internal static void RequireReadable(this Stream stream)
     {
         stream.NotNull(nameof(stream));
 
@@ -15,11 +14,9 @@ internal static class StreamValidationExtensions
         {
             throw new ArgumentException("Stream must be readable", nameof(stream));
         }
-
-        return stream;
     }
 
-    internal static Stream RequireSeekable(this Stream stream)
+    internal static void RequireSeekable(this Stream stream)
     {
         stream.NotNull(nameof(stream));
 
@@ -27,11 +24,9 @@ internal static class StreamValidationExtensions
         {
             throw new ArgumentException("Stream must be seekable", nameof(stream));
         }
-
-        return stream;
     }
 
-    internal static Stream RequireWritable(this Stream stream)
+    internal static void RequireWritable(this Stream stream)
     {
         stream.NotNull(nameof(stream));
 
@@ -39,32 +34,23 @@ internal static class StreamValidationExtensions
         {
             throw new ArgumentException("Stream must be writable", nameof(stream));
         }
-
-        return stream;
     }
 
-    internal static IReadOnlyList<Stream> RequireSeekable(this IReadOnlyList<Stream> streams)
+    internal static IEnumerable<Stream> RequireSeekable(this IEnumerable<Stream> streams)
     {
-        streams.NotNull(nameof(streams));
-
         foreach (var stream in streams)
         {
             stream.RequireSeekable();
+            yield return stream;
         }
-
-        return streams;
     }
 
-    internal static IReadOnlyList<Stream> RequireReadable(this IEnumerable<Stream> streams)
+    internal static IEnumerable<Stream> RequireReadable(this IEnumerable<Stream> streams)
     {
-        streams.NotNull(nameof(streams));
-
-        var streamArray = streams as IReadOnlyList<Stream> ?? streams.ToArray();
-        foreach (var stream in streamArray)
+        foreach (var stream in streams)
         {
             stream.RequireReadable();
+            yield return stream;
         }
-
-        return streamArray;
     }
 }

--- a/src/SharpCompress/Writers/GZip/GZipWriter.Factory.cs
+++ b/src/SharpCompress/Writers/GZip/GZipWriter.Factory.cs
@@ -22,7 +22,7 @@ public partial class GZipWriter : IWriterOpenable<GZipWriterOptions>
 
     public static IWriter OpenWriter(Stream stream, GZipWriterOptions writerOptions)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireWritable();
         return new GZipWriter(stream, writerOptions);
     }
 

--- a/src/SharpCompress/Writers/SevenZip/SevenZipWriter.Factory.cs
+++ b/src/SharpCompress/Writers/SevenZip/SevenZipWriter.Factory.cs
@@ -36,7 +36,7 @@ public partial class SevenZipWriter : IWriterOpenable<SevenZipWriterOptions>
     /// </summary>
     public static IWriter OpenWriter(Stream stream, SevenZipWriterOptions writerOptions)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireWritable();
         return new SevenZipWriter(stream, writerOptions);
     }
 

--- a/src/SharpCompress/Writers/Tar/TarWriter.Factory.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriter.Factory.cs
@@ -22,7 +22,7 @@ public partial class TarWriter : IWriterOpenable<TarWriterOptions>
 
     public static IWriter OpenWriter(Stream stream, TarWriterOptions writerOptions)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireWritable();
         return new TarWriter(stream, writerOptions);
     }
 

--- a/src/SharpCompress/Writers/WriterFactory.cs
+++ b/src/SharpCompress/Writers/WriterFactory.cs
@@ -75,6 +75,8 @@ public static class WriterFactory
         IWriterOptions writerOptions
     )
     {
+        stream.RequireWritable();
+
         var factory = Factories
             .Factory.Factories.OfType<IWriterFactory>()
             .FirstOrDefault(item => item.KnownArchiveType == archiveType);
@@ -102,6 +104,8 @@ public static class WriterFactory
         CancellationToken cancellationToken = default
     )
     {
+        stream.RequireWritable();
+
         var factory = Factories
             .Factory.Factories.OfType<IWriterFactory>()
             .FirstOrDefault(item => item.KnownArchiveType == archiveType);

--- a/src/SharpCompress/Writers/Zip/ZipWriter.Factory.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriter.Factory.cs
@@ -22,7 +22,7 @@ public partial class ZipWriter : IWriterOpenable<ZipWriterOptions>
 
     public static IWriter OpenWriter(Stream stream, ZipWriterOptions writerOptions)
     {
-        stream.NotNull(nameof(stream));
+        stream.RequireWritable();
         return new ZipWriter(stream, writerOptions);
     }
 

--- a/src/SharpCompress/packages.lock.json
+++ b/src/SharpCompress/packages.lock.json
@@ -268,9 +268,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.0, )",
-        "resolved": "10.0.0",
-        "contentHash": "kICGrGYEzCNI3wPzfEXcwNHgTvlvVn9yJDhSdRK+oZQy4jvYH529u7O0xf5ocQKzOMjfS07+3z9PKRIjrFMJDA=="
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "QKuvS0LWX4fjFqeDkyM7Kqt8P3wYTiPD4nwU+9y59n0sCiG714fxDgbbN82vDnzq89AF/PiHl92TP2C4aFDUQA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
@@ -400,9 +400,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.26, )",
+        "resolved": "8.0.26",
+        "contentHash": "o7/yVssM2r9Wyln2s9edBd5ANZXqdSdBI+g7JqXkyJmXrhs2WsJp25K5yPnYrTgdKBCjKB8bg+O2oew4sgzFaA=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",

--- a/tests/SharpCompress.Test/ArchiveFactoryTests.cs
+++ b/tests/SharpCompress.Test/ArchiveFactoryTests.cs
@@ -1,9 +1,11 @@
+using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using SharpCompress.Archives;
 using SharpCompress.Common;
 using SharpCompress.Factories;
+using SharpCompress.Test.Mocks;
 using Xunit;
 
 namespace SharpCompress.Test;
@@ -59,6 +61,26 @@ public class ArchiveFactoryTests : TestBase
 
         Assert.IsType(expectedFactoryType, factory);
         Assert.Equal(startPosition, stream.Position);
+    }
+
+    [Fact]
+    public void OpenArchive_StreamCollection_Throws_On_NonSeekable_Stream()
+    {
+        using var nonSeekable = new ForwardOnlyStream(new MemoryStream());
+        using var seekable = new MemoryStream();
+
+        Assert.Throws<ArgumentException>(() => ArchiveFactory.OpenArchive([nonSeekable, seekable]));
+    }
+
+    [Fact]
+    public async ValueTask OpenAsyncArchive_StreamCollection_Throws_On_NonSeekable_Stream()
+    {
+        using var nonSeekable = new ForwardOnlyStream(new MemoryStream());
+        using var seekable = new MemoryStream();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            ArchiveFactory.OpenAsyncArchive([nonSeekable, seekable]).AsTask()
+        );
     }
 
     [Fact]

--- a/tests/SharpCompress.Test/ArchiveFactoryTests.cs
+++ b/tests/SharpCompress.Test/ArchiveFactoryTests.cs
@@ -93,6 +93,24 @@ public class ArchiveFactoryTests : TestBase
         );
     }
 
+    [Fact]
+    public void OpenArchive_Stream_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+
+        Assert.Throws<ArgumentException>(() => ArchiveFactory.OpenArchive(unreadable));
+    }
+
+    [Fact]
+    public async ValueTask OpenAsyncArchive_Stream_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            ArchiveFactory.OpenAsyncArchive(unreadable).AsTask()
+        );
+    }
+
     [Theory]
     [InlineData("Zip.deflate.zip", ArchiveType.Zip)]
     [InlineData("Tar.noEmptyDirs.tar", ArchiveType.Tar)]

--- a/tests/SharpCompress.Test/GZip/GZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveTests.cs
@@ -138,6 +138,14 @@ public class GZipArchiveTests : ArchiveTests
     }
 
     [Fact]
+    public void GZipArchive_Stream_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+
+        Assert.Throws<ArgumentException>(() => GZipArchive.OpenArchive(unreadable));
+    }
+
+    [Fact]
     public void GZip_Archive_NonSeekableStream()
     {
         // Test that GZip extraction works with non-seekable streams (like HttpBaseStream)

--- a/tests/SharpCompress.Test/GZip/GZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveTests.cs
@@ -5,6 +5,7 @@ using SharpCompress.Archives;
 using SharpCompress.Archives.GZip;
 using SharpCompress.Archives.Tar;
 using SharpCompress.Common;
+using SharpCompress.Test.Mocks;
 using SharpCompress.Writers.GZip;
 using Xunit;
 
@@ -125,6 +126,15 @@ public class GZipArchiveTests : ArchiveTests
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
         using var archive = GZipArchive.OpenArchive(stream);
         Assert.Equal(archive.Type, ArchiveType.GZip);
+    }
+
+    [Fact]
+    public void GZipArchive_StreamCollection_Throws_On_NonSeekable_Stream()
+    {
+        using var nonSeekable = new ForwardOnlyStream(new MemoryStream());
+        using var seekable = new MemoryStream();
+
+        Assert.Throws<ArgumentException>(() => GZipArchive.OpenArchive([nonSeekable, seekable]));
     }
 
     [Fact]

--- a/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
@@ -132,6 +132,14 @@ public class RarArchiveTests : ArchiveTests
     }
 
     [Fact]
+    public void RarArchive_Stream_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+
+        Assert.Throws<ArgumentException>(() => RarArchive.OpenArchive(unreadable));
+    }
+
+    [Fact]
     public void Rar5_ArchiveStreamRead() => ArchiveStreamRead("Rar5.rar");
 
     [Fact]

--- a/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Rar/RarArchiveTests.cs
@@ -123,6 +123,15 @@ public class RarArchiveTests : ArchiveTests
     public void Rar_ArchiveStreamRead() => ArchiveStreamRead("Rar.rar");
 
     [Fact]
+    public void RarArchive_StreamCollection_Throws_On_NonSeekable_Stream()
+    {
+        using var nonSeekable = new ForwardOnlyStream(new MemoryStream());
+        using var seekable = new MemoryStream();
+
+        Assert.Throws<ArgumentException>(() => RarArchive.OpenArchive([nonSeekable, seekable]));
+    }
+
+    [Fact]
     public void Rar5_ArchiveStreamRead() => ArchiveStreamRead("Rar5.rar");
 
     [Fact]

--- a/tests/SharpCompress.Test/ReaderFactoryTests.cs
+++ b/tests/SharpCompress.Test/ReaderFactoryTests.cs
@@ -34,6 +34,8 @@ public class ReaderFactoryTests
         using var unreadable = new TestStream(new MemoryStream(), false, true, true);
         using var readable = new MemoryStream();
 
-        Assert.Throws<ArgumentException>(() => RarReader.OpenReader([unreadable, readable]));
+        Assert.Throws<ArgumentException>(() =>
+            RarReader.OpenReader([unreadable, readable]).MoveToNextEntry()
+        );
     }
 }

--- a/tests/SharpCompress.Test/ReaderFactoryTests.cs
+++ b/tests/SharpCompress.Test/ReaderFactoryTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using SharpCompress.Readers;
+using SharpCompress.Readers.Rar;
+using SharpCompress.Test.Mocks;
+using Xunit;
+
+namespace SharpCompress.Test;
+
+public class ReaderFactoryTests
+{
+    [Fact]
+    public void OpenReader_Stream_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+
+        Assert.Throws<ArgumentException>(() => ReaderFactory.OpenReader(unreadable));
+    }
+
+    [Fact]
+    public async ValueTask OpenAsyncReader_Stream_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            ReaderFactory.OpenAsyncReader(unreadable).AsTask()
+        );
+    }
+
+    [Fact]
+    public void RarReader_StreamCollection_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+        using var readable = new MemoryStream();
+
+        Assert.Throws<ArgumentException>(() => RarReader.OpenReader([unreadable, readable]));
+    }
+}

--- a/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
@@ -38,6 +38,14 @@ public class SevenZipArchiveTests : ArchiveTests
     }
 
     [Fact]
+    public void SevenZipArchive_Stream_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+
+        Assert.Throws<ArgumentException>(() => SevenZipArchive.OpenArchive(unreadable));
+    }
+
+    [Fact]
     public void SevenZipArchive_LZMAAES_StreamRead() =>
         ArchiveStreamRead(
             "7Zip.LZMA.Aes.7z",

--- a/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/SevenZip/SevenZipArchiveTests.cs
@@ -7,6 +7,7 @@ using SharpCompress.Common;
 using SharpCompress.Common.SevenZip;
 using SharpCompress.Factories;
 using SharpCompress.Readers;
+using SharpCompress.Test.Mocks;
 using Xunit;
 
 namespace SharpCompress.Test.SevenZip;
@@ -24,6 +25,17 @@ public class SevenZipArchiveTests : ArchiveTests
 
     [Fact]
     public void SevenZipArchive_LZMA_PathRead() => ArchiveFileRead("7Zip.LZMA.7z");
+
+    [Fact]
+    public void SevenZipArchive_StreamCollection_Throws_On_NonSeekable_Stream()
+    {
+        using var nonSeekable = new ForwardOnlyStream(new MemoryStream());
+        using var seekable = new MemoryStream();
+
+        Assert.Throws<ArgumentException>(() =>
+            SevenZipArchive.OpenArchive([nonSeekable, seekable])
+        );
+    }
 
     [Fact]
     public void SevenZipArchive_LZMAAES_StreamRead() =>

--- a/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
@@ -23,6 +23,16 @@ public class TarArchiveAsyncTests : ArchiveTests
     public async ValueTask TarArchiveStreamRead_Async() => await ArchiveStreamReadAsync("Tar.tar");
 
     [Fact]
+    public async ValueTask TarArchiveOpenAsyncStream_Throws_On_NonSeekable_Stream()
+    {
+        using var stream = new ForwardOnlyStream(new MemoryStream());
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            TarArchive.OpenAsyncArchive(stream).AsTask()
+        );
+    }
+
+    [Fact]
     public async ValueTask Tar_FileName_Exactly_100_Characters_Async()
     {
         var archive = "Tar_FileName_Exactly_100_Characters.tar";

--- a/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
@@ -33,6 +33,16 @@ public class TarArchiveAsyncTests : ArchiveTests
     }
 
     [Fact]
+    public async ValueTask TarArchiveOpenAsyncStream_Throws_On_Unreadable_Stream()
+    {
+        using var stream = new TestStream(new MemoryStream(), false, true, true);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            TarArchive.OpenAsyncArchive(stream).AsTask()
+        );
+    }
+
+    [Fact]
     public async ValueTask Tar_FileName_Exactly_100_Characters_Async()
     {
         var archive = "Tar_FileName_Exactly_100_Characters.tar";

--- a/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
@@ -35,6 +35,15 @@ public class TarArchiveTests : ArchiveTests
     }
 
     [Fact]
+    public void TarArchive_StreamCollection_Throws_On_NonSeekable_Stream()
+    {
+        using var nonSeekable = new ForwardOnlyStream(new MemoryStream());
+        using var seekable = new MemoryStream();
+
+        Assert.Throws<ArgumentException>(() => TarArchive.OpenArchive([nonSeekable, seekable]));
+    }
+
+    [Fact]
     public void Tar_FileName_Exactly_100_Characters()
     {
         var archive = "Tar_FileName_Exactly_100_Characters.tar";

--- a/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveTests.cs
@@ -35,6 +35,19 @@ public class TarArchiveTests : ArchiveTests
     }
 
     [Fact]
+    public void TarArchiveStreamRead_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(
+            File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar")),
+            false,
+            true,
+            true
+        );
+
+        Assert.Throws<ArgumentException>(() => TarArchive.OpenArchive(unreadable));
+    }
+
+    [Fact]
     public void TarArchive_StreamCollection_Throws_On_NonSeekable_Stream()
     {
         using var nonSeekable = new ForwardOnlyStream(new MemoryStream());

--- a/tests/SharpCompress.Test/WriterFactoryTests.cs
+++ b/tests/SharpCompress.Test/WriterFactoryTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using SharpCompress.Common;
+using SharpCompress.Test.Mocks;
+using SharpCompress.Writers;
+using Xunit;
+
+namespace SharpCompress.Test;
+
+public class WriterFactoryTests
+{
+    [Fact]
+    public void OpenWriter_Stream_Throws_On_Unwritable_Stream()
+    {
+        using var unwritable = new TestStream(new MemoryStream(), true, false, true);
+
+        Assert.Throws<ArgumentException>(() =>
+            WriterFactory.OpenWriter(unwritable, ArchiveType.Zip, WriterOptions.ForZip())
+        );
+    }
+
+    [Fact]
+    public async ValueTask OpenAsyncWriter_Stream_Throws_On_Unwritable_Stream()
+    {
+        using var unwritable = new TestStream(new MemoryStream(), true, false, true);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            WriterFactory
+                .OpenAsyncWriter(unwritable, ArchiveType.Zip, WriterOptions.ForZip())
+                .AsTask()
+        );
+    }
+}

--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -29,6 +29,15 @@ public class ZipArchiveTests : ArchiveTests
     public void Zip_BZip2_ArchiveStreamRead() => ArchiveStreamRead("Zip.bzip2.zip");
 
     [Fact]
+    public void ZipArchive_StreamCollection_Throws_On_NonSeekable_Stream()
+    {
+        using var nonSeekable = new NonSeekableMemoryStream();
+        using var seekable = new MemoryStream();
+
+        Assert.Throws<ArgumentException>(() => ZipArchive.OpenArchive([nonSeekable, seekable]));
+    }
+
+    [Fact]
     public void Zip_Deflate_Streamed2_ArchiveStreamRead() =>
         ArchiveStreamRead("Zip.deflate.dd-.zip");
 

--- a/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipArchiveTests.cs
@@ -7,6 +7,7 @@ using SharpCompress.Archives.Zip;
 using SharpCompress.Common;
 using SharpCompress.Common.Zip;
 using SharpCompress.Readers;
+using SharpCompress.Test.Mocks;
 using SharpCompress.Writers;
 using SharpCompress.Writers.Zip;
 using Xunit;
@@ -35,6 +36,14 @@ public class ZipArchiveTests : ArchiveTests
         using var seekable = new MemoryStream();
 
         Assert.Throws<ArgumentException>(() => ZipArchive.OpenArchive([nonSeekable, seekable]));
+    }
+
+    [Fact]
+    public void ZipArchive_Stream_Throws_On_Unreadable_Stream()
+    {
+        using var unreadable = new TestStream(new MemoryStream(), false, true, true);
+
+        Assert.Throws<ArgumentException>(() => ZipArchive.OpenArchive(unreadable));
     }
 
     [Fact]


### PR DESCRIPTION
Inspired by https://github.com/adamhathcock/sharpcompress/issues/1296

This pull request refactors validation logic for stream parameters throughout the archive and reader factory classes. The main improvement is replacing scattered null and capability checks with centralized extension methods, specifically `RequireReadable()` and `RequireSeekable()`. This change ensures consistency, reduces code duplication, and improves readability and maintainability.

The most important changes are:

**Stream Validation Refactoring:**

* Replaced all usages of `NotNull` and explicit `CanRead`/`CanSeek` checks with the new `RequireReadable()` and `RequireSeekable()` extension methods for both single and multi-stream parameters in archive and reader factory methods. This affects methods in `ArchiveFactory`, `GZipArchive.Factory`, `RarArchive.Factory`, `SevenZipArchive.Factory`, `TarArchive.Factory`, `ZipArchive.Factory`, and all corresponding reader factories. [[1]](diffhunk://#diff-50da048b83ebc76ae4fa804e559576e2f212b170e66b01b0b15d199aef1837c7L95-R96) [[2]](diffhunk://#diff-50da048b83ebc76ae4fa804e559576e2f212b170e66b01b0b15d199aef1837c7L146-R147) [[3]](diffhunk://#diff-22b8bc5a3d713f2404d058a5fddfba4cec7f175d67a00be88fe4f96da36f7d18L76-R77) [[4]](diffhunk://#diff-22b8bc5a3d713f2404d058a5fddfba4cec7f175d67a00be88fe4f96da36f7d18L124-R125) [[5]](diffhunk://#diff-22b8bc5a3d713f2404d058a5fddfba4cec7f175d67a00be88fe4f96da36f7d18L163-R161) [[6]](diffhunk://#diff-22b8bc5a3d713f2404d058a5fddfba4cec7f175d67a00be88fe4f96da36f7d18L202-R196) [[7]](diffhunk://#diff-5e5c5824ff1ec9f6a3945d5e9cde1e4064182db296c2845d49563890dfe32ecdL79-R80) [[8]](diffhunk://#diff-5e5c5824ff1ec9f6a3945d5e9cde1e4064182db296c2845d49563890dfe32ecdL95-R96) [[9]](diffhunk://#diff-c917224df3ff936ef99480cb13f4d79d64db4bac3abba0c377b716a24c209c69L61-R62) [[10]](diffhunk://#diff-c917224df3ff936ef99480cb13f4d79d64db4bac3abba0c377b716a24c209c69L94-R91) [[11]](diffhunk://#diff-3c93be69c25d07fa44b4fe2394bb54f93c4e63e05e387b7bd6d5713048d44d01L74-R75) [[12]](diffhunk://#diff-3c93be69c25d07fa44b4fe2394bb54f93c4e63e05e387b7bd6d5713048d44d01L87-R88) [[13]](diffhunk://#diff-31112d7dfdc65bd7cca0da2d515de9d2b599c9a3196bc3562031d6e6a59788e3L69-R70) [[14]](diffhunk://#diff-31112d7dfdc65bd7cca0da2d515de9d2b599c9a3196bc3562031d6e6a59788e3L89-R90) [[15]](diffhunk://#diff-31112d7dfdc65bd7cca0da2d515de9d2b599c9a3196bc3562031d6e6a59788e3L105-R102) [[16]](diffhunk://#diff-31112d7dfdc65bd7cca0da2d515de9d2b599c9a3196bc3562031d6e6a59788e3L161-R159) [[17]](diffhunk://#diff-6ac2ef320c885e60f6cf8e8b4cf19a2c22cf88e2056539935ed458df36ada117L70-R71) [[18]](diffhunk://#diff-6ac2ef320c885e60f6cf8e8b4cf19a2c22cf88e2056539935ed458df36ada117L86-R87) [[19]](diffhunk://#diff-36c5e206881333661f2ea6e09a848bf6cb5584a4d84d1c6cbb55d507e13a70e9L22-R22) [[20]](diffhunk://#diff-36c5e206881333661f2ea6e09a848bf6cb5584a4d84d1c6cbb55d507e13a70e9L34-R35) [[21]](diffhunk://#diff-36c5e206881333661f2ea6e09a848bf6cb5584a4d84d1c6cbb55d507e13a70e9L64-R65) [[22]](diffhunk://#diff-ac822e185e8bdbbdbfcebefd4b41d850720cc4fec11e582f8d3e738e7c36ed6dL15-R15) [[23]](diffhunk://#diff-b89d27bb10d3d36ecb43d6adbefa80131674b22c28b502dcb3b8a70105ab4a6dL27-R27) [[24]](diffhunk://#diff-63cfd5595cd2ad29617248bf92035208f8e33465e1d5f6ab81f6f1e1a9a09e9aL34-R34) [[25]](diffhunk://#diff-63cfd5595cd2ad29617248bf92035208f8e33465e1d5f6ab81f6f1e1a9a09e9aL46-R47) [[26]](diffhunk://#diff-babb3dde4a89e1136bb9b30bc03ad03c7789e2c72d36723fc6e2cb7c849b19cdL15-R15) [[27]](diffhunk://#diff-1a36d82da139bc01740b501de6967d79d1ffc4a0eb56a58891e87365888ece57L58-R58) [[28]](diffhunk://#diff-ba87c31176443e1722f05a6cbc941d5f23d5408c6b9bafa857b72b090d18237cL58-R58) [[29]](diffhunk://#diff-df9100aa68bb12fa74c9d9887fa55e104337a48cc9dc7470f61f02ead44d13d2L74-R74) [[30]](diffhunk://#diff-df9100aa68bb12fa74c9d9887fa55e104337a48cc9dc7470f61f02ead44d13d2L86-R87) [[31]](diffhunk://#diff-bb23ddfdfc1e73bf40939c16d65aaca79f415a9573bb29448d8c2b51a6415f4fL59-R59)

**Consistency Improvements:**

* Ensured that all factory methods for opening archives and readers (sync and async) now consistently validate that streams are readable and, where required, seekable, using the same extension methods. This eliminates subtle bugs and inconsistent error handling across formats. (All references above)

**Simplification of Method Bodies:**

* Removed repetitive null and capability checks, as well as redundant exception throwing code, in favor of the new extension methods, resulting in cleaner and more maintainable method implementations. (All references above)

This refactoring centralizes stream validation, making the codebase easier to maintain and less error-prone.