### PR TITLE
LeaveOpen wasn't respected by GZip

### DIFF
--- a/src/SharpCompress/Compressors/Deflate/GZipStream.cs
+++ b/src/SharpCompress/Compressors/Deflate/GZipStream.cs
@@ -71,6 +71,7 @@ public partial class GZipStream : Stream
             stream,
             mode,
             level,
+            readerOptions.LeaveStreamOpen,
             (
                 readerOptions ?? throw new ArgumentNullException(nameof(readerOptions))
             ).ArchiveEncoding.GetEncoding()

--- a/src/SharpCompress/Compressors/Deflate/GZipStream.cs
+++ b/src/SharpCompress/Compressors/Deflate/GZipStream.cs
@@ -71,20 +71,28 @@ public partial class GZipStream : Stream
             stream,
             mode,
             level,
-            readerOptions.LeaveStreamOpen,
             (
                 readerOptions ?? throw new ArgumentNullException(nameof(readerOptions))
-            ).ArchiveEncoding.GetEncoding()
+            ).ArchiveEncoding.GetEncoding(),
+            readerOptions.LeaveStreamOpen
         ) { }
 
     public GZipStream(
         Stream stream,
         CompressionMode mode,
         CompressionLevel level,
-        Encoding encoding
+        Encoding encoding,
+        bool leaveOpen = false
     )
     {
-        BaseStream = new ZlibBaseStream(stream, mode, level, ZlibStreamFlavor.GZIP, encoding);
+        BaseStream = new ZlibBaseStream(
+            stream,
+            mode,
+            level,
+            ZlibStreamFlavor.GZIP,
+            leaveOpen,
+            encoding
+        );
         _encoding = encoding;
     }
 


### PR DESCRIPTION
bugfix from: https://github.com/adamhathcock/sharpcompress/pull/1282

This pull request makes a small change to the `GZipStream` class to ensure that the `LeaveStreamOpen` option from `readerOptions` is passed when initializing the stream. This helps control whether the underlying stream remains open after the `GZipStream` is disposed.