### PR TITLE
fix: dispose source streams in writable archive async add entry

### DIFF
--- a/src/SharpCompress/Archives/AbstractWritableArchive.Async.cs
+++ b/src/SharpCompress/Archives/AbstractWritableArchive.Async.cs
@@ -122,6 +122,14 @@ public abstract partial class AbstractWritableArchive<TEntry, TVolume, TOptions>
             .ConfigureAwait(false);
     }
 
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync().ConfigureAwait(false);
+        newEntries.Cast<Entry>().ForEach(x => x.Close());
+        removedEntries.Cast<Entry>().ForEach(x => x.Close());
+        modifiedEntries.Cast<Entry>().ForEach(x => x.Close());
+    }
+
     protected abstract ValueTask SaveToAsync(
         Stream stream,
         TOptions options,

--- a/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
@@ -177,6 +177,50 @@ public class TarArchiveAsyncTests : ArchiveTests
     }
 
     [Fact]
+    public async ValueTask TarAsync_AddEntryAndReleaseSourceFile()
+    {
+        // Arrange
+        var sourcePath = Path.Combine(SCRATCH_FILES_PATH, "Tar.source.txt");
+        const string content = "source file lock test";
+        File.WriteAllText(sourcePath, content);
+        Assert.True(File.Exists(sourcePath));
+
+        var archivePath = Path.Combine(SCRATCH_FILES_PATH, "Tar.source.tar");
+        
+        await using (var archive = await TarArchive.CreateAsyncArchive())
+        {
+            await archive.AddEntryAsync("source.txt", sourcePath);
+
+            using var fileStream = new FileStream(
+                archivePath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 1024 * 1024,
+                FileOptions.SequentialScan
+            );
+
+            await archive.SaveToAsync(
+                fileStream,
+                new TarWriterOptions(CompressionType.None) { LeaveStreamOpen = false }
+            );
+        }
+
+        // Assert: after the archive is disposed the source file should no longer be locked
+        try
+        {
+            File.Delete(archivePath);
+            File.Delete(sourcePath);
+        }
+        catch (IOException ex)
+        {
+            Assert.True(false, "Source file is still locked after disposing archive: " + ex.Message);
+        }
+
+        Assert.False(File.Exists(sourcePath));
+    }
+
+    [Fact]
     public async ValueTask Tar_Random_Write_Remove_Async()
     {
         var scratchPath = Path.Combine(SCRATCH_FILES_PATH, "Tar.mod.tar");

--- a/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/Tar/TarArchiveAsyncTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using SharpCompress.Archives;
@@ -186,7 +187,7 @@ public class TarArchiveAsyncTests : ArchiveTests
         Assert.True(File.Exists(sourcePath));
 
         var archivePath = Path.Combine(SCRATCH_FILES_PATH, "Tar.source.tar");
-        
+
         await using (var archive = await TarArchive.CreateAsyncArchive())
         {
             await archive.AddEntryAsync("source.txt", sourcePath);
@@ -206,15 +207,39 @@ public class TarArchiveAsyncTests : ArchiveTests
             );
         }
 
+#if LEGACY_DOTNET
+        await Task.Delay(100);
+#endif
+
         // Assert: after the archive is disposed the source file should no longer be locked
-        try
+
+        // Windows enforces this through delete semantics; Unix-like platforms do not.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            File.Delete(archivePath);
-            File.Delete(sourcePath);
+            try
+            {
+                File.Delete(archivePath);
+                File.Delete(sourcePath);
+            }
+            catch (IOException ex)
+            {
+                Assert.True(
+                    false,
+                    "Source file is still locked after disposing archive: " + ex.Message
+                );
+            }
         }
-        catch (IOException ex)
+        else
         {
-            Assert.True(false, "Source file is still locked after disposing archive: " + ex.Message);
+            if (File.Exists(archivePath))
+            {
+                File.Delete(archivePath);
+            }
+
+            if (File.Exists(sourcePath))
+            {
+                File.Delete(sourcePath);
+            }
         }
 
         Assert.False(File.Exists(sourcePath));


### PR DESCRIPTION
This pull request introduces an important resource management improvement to the archive disposal process and adds a new test to ensure source files are properly released after creating a tar archive asynchronously.

Resource management improvements:

* Added an override for `DisposeAsync` in `AbstractWritableArchive.Async.cs` to ensure that all entries in `newEntries`, `removedEntries`, and `modifiedEntries` are properly closed when the archive is disposed asynchronously. This helps prevent resource leaks and file locks.

Testing enhancements:

* Added a new test `TarAsync_AddEntryAndReleaseSourceFile` in `TarArchiveAsyncTests.cs` to verify that after creating and disposing a tar archive asynchronously, the source file is no longer locked and can be deleted, ensuring correct resource release.