### PR TITLE
Add Polysharp and adjustments that do not break legacy frameworks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,7 @@ SharpCompress supports multiple archive and compression formats:
 - Preserve existing public method signatures and behavior when possible.
 - If a breaking change is unavoidable, document it and provide a migration path.
 - Add or update tests that cover backward compatibility expectations.
+- Avoid exposing public `init` setters, positional records, `required` members, or other metadata that forces consumers onto newer C# language versions; validate older-consumer compatibility with tests when changing exported APIs.
 
 ### Stream Ownership and Position Checklist
 - Verify `LeaveStreamOpen` behavior for externally owned streams.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,5 +18,6 @@
       Include="Microsoft.VisualStudio.Threading.Analyzers"
       Version="17.14.15"
     />
+    <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
   </ItemGroup>
 </Project>

--- a/build/packages.lock.json
+++ b/build/packages.lock.json
@@ -39,6 +39,12 @@
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
       },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
       "SimpleExec": {
         "type": "Direct",
         "requested": "[13.0.0, )",

--- a/src/SharpCompress/Archives/ArchiveInformation.cs
+++ b/src/SharpCompress/Archives/ArchiveInformation.cs
@@ -10,13 +10,29 @@ namespace SharpCompress.Archives;
 /// <see cref="ArchiveFactory.GetArchiveInformationAsync(System.IO.Stream,System.Threading.CancellationToken)"/>
 /// to obtain an instance of this record.
 /// </remarks>
-/// <param name="Type">
-/// The type of archive detected, or <see langword="null"/> when the format is not a registered well-known type.
-/// </param>
-/// <param name="SupportsRandomAccess">
-/// <see langword="true"/> when this archive format supports random access via the <see cref="IArchive"/> API,
-/// meaning the full file listing can be retrieved without decompressing the entire archive.
-/// <see langword="false"/> when only the <see cref="SharpCompress.Readers.IReader"/> API is available,
-/// which reads entries sequentially and can only report per-entry progress.
-/// </param>
-public record ArchiveInformation(ArchiveType? Type, bool SupportsRandomAccess);
+public record ArchiveInformation
+{
+    /// <summary>
+    /// The type of archive detected, or <see langword="null"/> when the format is not a registered well-known type.
+    /// </summary>
+    public ArchiveType? Type { get; set; }
+
+    /// <summary>
+    /// <see langword="true"/> when this archive format supports random access via the <see cref="IArchive"/> API,
+    /// meaning the full file listing can be retrieved without decompressing the entire archive.
+    /// <see langword="false"/> when only the <see cref="SharpCompress.Readers.IReader"/> API is available,
+    /// which reads entries sequentially and can only report per-entry progress.
+    /// </summary>
+    public bool SupportsRandomAccess { get; set; }
+
+    /// <summary>
+    /// Creates a new archive information instance.
+    /// </summary>
+    /// <param name="type">The detected archive type.</param>
+    /// <param name="supportsRandomAccess">Whether the detected format supports random access.</param>
+    public ArchiveInformation(ArchiveType? type, bool supportsRandomAccess)
+    {
+        Type = type;
+        SupportsRandomAccess = supportsRandomAccess;
+    }
+}

--- a/src/SharpCompress/Common/ExtractionOptions.cs
+++ b/src/SharpCompress/Common/ExtractionOptions.cs
@@ -7,7 +7,7 @@ namespace SharpCompress.Common;
 /// Options for configuring extraction behavior when extracting archive entries.
 /// </summary>
 /// <remarks>
-/// This class is immutable. Use the <c>with</c> expression to create modified copies:
+/// Configure extraction behavior with constructors, property setters, or the <c>with</c> expression:
 /// <code>
 /// var options = new ExtractionOptions { Overwrite = false };
 /// options = options with { PreserveFileTime = true };
@@ -19,24 +19,24 @@ public sealed record ExtractionOptions : IExtractionOptions
     /// Overwrite target if it exists.
     /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
     /// </summary>
-    public bool Overwrite { get; init; } = true;
+    public bool Overwrite { get; set; } = true;
 
     /// <summary>
     /// Extract with internal directory structure.
     /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
     /// </summary>
-    public bool ExtractFullPath { get; init; } = true;
+    public bool ExtractFullPath { get; set; } = true;
 
     /// <summary>
     /// Preserve file time.
     /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
     /// </summary>
-    public bool PreserveFileTime { get; init; } = true;
+    public bool PreserveFileTime { get; set; } = true;
 
     /// <summary>
     /// Preserve windows file attributes.
     /// </summary>
-    public bool PreserveAttributes { get; init; }
+    public bool PreserveAttributes { get; set; }
 
     /// <summary>
     /// Delegate for writing symbolic links to disk.
@@ -44,10 +44,10 @@ public sealed record ExtractionOptions : IExtractionOptions
     /// The second parameter is the target path (what the symlink refers to).
     /// </summary>
     /// <remarks>
-    /// <b>Breaking change:</b> Changed from field to init-only property in version 0.40.0.
+    /// <b>Breaking change:</b> Changed from field to property in version 0.40.0.
     /// If no handler is provided, symbolic links are silently skipped during extraction.
     /// </remarks>
-    public Action<string, string>? SymbolicLinkHandler { get; init; }
+    public Action<string, string>? SymbolicLinkHandler { get; set; }
 
     /// <summary>
     /// Creates a new ExtractionOptions instance with default values.

--- a/src/SharpCompress/Common/Options/IEncodingOptions.cs
+++ b/src/SharpCompress/Common/Options/IEncodingOptions.cs
@@ -2,5 +2,5 @@ namespace SharpCompress.Common.Options;
 
 public interface IEncodingOptions
 {
-    IArchiveEncoding ArchiveEncoding { get; init; }
+    IArchiveEncoding ArchiveEncoding { get; set; }
 }

--- a/src/SharpCompress/Common/Options/IExtractionOptions.cs
+++ b/src/SharpCompress/Common/Options/IExtractionOptions.cs
@@ -11,29 +11,29 @@ public interface IExtractionOptions
     /// Overwrite target if it exists.
     /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
     /// </summary>
-    bool Overwrite { get; init; }
+    bool Overwrite { get; set; }
 
     /// <summary>
     /// Extract with internal directory structure.
     /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
     /// </summary>
-    bool ExtractFullPath { get; init; }
+    bool ExtractFullPath { get; set; }
 
     /// <summary>
     /// Preserve file time.
     /// <para><b>Breaking change:</b> Default changed from false to true in version 0.40.0.</para>
     /// </summary>
-    bool PreserveFileTime { get; init; }
+    bool PreserveFileTime { get; set; }
 
     /// <summary>
     /// Preserve windows file attributes.
     /// </summary>
-    bool PreserveAttributes { get; init; }
+    bool PreserveAttributes { get; set; }
 
     /// <summary>
     /// Delegate for writing symbolic links to disk.
     /// The first parameter is the source path (where the symlink is created).
     /// The second parameter is the target path (what the symlink refers to).
     /// </summary>
-    Action<string, string>? SymbolicLinkHandler { get; init; }
+    Action<string, string>? SymbolicLinkHandler { get; set; }
 }

--- a/src/SharpCompress/Common/Options/IProgressOptions.cs
+++ b/src/SharpCompress/Common/Options/IProgressOptions.cs
@@ -4,5 +4,5 @@ namespace SharpCompress.Common.Options;
 
 public interface IProgressOptions
 {
-    IProgress<ProgressReport>? Progress { get; init; }
+    IProgress<ProgressReport>? Progress { get; set; }
 }

--- a/src/SharpCompress/Common/Options/IReaderOptions.cs
+++ b/src/SharpCompress/Common/Options/IReaderOptions.cs
@@ -8,37 +8,37 @@ public interface IReaderOptions : IStreamOptions, IEncodingOptions, IProgressOpt
     /// <summary>
     /// Look for RarArchive (Check for self-extracting archives or cases where RarArchive isn't at the start of the file)
     /// </summary>
-    bool LookForHeader { get; init; }
+    bool LookForHeader { get; set; }
 
     /// <summary>
     /// Password for encrypted archives.
     /// </summary>
-    string? Password { get; init; }
+    string? Password { get; set; }
 
     /// <summary>
     /// Disable checking for incomplete archives.
     /// </summary>
-    bool DisableCheckIncomplete { get; init; }
+    bool DisableCheckIncomplete { get; set; }
 
     /// <summary>
     /// Buffer size for stream operations.
     /// </summary>
-    int BufferSize { get; init; }
+    int BufferSize { get; set; }
 
     /// <summary>
     /// Provide a hint for the extension of the archive being read, can speed up finding the correct decoder.
     /// </summary>
-    string? ExtensionHint { get; init; }
+    string? ExtensionHint { get; set; }
 
     /// <summary>
     /// Size of the rewindable buffer for non-seekable streams.
     /// </summary>
-    int? RewindableBufferSize { get; init; }
+    int? RewindableBufferSize { get; set; }
 
     /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom providers.
     /// Use this to provide alternative decompression implementations.
     /// </summary>
-    CompressionProviderRegistry Providers { get; init; }
+    CompressionProviderRegistry Providers { get; set; }
 }

--- a/src/SharpCompress/Common/Options/IStreamOptions.cs
+++ b/src/SharpCompress/Common/Options/IStreamOptions.cs
@@ -2,5 +2,5 @@ namespace SharpCompress.Common.Options;
 
 public interface IStreamOptions
 {
-    bool LeaveStreamOpen { get; init; }
+    bool LeaveStreamOpen { get; set; }
 }

--- a/src/SharpCompress/Common/Options/IWriterOptions.cs
+++ b/src/SharpCompress/Common/Options/IWriterOptions.cs
@@ -12,17 +12,17 @@ public interface IWriterOptions : IStreamOptions, IEncodingOptions, IProgressOpt
     /// <summary>
     /// The compression type to use for the archive.
     /// </summary>
-    CompressionType CompressionType { get; init; }
+    CompressionType CompressionType { get; set; }
 
     /// <summary>
     /// The compression level to be used when the compression type supports variable levels.
     /// </summary>
-    int CompressionLevel { get; init; }
+    int CompressionLevel { get; set; }
 
     /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom providers, such as
     /// System.IO.Compression for Deflate/GZip on modern .NET.
     /// </summary>
-    CompressionProviderRegistry Providers { get; init; }
+    CompressionProviderRegistry Providers { get; set; }
 }

--- a/src/SharpCompress/Providers/CompressionContext.cs
+++ b/src/SharpCompress/Providers/CompressionContext.cs
@@ -12,22 +12,22 @@ public sealed record CompressionContext
     /// <summary>
     /// The size of the input data, or -1 if unknown.
     /// </summary>
-    public long InputSize { get; init; } = -1;
+    public long InputSize { get; set; } = -1;
 
     /// <summary>
     /// The expected output size, or -1 if unknown.
     /// </summary>
-    public long OutputSize { get; init; } = -1;
+    public long OutputSize { get; set; } = -1;
 
     /// <summary>
     /// Properties bytes for the compression format (e.g., LZMA properties).
     /// </summary>
-    public byte[]? Properties { get; init; }
+    public byte[]? Properties { get; set; }
 
     /// <summary>
     /// Whether the underlying stream supports seeking.
     /// </summary>
-    public bool CanSeek { get; init; }
+    public bool CanSeek { get; set; }
 
     /// <summary>
     /// Additional format-specific options.
@@ -38,7 +38,7 @@ public sealed record CompressionContext
     /// Examples of valid FormatOptions values include compression properties (e.g., LZMA properties),
     /// format flags, or algorithm-specific configuration.
     /// </remarks>
-    public object? FormatOptions { get; init; }
+    public object? FormatOptions { get; set; }
 
     /// <summary>
     /// Creates a CompressionContext from a stream.
@@ -51,7 +51,7 @@ public sealed record CompressionContext
     /// <summary>
     /// Reader options for accessing archive metadata such as header encoding.
     /// </summary>
-    public IReaderOptions? ReaderOptions { get; init; }
+    public IReaderOptions? ReaderOptions { get; set; }
 
     /// <summary>
     /// Returns a new <see cref="CompressionContext"/> with the specified reader options.

--- a/src/SharpCompress/Readers/ReaderOptions.cs
+++ b/src/SharpCompress/Readers/ReaderOptions.cs
@@ -10,7 +10,7 @@ namespace SharpCompress.Readers;
 /// Options for configuring reader behavior when opening archives.
 /// </summary>
 /// <remarks>
-/// This class is immutable. Use preset properties and fluent helpers for common configurations:
+/// Use preset properties, setters, and fluent helpers for common configurations:
 /// <code>
 /// var options = ReaderOptions.ForExternalStream
 ///     .WithPassword("secret")
@@ -53,43 +53,43 @@ public sealed record ReaderOptions : IReaderOptions
     /// </code>
     /// </para>
     /// </remarks>
-    public bool LeaveStreamOpen { get; init; } = false;
+    public bool LeaveStreamOpen { get; set; } = false;
 
     /// <summary>
     /// Encoding to use for archive entry names.
     /// </summary>
-    public IArchiveEncoding ArchiveEncoding { get; init; } = new ArchiveEncoding();
+    public IArchiveEncoding ArchiveEncoding { get; set; } = new ArchiveEncoding();
 
     /// <summary>
     /// Look for RarArchive (Check for self-extracting archives or cases where RarArchive isn't at the start of the file)
     /// </summary>
-    public bool LookForHeader { get; init; }
+    public bool LookForHeader { get; set; }
 
     /// <summary>
     /// Password for encrypted archives.
     /// </summary>
-    public string? Password { get; init; }
+    public string? Password { get; set; }
 
     /// <summary>
     /// Disable checking for incomplete archives.
     /// </summary>
-    public bool DisableCheckIncomplete { get; init; }
+    public bool DisableCheckIncomplete { get; set; }
 
     /// <summary>
     /// Buffer size for stream operations.
     /// </summary>
-    public int BufferSize { get; init; } = Constants.BufferSize;
+    public int BufferSize { get; set; } = Constants.BufferSize;
 
     /// <summary>
     /// Provide a hint for the extension of the archive being read, can speed up finding the correct decoder.  Should be without the leading period in the form like: tar.gz or zip
     /// </summary>
-    public string? ExtensionHint { get; init; }
+    public string? ExtensionHint { get; set; }
 
     /// <summary>
     /// An optional progress reporter for tracking extraction operations.
     /// When set, progress updates will be reported as entries are extracted.
     /// </summary>
-    public IProgress<ProgressReport>? Progress { get; init; }
+    public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
     /// Size of the rewindable buffer for non-seekable streams.
@@ -133,14 +133,14 @@ public sealed record ReaderOptions : IReaderOptions
     /// using var reader = ReaderFactory.OpenReader(networkStream, options);
     /// </code>
     /// </example>
-    public int? RewindableBufferSize { get; init; }
+    public int? RewindableBufferSize { get; set; }
 
     /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations, such as
     /// System.IO.Compression for Deflate/GZip on modern .NET.
     /// </summary>
-    public CompressionProviderRegistry Providers { get; init; } =
+    public CompressionProviderRegistry Providers { get; set; } =
         CompressionProviderRegistry.Default;
 
     /// <summary>

--- a/src/SharpCompress/Writers/GZip/GZipWriterOptions.cs
+++ b/src/SharpCompress/Writers/GZip/GZipWriterOptions.cs
@@ -12,7 +12,7 @@ namespace SharpCompress.Writers.GZip;
 /// Options for configuring GZip writer behavior.
 /// </summary>
 /// <remarks>
-/// This class is immutable. Use factory methods for creation:
+/// Use factory methods, property setters, or fluent helpers for creation:
 /// <code>
 /// var options = WriterOptions.ForGZip().WithLeaveStreamOpen(false).WithCompressionLevel(9);
 /// </code>
@@ -27,7 +27,7 @@ public sealed record GZipWriterOptions : IWriterOptions
     public CompressionType CompressionType
     {
         get => CompressionType.GZip;
-        init
+        set
         {
             if (value != CompressionType.GZip)
             {
@@ -46,7 +46,7 @@ public sealed record GZipWriterOptions : IWriterOptions
     public int CompressionLevel
     {
         get => _compressionLevel;
-        init
+        set
         {
             CompressionLevelValidation.Validate(CompressionType.GZip, value);
             _compressionLevel = value;
@@ -56,24 +56,24 @@ public sealed record GZipWriterOptions : IWriterOptions
     /// <summary>
     /// SharpCompress will keep the supplied streams open.  Default is true.
     /// </summary>
-    public bool LeaveStreamOpen { get; init; } = true;
+    public bool LeaveStreamOpen { get; set; } = true;
 
     /// <summary>
     /// Encoding to use for archive entry names.
     /// </summary>
-    public IArchiveEncoding ArchiveEncoding { get; init; } = new ArchiveEncoding();
+    public IArchiveEncoding ArchiveEncoding { get; set; } = new ArchiveEncoding();
 
     /// <summary>
     /// An optional progress reporter for tracking compression operations.
     /// </summary>
-    public IProgress<ProgressReport>? Progress { get; init; }
+    public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations, such as
     /// System.IO.Compression for GZip on modern .NET.
     /// </summary>
-    public CompressionProviderRegistry Providers { get; init; } =
+    public CompressionProviderRegistry Providers { get; set; } =
         CompressionProviderRegistry.Default;
 
     /// <summary>

--- a/src/SharpCompress/Writers/SevenZip/SevenZipWriterOptions.cs
+++ b/src/SharpCompress/Writers/SevenZip/SevenZipWriterOptions.cs
@@ -20,7 +20,7 @@ public sealed record SevenZipWriterOptions : IWriterOptions
     public CompressionType CompressionType
     {
         get => _compressionType;
-        init
+        set
         {
             if (value != CompressionType.LZMA && value != CompressionType.LZMA2)
             {
@@ -39,41 +39,41 @@ public sealed record SevenZipWriterOptions : IWriterOptions
     public int CompressionLevel
     {
         get => _compressionLevel;
-        init => _compressionLevel = value;
+        set => _compressionLevel = value;
     }
 
     /// <summary>
     /// SharpCompress will keep the supplied streams open. Default is true.
     /// </summary>
-    public bool LeaveStreamOpen { get; init; } = true;
+    public bool LeaveStreamOpen { get; set; } = true;
 
     /// <summary>
     /// Encoding to use for archive entry names.
     /// </summary>
-    public IArchiveEncoding ArchiveEncoding { get; init; } = new ArchiveEncoding();
+    public IArchiveEncoding ArchiveEncoding { get; set; } = new ArchiveEncoding();
 
     /// <summary>
     /// An optional progress reporter for tracking compression operations.
     /// </summary>
-    public IProgress<ProgressReport>? Progress { get; init; }
+    public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations.
     /// </summary>
-    public CompressionProviderRegistry Providers { get; init; } =
+    public CompressionProviderRegistry Providers { get; set; } =
         CompressionProviderRegistry.Default;
 
     /// <summary>
     /// Whether to compress the archive header itself using LZMA.
     /// Default is true, matching standard 7-Zip behavior.
     /// </summary>
-    public bool CompressHeader { get; init; } = true;
+    public bool CompressHeader { get; set; } = true;
 
     /// <summary>
     /// Custom LZMA encoder properties. Null uses defaults (1MB dictionary, 32 fast bytes).
     /// </summary>
-    public LzmaEncoderProperties? LzmaProperties { get; init; }
+    public LzmaEncoderProperties? LzmaProperties { get; set; }
 
     /// <summary>
     /// Creates a new SevenZipWriterOptions instance with LZMA2 compression (default).

--- a/src/SharpCompress/Writers/Tar/TarWriterOptions.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriterOptions.cs
@@ -11,7 +11,7 @@ namespace SharpCompress.Writers.Tar;
 /// Options for configuring Tar writer behavior.
 /// </summary>
 /// <remarks>
-/// This class is immutable. Use the <c>with</c> expression to create modified copies:
+/// Configure tar writing with constructors, property setters, or the <c>with</c> expression:
 /// <code>
 /// var options = new TarWriterOptions(CompressionType.GZip, true);
 /// options = options with { HeaderFormat = TarHeaderWriteFormat.V7 };
@@ -22,45 +22,44 @@ public sealed record TarWriterOptions : IWriterOptions
     /// <summary>
     /// The compression type to use for the archive.
     /// </summary>
-    public CompressionType CompressionType { get; init; }
+    public CompressionType CompressionType { get; set; }
 
     /// <summary>
     /// The compression level to be used when the compression type supports variable levels.
     /// </summary>
-    public int CompressionLevel { get; init; }
+    public int CompressionLevel { get; set; }
 
     /// <summary>
     /// SharpCompress will keep the supplied streams open.  Default is true.
     /// </summary>
-    public bool LeaveStreamOpen { get; init; } = true;
+    public bool LeaveStreamOpen { get; set; } = true;
 
     /// <summary>
     /// Encoding to use for archive entry names.
     /// </summary>
-    public IArchiveEncoding ArchiveEncoding { get; init; } = new ArchiveEncoding();
+    public IArchiveEncoding ArchiveEncoding { get; set; } = new ArchiveEncoding();
 
     /// <summary>
     /// An optional progress reporter for tracking compression operations.
     /// </summary>
-    public IProgress<ProgressReport>? Progress { get; init; }
+    public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations.
     /// </summary>
-    public CompressionProviderRegistry Providers { get; init; } =
+    public CompressionProviderRegistry Providers { get; set; } =
         CompressionProviderRegistry.Default;
 
     /// <summary>
     /// Indicates if archive should be finalized (by 2 empty blocks) on close.
     /// </summary>
-    public bool FinalizeArchiveOnClose { get; init; } = true;
+    public bool FinalizeArchiveOnClose { get; set; } = true;
 
     /// <summary>
     /// The format to use when writing tar headers.
     /// </summary>
-    public TarHeaderWriteFormat HeaderFormat { get; init; } =
-        TarHeaderWriteFormat.GNU_TAR_LONG_LINK;
+    public TarHeaderWriteFormat HeaderFormat { get; set; } = TarHeaderWriteFormat.GNU_TAR_LONG_LINK;
 
     /// <summary>
     /// Creates a new TarWriterOptions instance with the specified compression type and finalization option.

--- a/src/SharpCompress/Writers/WriterOptions.cs
+++ b/src/SharpCompress/Writers/WriterOptions.cs
@@ -10,7 +10,7 @@ namespace SharpCompress.Writers;
 /// Options for configuring writer behavior when creating archives.
 /// </summary>
 /// <remarks>
-/// This class is immutable. Use factory methods for creation:
+/// Use factory methods, property setters, or fluent helpers for creation:
 /// <code>
 /// var options = WriterOptions.ForZip().WithLeaveStreamOpen(false).WithCompressionLevel(9);
 /// </code>
@@ -20,7 +20,7 @@ public sealed record WriterOptions : IWriterOptions
     /// <summary>
     /// The compression type to use for the archive.
     /// </summary>
-    public CompressionType CompressionType { get; init; }
+    public CompressionType CompressionType { get; set; }
 
     /// <summary>
     /// The compression level to be used when the compression type supports variable levels.
@@ -33,7 +33,7 @@ public sealed record WriterOptions : IWriterOptions
     public int CompressionLevel
     {
         get;
-        init
+        set
         {
             CompressionLevelValidation.Validate(CompressionType, value);
             field = value;
@@ -43,25 +43,25 @@ public sealed record WriterOptions : IWriterOptions
     /// <summary>
     /// SharpCompress will keep the supplied streams open.  Default is true.
     /// </summary>
-    public bool LeaveStreamOpen { get; init; } = true;
+    public bool LeaveStreamOpen { get; set; } = true;
 
     /// <summary>
     /// Encoding to use for archive entry names.
     /// </summary>
-    public IArchiveEncoding ArchiveEncoding { get; init; } = new ArchiveEncoding();
+    public IArchiveEncoding ArchiveEncoding { get; set; } = new ArchiveEncoding();
 
     /// <summary>
     /// An optional progress reporter for tracking compression operations.
     /// When set, progress updates will be reported as entries are written.
     /// </summary>
-    public IProgress<ProgressReport>? Progress { get; init; }
+    public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations, such as
     /// System.IO.Compression for Deflate/GZip on modern .NET.
     /// </summary>
-    public CompressionProviderRegistry Providers { get; init; } =
+    public CompressionProviderRegistry Providers { get; set; } =
         CompressionProviderRegistry.Default;
 
     /// <summary>

--- a/src/SharpCompress/Writers/Zip/ZipWriterOptions.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriterOptions.cs
@@ -13,7 +13,7 @@ namespace SharpCompress.Writers.Zip;
 /// Options for configuring Zip writer behavior.
 /// </summary>
 /// <remarks>
-/// This class is immutable. Use the <c>with</c> expression to create modified copies:
+/// Configure zip writing with constructors, property setters, or the <c>with</c> expression:
 /// <code>
 /// var options = new ZipWriterOptions(CompressionType.Zip);
 /// options = options with { UseZip64 = true };
@@ -30,7 +30,7 @@ public sealed record ZipWriterOptions : IWriterOptions
     public CompressionType CompressionType
     {
         get => _compressionType;
-        init => _compressionType = value;
+        set => _compressionType = value;
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public sealed record ZipWriterOptions : IWriterOptions
     public int CompressionLevel
     {
         get => _compressionLevel;
-        init
+        set
         {
             CompressionLevelValidation.Validate(CompressionType, value);
             _compressionLevel = value;
@@ -49,29 +49,29 @@ public sealed record ZipWriterOptions : IWriterOptions
     /// <summary>
     /// SharpCompress will keep the supplied streams open.  Default is true.
     /// </summary>
-    public bool LeaveStreamOpen { get; init; } = true;
+    public bool LeaveStreamOpen { get; set; } = true;
 
     /// <summary>
     /// Encoding to use for archive entry names.
     /// </summary>
-    public IArchiveEncoding ArchiveEncoding { get; init; } = new ArchiveEncoding();
+    public IArchiveEncoding ArchiveEncoding { get; set; } = new ArchiveEncoding();
 
     /// <summary>
     /// An optional progress reporter for tracking compression operations.
     /// </summary>
-    public IProgress<ProgressReport>? Progress { get; init; }
+    public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations.
     /// </summary>
-    public CompressionProviderRegistry Providers { get; init; } =
+    public CompressionProviderRegistry Providers { get; set; } =
         CompressionProviderRegistry.Default;
 
     /// <summary>
     /// Optional comment for the archive.
     /// </summary>
-    public string? ArchiveComment { get; init; }
+    public string? ArchiveComment { get; set; }
 
     /// <summary>
     /// Sets a value indicating if zip64 support is enabled.
@@ -80,7 +80,7 @@ public sealed record ZipWriterOptions : IWriterOptions
     /// Archives larger than 4GiB are supported as long as all streams
     /// are less than 4GiB in length.
     /// </summary>
-    public bool UseZip64 { get; init; }
+    public bool UseZip64 { get; set; }
 
     /// <summary>
     /// Creates a new ZipWriterOptions instance with the specified compression type.

--- a/src/SharpCompress/packages.lock.json
+++ b/src/SharpCompress/packages.lock.json
@@ -36,6 +36,12 @@
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
       },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
       "System.Text.Encoding.CodePages": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -139,6 +145,12 @@
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
       "System.Text.Encoding.CodePages": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -235,6 +247,12 @@
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
       },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
       "System.Text.Encoding.CodePages": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -268,9 +286,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.6, )",
-        "resolved": "10.0.6",
-        "contentHash": "QKuvS0LWX4fjFqeDkyM7Kqt8P3wYTiPD4nwU+9y59n0sCiG714fxDgbbN82vDnzq89AF/PiHl92TP2C4aFDUQA=="
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "AA/yhzFHNtQZXLdqjzujPy25G8EWwGWsAnxOE2zYSBoT/8QHP6ketN3CToD3DFreO653ipUwnKHo22B8AlBMCw=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
@@ -296,6 +314,12 @@
         "requested": "[17.14.15, )",
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -338,6 +362,12 @@
         "requested": "[17.14.15, )",
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
@@ -386,6 +416,12 @@
         "requested": "[17.14.15, )",
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",

--- a/tests/SharpCompress.Performance/packages.lock.json
+++ b/tests/SharpCompress.Performance/packages.lock.json
@@ -55,6 +55,12 @@
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
       },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
         "resolved": "0.15.8",

--- a/tests/SharpCompress.Test/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Test/OptionsUsabilityTests.cs
@@ -232,10 +232,15 @@ public class OptionsUsabilityTests : TestBase
     }
 
     [Fact]
-    public void Public_Option_Surface_Does_Not_Require_Init_Only_Setters()
+    public void Public_Api_Does_Not_Expose_CSharp_9_Required_Metadata()
     {
-        var initOnlyProperties = typeof(ReaderOptions)
-            .Assembly.GetExportedTypes()
+        var assembly = typeof(ReaderOptions).Assembly;
+        const string RequiredMemberAttributeName =
+            "System.Runtime.CompilerServices.RequiredMemberAttribute";
+        const string SetsRequiredMembersAttributeName =
+            "System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute";
+        var initOnlyProperties = assembly
+            .GetExportedTypes()
             .SelectMany(type =>
                 type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                     .Where(property => property.SetMethod?.IsPublic == true)
@@ -249,6 +254,40 @@ public class OptionsUsabilityTests : TestBase
             .ToArray();
 
         Assert.Empty(initOnlyProperties);
+
+        var requiredMembers = assembly
+            .GetExportedTypes()
+            .SelectMany(type =>
+                type.GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public)
+                    .Where(member =>
+                        member
+                            .GetCustomAttributesData()
+                            .Any(attribute =>
+                                attribute.AttributeType.FullName == RequiredMemberAttributeName
+                            )
+                    )
+                    .Select(member => $"{type.FullName}.{member.Name}")
+            )
+            .ToArray();
+
+        Assert.Empty(requiredMembers);
+
+        var constructorsWithRequiredMembers = assembly
+            .GetExportedTypes()
+            .SelectMany(type =>
+                type.GetConstructors(BindingFlags.Instance | BindingFlags.Public)
+                    .Where(constructor =>
+                        constructor
+                            .GetCustomAttributesData()
+                            .Any(attribute =>
+                                attribute.AttributeType.FullName == SetsRequiredMembersAttributeName
+                            )
+                    )
+                    .Select(_ => $"{type.FullName}.ctor")
+            )
+            .ToArray();
+
+        Assert.Empty(constructorsWithRequiredMembers);
     }
 
     [Fact]

--- a/tests/SharpCompress.Test/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Test/OptionsUsabilityTests.cs
@@ -1,5 +1,8 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using SharpCompress.Archives;
 using SharpCompress.Common;
@@ -226,6 +229,26 @@ public class OptionsUsabilityTests : TestBase
         var preserveMetadata = ExtractionOptions.PreserveMetadata;
         Assert.True(preserveMetadata.PreserveFileTime);
         Assert.True(preserveMetadata.PreserveAttributes);
+    }
+
+    [Fact]
+    public void Public_Option_Surface_Does_Not_Require_Init_Only_Setters()
+    {
+        var initOnlyProperties = typeof(ReaderOptions)
+            .Assembly.GetExportedTypes()
+            .SelectMany(type =>
+                type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .Where(property => property.SetMethod?.IsPublic == true)
+                    .Where(property =>
+                        property
+                            .SetMethod!.ReturnParameter.GetRequiredCustomModifiers()
+                            .Contains(typeof(IsExternalInit))
+                    )
+                    .Select(property => $"{type.FullName}.{property.Name}")
+            )
+            .ToArray();
+
+        Assert.Empty(initOnlyProperties);
     }
 
     [Fact]

--- a/tests/SharpCompress.Test/packages.lock.json
+++ b/tests/SharpCompress.Test/packages.lock.json
@@ -45,6 +45,12 @@
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
       },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
       "xunit.runner.visualstudio": {
         "type": "Direct",
         "requested": "[3.1.5, )",
@@ -309,6 +315,30 @@
         }
       }
     },
+    ".NETFramework,Version=v4.8/win-x86": {
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg==",
+        "dependencies": {
+          "System.Security.AccessControl": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
+        }
+      },
+      "System.Security.AccessControl": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dagJ1mHZO3Ani8GH0PHpPEe/oYO+rVdbQjvjJkBRNQkX4t0r1iaeGn8+/ybkSLEan3/slM0t59SVdHzuHf2jmw==",
+        "dependencies": {
+          "System.Security.Principal.Windows": "5.0.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
+      }
+    },
     "net10.0": {
       "AwesomeAssertions": {
         "type": "Direct",
@@ -350,6 +380,12 @@
         "requested": "[17.14.15, )",
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.15.0, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
@@ -520,6 +556,13 @@
         "requested": "[8.0.0, )",
         "resolved": "8.0.0",
         "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
+      }
+    },
+    "net10.0/win-x86": {
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/adamhathcock/sharpcompress/issues/1329

This pull request introduces significant changes to the mutability of various options and configuration classes across the codebase, shifting from immutable `init`-only properties to mutable `set` properties. This enables modifying options after object creation, increasing flexibility in how these objects are used and configured. Additionally, the PR updates documentation to reflect these changes and adds a new package dependency.

Key changes include:

**Mutability Changes Across Options and Records:**

* Changed most properties in options interfaces and records (such as `IExtractionOptions`, `IReaderOptions`, `IWriterOptions`, `ExtractionOptions`, `ReaderOptions`, `GZipWriterOptions`, `SevenZipWriterOptions`, and `CompressionContext`) from `init`-only to standard `set` properties, making them mutable after construction. This impacts how these objects can be used, allowing for property modifications post-instantiation. [[1]](diffhunk://#diff-c039d222cbe3e827d844a6543e03fc0d1815484a851496ec8e89e9b52ae56adaL22-R50) [[2]](diffhunk://#diff-a0a2905d41815a8413aba21617704f6988487bf287257ed99d15e8372be8f6d5L14-R38) [[3]](diffhunk://#diff-b78f05a3a1fdb25d43099e1a741dea900c12576917cdae447469d771a7df070bL11-R43) [[4]](diffhunk://#diff-09cbb9eed9db335a09d2820b178e259f70cda4568032f1d654a653d51d5cb159L15-R27) [[5]](diffhunk://#diff-9b0a59e6c4ea7e1a3a33cc68a25bde185674fd9d09c53c505f5ad0f1f26e4cf7L15-R30) [[6]](diffhunk://#diff-9b0a59e6c4ea7e1a3a33cc68a25bde185674fd9d09c53c505f5ad0f1f26e4cf7L41-R41) [[7]](diffhunk://#diff-9b0a59e6c4ea7e1a3a33cc68a25bde185674fd9d09c53c505f5ad0f1f26e4cf7L54-R54) [[8]](diffhunk://#diff-13748160e4b6d80308b56fe7dd47fd436e1f6bcc739123932ed596228b9b1188L56-R92) [[9]](diffhunk://#diff-13748160e4b6d80308b56fe7dd47fd436e1f6bcc739123932ed596228b9b1188L136-R143) [[10]](diffhunk://#diff-ec3465a208d763878304dda0ebcce389add70d43f14cad60495086a174dfa43fL30-R30) [[11]](diffhunk://#diff-ec3465a208d763878304dda0ebcce389add70d43f14cad60495086a174dfa43fL49-R49) [[12]](diffhunk://#diff-ec3465a208d763878304dda0ebcce389add70d43f14cad60495086a174dfa43fL59-R76) [[13]](diffhunk://#diff-c358f4c29e89879f75339cfbd7cb1162c586f2b2911ddf021eed0479e90e6c2fL23-R23) [[14]](diffhunk://#diff-da6908183ac0348dc4de4397e5e0f00ac8dc029132774e273584959319d634ffL5-R5) [[15]](diffhunk://#diff-fdd7be5459eed2d283efbd8f9126556cd89f4f99e6026d87e118fe486f6fbd32L7-R7) [[16]](diffhunk://#diff-0ab552186c0114745b95bf4ace7508c7796bba20da057c77a5541a289f62e756L5-R5)

* Refactored `ArchiveInformation` from a positional record with init-only properties to a class with mutable properties and an explicit constructor, improving clarity and consistency with the new mutability model.

**Documentation and Usability Updates:**

* Updated XML documentation and remarks in several files to clarify that options can now be configured with property setters, not just via constructors or `with` expressions, reflecting the move to mutable properties. [[1]](diffhunk://#diff-c039d222cbe3e827d844a6543e03fc0d1815484a851496ec8e89e9b52ae56adaL10-R10) [[2]](diffhunk://#diff-13748160e4b6d80308b56fe7dd47fd436e1f6bcc739123932ed596228b9b1188L13-R13) [[3]](diffhunk://#diff-ec3465a208d763878304dda0ebcce389add70d43f14cad60495086a174dfa43fL15-R15)

**Dependency Management:**

* Added a new global package reference to `PolySharp` version 1.15.0 in `Directory.Packages.props` and updated the lock file accordingly. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R21) [[2]](diffhunk://#diff-d4f5e1663f2dbe2f891a4b071854faf7059d2c898fb4372b75eb98e4be04945bR42-R47)