### PR TITLE
fix: release source file handles in async archive add entry

### DIFF
--- a/src/SharpCompress/Archives/IWritableArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IWritableArchiveExtensions.cs
@@ -25,13 +25,7 @@ public static class IWritableArchiveExtensions
                 )
                 {
                     var fileInfo = new FileInfo(filePath);
-                    writableArchive.AddEntry(
-                        filePath.Substring(directoryPath.Length),
-                        fileInfo.OpenRead(),
-                        true,
-                        fileInfo.Length,
-                        fileInfo.LastWriteTime
-                    );
+                    writableArchive.AddEntry(filePath.Substring(directoryPath.Length), fileInfo);
                 }
             }
         }
@@ -52,13 +46,27 @@ public static class IWritableArchiveExtensions
             {
                 throw new ArgumentException("FileInfo does not exist.");
             }
-            return writableArchive.AddEntry(
-                key,
-                fileInfo.OpenRead(),
-                true,
-                fileInfo.Length,
-                fileInfo.LastWriteTime
-            );
+
+            using var sourceStream = fileInfo.OpenRead();
+            var bufferedStream = new MemoryStream();
+
+            try
+            {
+                sourceStream.CopyTo(bufferedStream);
+                bufferedStream.Position = 0;
+                return writableArchive.AddEntry(
+                    key,
+                    bufferedStream,
+                    true,
+                    fileInfo.Length,
+                    fileInfo.LastWriteTime
+                );
+            }
+            catch
+            {
+                bufferedStream.Dispose();
+                throw;
+            }
         }
     }
 

--- a/src/SharpCompress/Archives/IWritableAsyncArchiveExtensions.cs
+++ b/src/SharpCompress/Archives/IWritableAsyncArchiveExtensions.cs
@@ -28,13 +28,7 @@ public static class IWritableAsyncArchiveExtensions
                 {
                     var fileInfo = new FileInfo(filePath);
                     await writableArchive
-                        .AddEntryAsync(
-                            filePath.Substring(directoryPath.Length),
-                            fileInfo.OpenRead(),
-                            true,
-                            fileInfo.Length,
-                            fileInfo.LastWriteTime
-                        )
+                        .AddEntryAsync(filePath.Substring(directoryPath.Length), fileInfo)
                         .ConfigureAwait(false);
                 }
             }
@@ -56,13 +50,30 @@ public static class IWritableAsyncArchiveExtensions
             {
                 throw new ArgumentException("FileInfo does not exist.");
             }
-            return writableArchive.AddEntryAsync(
-                key,
-                fileInfo.OpenRead(),
-                true,
-                fileInfo.Length,
-                fileInfo.LastWriteTime
-            );
+
+            return AddEntryAsyncBuffered(fileInfo);
+
+            async ValueTask<IArchiveEntry> AddEntryAsyncBuffered(FileInfo info)
+            {
+                using var sourceStream = info.OpenRead();
+                var bufferedStream = new MemoryStream();
+
+                try
+                {
+                    await sourceStream.CopyToAsync(bufferedStream).ConfigureAwait(false);
+                    bufferedStream.Position = 0;
+                    return await writableArchive
+                        .AddEntryAsync(key, bufferedStream, true, info.Length, info.LastWriteTime)
+                        .ConfigureAwait(false);
+                }
+                catch
+                {
+#pragma warning disable VSTHRD103
+                    bufferedStream.Dispose();
+#pragma warning restore VSTHRD103
+                    throw;
+                }
+            }
         }
     }
 

--- a/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using SharpCompress.Archives;
@@ -174,6 +175,50 @@ public class TarArchiveAsyncTests : ArchiveTests
             );
         }
         CompareArchivesByPath(modified, scratchPath);
+    }
+
+    [Fact]
+    public async ValueTask Tar_Random_Write_Add_Releases_Source_File_Async()
+    {
+        var sourcePath = Path.Combine(SCRATCH_FILES_PATH, "Tar.source.txt");
+        var content = "source file lock test";
+
+        File.WriteAllText(sourcePath, content);
+
+        using var archiveStream = new MemoryStream();
+
+        await using (var archive = await TarArchive.CreateAsyncArchive())
+        {
+            await archive.AddEntryAsync("source.txt", sourcePath);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                using var exclusiveHandle = File.Open(
+                    sourcePath,
+                    FileMode.Open,
+                    FileAccess.ReadWrite,
+                    FileShare.None
+                );
+            }
+
+            await archive.SaveToAsync(
+                archiveStream,
+                new TarWriterOptions(CompressionType.None, true)
+            );
+        }
+
+        archiveStream.Position = 0;
+
+        await using (var archive = await TarArchive.OpenAsyncArchive(archiveStream))
+        {
+            var entry = await archive.EntriesAsync.SingleAsync();
+
+            using var entryStream = await entry.OpenEntryStreamAsync();
+            using var reader = new StreamReader(entryStream);
+            Assert.Equal(content, await reader.ReadToEndAsync());
+        }
+
+        File.Delete(sourcePath);
     }
 
     [Fact]


### PR DESCRIPTION
This pull request refactors how files are added to writable archives, both synchronously and asynchronously, to improve resource management and prevent file locking issues. It introduces buffered streams when adding files, ensuring that the source files can be accessed or deleted immediately after archiving. Additionally, a new asynchronous test verifies that source files are not locked during the archive creation process.

**Resource management and file locking improvements:**

* Refactored `AddEntry` in `IWritableArchiveExtensions.cs` to buffer file contents in memory before adding them to the archive, preventing the archive from holding open file handles on the source files. [[1]](diffhunk://#diff-4ab4fbb9acbd843bb76dcbb65a3e6d752eca4e6b630faa7ff533c5bb13048518L28-R28) [[2]](diffhunk://#diff-4ab4fbb9acbd843bb76dcbb65a3e6d752eca4e6b630faa7ff533c5bb13048518R49-R70)
* Refactored `AddEntryAsync` in `IWritableAsyncArchiveExtensions.cs` to buffer file contents asynchronously, ensuring source files are not locked during or after the async archiving process. [[1]](diffhunk://#diff-afdb0a9380673b9e21cda9070a5239c01a4bfe8c5b851b15d3fdea9a3190262bL31-R31) [[2]](diffhunk://#diff-afdb0a9380673b9e21cda9070a5239c01a4bfe8c5b851b15d3fdea9a3190262bL59-R76)

**Testing for file lock issues:**

* Added a new test `Tar_Random_Write_Add_Releases_Source_File_Async` in `TarArchiveAsyncTests.cs` to verify that source files can be opened exclusively after being added to an archive, confirming that file locks are released as expected.
* Updated test imports in `TarArchiveAsyncTests.cs` to include `System.Runtime.InteropServices` for platform-specific file lock checks.