### PR TITLE
Fix GZip write async

### DIFF
--- a/src/SharpCompress/Archives/GZip/GZipArchiveEntry.cs
+++ b/src/SharpCompress/Archives/GZip/GZipArchiveEntry.cs
@@ -24,7 +24,7 @@ public class GZipArchiveEntry : GZipEntry, IArchiveEntry
         return Parts.Single().GetCompressedStream().NotNull();
     }
 
-    public async ValueTask<Stream> OpenEntryStreamAsync(
+    public virtual async ValueTask<Stream> OpenEntryStreamAsync(
         CancellationToken cancellationToken = default
     )
     {

--- a/src/SharpCompress/Archives/GZip/GZipWritableArchiveEntry.cs
+++ b/src/SharpCompress/Archives/GZip/GZipWritableArchiveEntry.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using SharpCompress.Common;
 using SharpCompress.IO;
 
@@ -59,6 +61,14 @@ internal sealed class GZipWritableArchiveEntry : GZipArchiveEntry, IWritableArch
         //ensure new stream is at the start, this could be reset
         stream.Seek(0, SeekOrigin.Begin);
         return SharpCompressStream.CreateNonDisposing(stream);
+    }
+
+    public override ValueTask<Stream> OpenEntryStreamAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new(OpenEntryStream());
     }
 
     internal override void Close()

--- a/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
@@ -177,7 +177,7 @@ public class GZipArchiveAsyncTests : ArchiveTests
     {
 #if NETFRAMEWORK
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
-#else
+        #else
         await using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
 #endif
         await using var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream));
@@ -204,7 +204,11 @@ public class GZipArchiveAsyncTests : ArchiveTests
             Directory.CreateDirectory(scratchPath2);
         }
 
+#if NETFRAMEWORK
+        using var fileStream = File.OpenRead(filePath);
+#else
         await using var fileStream = File.OpenRead(filePath);
+#endif
         await using var archive2 = await GZipArchive.OpenAsyncArchive(
             new AsyncOnlyStream(fileStream)
         );

--- a/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
@@ -204,8 +204,9 @@ public class GZipArchiveAsyncTests : ArchiveTests
             Directory.CreateDirectory(scratchPath2);
         }
 
+        await using var fileStream = File.OpenRead(filePath);
         await using var archive2 = await GZipArchive.OpenAsyncArchive(
-            new AsyncOnlyStream(File.OpenRead(filePath))
+            new AsyncOnlyStream(fileStream)
         );
         await foreach (var entry in archive2.EntriesAsync)
         {

--- a/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
@@ -6,6 +6,8 @@ using SharpCompress.Archives;
 using SharpCompress.Archives.GZip;
 using SharpCompress.Archives.Tar;
 using SharpCompress.Common;
+using SharpCompress.Compressors.Deflate;
+using SharpCompress.Readers;
 using SharpCompress.Test.Mocks;
 using SharpCompress.Writers.GZip;
 using Xunit;
@@ -180,5 +182,38 @@ public class GZipArchiveAsyncTests : ArchiveTests
 #endif
         await using var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream));
         Assert.Equal(archive.Type, ArchiveType.GZip);
+    }
+
+    [Fact]
+    public async ValueTask GZip_Create_New_Async()
+    {
+        var scratchPath = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        var filePath = Path.Combine(scratchPath, "test.gz");
+        if (!Directory.Exists(scratchPath))
+        {
+            Directory.CreateDirectory(scratchPath);
+        }
+        await using (var archive = (GZipArchive)await GZipArchive.CreateAsyncArchive())
+        {
+            await archive.AddEntryAsync("Tar.tar", Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"));
+            await archive.SaveToAsync(filePath, new GZipWriterOptions(CompressionLevel.BestSpeed));
+        }
+        var scratchPath2 = Path.Combine(SCRATCH_FILES_PATH, Guid.NewGuid().ToString());
+        if (!Directory.Exists(scratchPath2))
+        {
+            Directory.CreateDirectory(scratchPath2);
+        }
+
+        await using var archive2 = await GZipArchive.OpenAsyncArchive(
+            new AsyncOnlyStream(File.OpenRead(filePath))
+        );
+        await foreach (var entry in archive2.EntriesAsync)
+        {
+            await entry.WriteToDirectoryAsync(scratchPath2);
+        }
+        CompareFilesByPath(
+            Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar"),
+            Path.Combine(scratchPath2, "Tar.tar")
+        );
     }
 }

--- a/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipArchiveAsyncTests.cs
@@ -177,7 +177,7 @@ public class GZipArchiveAsyncTests : ArchiveTests
     {
 #if NETFRAMEWORK
         using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
-        #else
+#else
         await using var stream = File.OpenRead(Path.Combine(TEST_ARCHIVES_PATH, "Tar.tar.gz"));
 #endif
         await using var archive = await GZipArchive.OpenAsyncArchive(new AsyncOnlyStream(stream));


### PR DESCRIPTION
fixes https://github.com/adamhathcock/sharpcompress/issues/1316

same as https://github.com/adamhathcock/sharpcompress/pull/1319

This pull request adds asynchronous support for opening GZip archive entry streams and introduces a new async test for GZip archive creation and extraction. The main changes involve implementing an asynchronous version of `OpenEntryStream` in both the base and writable GZip archive entry classes, updating usings for async functionality, and adding comprehensive tests to validate the new async operations.

**Async support for GZip archive entries:**
* Made `OpenEntryStreamAsync` a `virtual` method in `GZipArchiveEntry`, allowing for override and enabling async stream opening for GZip entries.
* Implemented an `override` of `OpenEntryStreamAsync` in `GZipWritableArchiveEntry`, providing cancellation support and returning a `ValueTask<Stream>`.
* Added necessary `using` statements for `System.Threading` and `System.Threading.Tasks` in `GZipWritableArchiveEntry.cs` to support async methods.

**Testing improvements:**
* Added a new async test `GZip_Create_New_Async` in `GZipArchiveAsyncTests.cs` to verify asynchronous archive creation, saving, extraction, and file comparison.
* Updated test file usings to include async-related namespaces.