### PR TITLE
Fix GZip write async

### DIFF
--- a/src/SharpCompress/Archives/GZip/GZipArchiveEntry.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchiveEntry.cs
@@ -24,7 +24,7 @@ public class GZipArchiveEntry : GZipEntry, IArchiveEntry
         return Parts.Single().GetCompressedStream().NotNull();
     }
 
-    public async ValueTask<Stream> OpenEntryStreamAsync(
+    public virtual async ValueTask<Stream> OpenEntryStreamAsync(
         CancellationToken cancellationToken = default
     )
     {

--- a/src/SharpCompress/Archives/GZip/GZipWritableArchiveEntry.cs
+++ b/src/SharpCompress/Archives/GZip/GZipWritableArchiveEntry.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using SharpCompress.Common;
 using SharpCompress.IO;
 
@@ -59,6 +61,14 @@ internal sealed class GZipWritableArchiveEntry : GZipArchiveEntry, IWritableArch
         //ensure new stream is at the start, this could be reset
         stream.Seek(0, SeekOrigin.Begin);
         return SharpCompressStream.CreateNonDisposing(stream);
+    }
+
+    public override ValueTask<Stream> OpenEntryStreamAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new(OpenEntryStream());
     }
 
     internal override void Close()

--- a/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
@@ -6,6 +6,8 @@ using SharpCompress.Archives;
 using SharpCompress.Archives.GZip;
 using SharpCompress.Archives.Tar;
 using SharpCompress.Common;
+using SharpCompress.Compressors.Deflate;
+using SharpCompress.Readers;
 using SharpCompress.Test.Mocks;
 using SharpCompress.Writers.GZip;
 using Xunit;
@@ -180,5 +182,38 @@ public class GZipArchiveAsyncTests : ArchiveTests
 #endif
         await using var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream));
         Assert.Equal(archive.Type, ArchiveType.GZip);
+    }
+
+    [Fact]
+    public async ValueTask GZip_Create_New_Async()
+    {
+        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var filePath = Path.Combine(scratchPath, "test.gz");
+        if (!Directory.Exists(scratchPath))
+        {
+            Directory.CreateDirectory(scratchPath);
+        }
+        await using (var archive = (GZipArchive)await GZipArchive.CreateAsyncArchive())
+        {
+            await archive.AddEntryAsync("Tar.tar", Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            await archive.SaveToAsync(filePath, new GZipWriterOptions(CompressionLevel.BestSpeed));
+        }
+        var scratchPath2 = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        if (!Directory.Exists(scratchPath2))
+        {
+            Directory.CreateDirectory(scratchPath2);
+        }
+
+        await using var archive2 = await GZipArchive.OpenAsyncArchive(
+            new AsyncOnlyStream(File.OpenRead(filePath))
+        );
+        await foreach (var entry in archive2.EntriesAsync)
+        {
+            await entry.WriteToDirectoryAsync(scratchPath2);
+        }
+        CompareFilesByPath(
+            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"),
+            Path.Combine(scratchPath2, "Tar.tar")
+        );
     }
 }


### PR DESCRIPTION
fixes https://github.com/adamhathcock/sharpcompress/issues/1316

This pull request adds asynchronous support for opening entry streams in GZip archive entries and introduces new tests to ensure correct async behavior. The main focus is on enabling async operations for GZip writable archive entries and verifying them with comprehensive test coverage.

**Async support for GZip archive entries:**

* Made `OpenEntryStreamAsync` virtual in `GZipArchiveEntry` to allow overriding for async stream opening.
* Added an override for `OpenEntryStreamAsync` in `GZipWritableArchiveEntry` that supports cancellation and returns a `ValueTask<Stream>`.
* Included necessary `System.Threading` and `System.Threading.Tasks` namespaces for async/cancellation support in `GZipWritableArchiveEntry`.

**Test improvements:**

* Added a new async test `GZip_Create_New_Async` to verify creating, saving, and extracting GZip archives asynchronously, ensuring file integrity.
* Updated test imports to support new async test scenarios.