### PR TITLE
Instanced buffer size

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "1.2.6",
+      "version": "1.3.0",
       "commands": [
         "csharpier"
       ],

--- a/docs/API.md
+++ b/docs/API.md
@@ -315,6 +315,9 @@ var safeOptions = ExtractionOptions.SafeExtract;  // No overwrite
 var flatOptions = ExtractionOptions.FlatExtract;  // No directory structure
 var metadataOptions = ExtractionOptions.PreserveMetadata; // Keep timestamps and attributes
 
+// Tune extraction copy buffering
+var extractionOptions = new ExtractionOptions { BufferSize = 131072 };
+
 // Factory defaults:
 // - file path / FileInfo overloads use LeaveStreamOpen = false
 // - stream overloads use LeaveStreamOpen = true
@@ -333,6 +336,13 @@ var options = new ReaderOptions
     DisableCheckIncomplete = false,
     BufferSize = 81920,
     RewindableBufferSize = 1_048_576,
+};
+
+var extractionOptions = new ExtractionOptions
+{
+    ExtractFullPath = true,
+    Overwrite = true,
+    BufferSize = 131072,
 };
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -92,7 +92,8 @@ using (var archive = GZipArchive.CreateArchive())
 // With fluent options (preferred)
 var options = WriterOptions.ForZip()
     .WithCompressionLevel(9)
-    .WithLeaveStreamOpen(false);
+    .WithLeaveStreamOpen(false)
+    .WithBufferSize(131072);
 using (var archive = ZipArchive.CreateArchive())
 {
     archive.SaveTo("output.zip", options);
@@ -102,9 +103,12 @@ using (var archive = ZipArchive.CreateArchive())
 var options2 = new WriterOptions(CompressionType.Deflate)
 {
     CompressionLevel = 9,
-    LeaveStreamOpen = false
+    LeaveStreamOpen = false,
+    BufferSize = 131072
 };
 ```
+
+`WriterOptions.BufferSize` controls stream copy buffers used while writing archive entries. If it is not set, SharpCompress falls back to `Constants.BufferSize`.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -100,7 +100,12 @@ using (var archive = RarArchive.OpenArchive("Test.rar", ReaderOptions.ForFilePat
     // Simple extraction with RarArchive; this WriteToDirectory pattern works for all archive types
     archive.WriteToDirectory(
         @"D:\temp",
-        new ExtractionOptions { ExtractFullPath = true, Overwrite = true }
+        new ExtractionOptions
+        {
+            ExtractFullPath = true,
+            Overwrite = true,
+            BufferSize = 131072,
+        }
     );
 }
 ```

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.300",
-    "rollForward": "latestPatch"
+    "rollForward": "disable"
   }
 }

--- a/src/SharpCompress/Archives/IArchiveEntryExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveEntryExtensions.cs
@@ -17,7 +17,8 @@ public static class IArchiveEntryExtensions
         /// </summary>
         /// <param name="streamToWriteTo">The stream to write the entry content to.</param>
         /// <param name="progress">Optional progress reporter for tracking extraction progress.</param>
-        public void WriteTo(Stream streamToWriteTo, IProgress<ProgressReport>? progress = null) => archiveEntry.WriteTo(streamToWriteTo, null, progress);
+        public void WriteTo(Stream streamToWriteTo, IProgress<ProgressReport>? progress = null) =>
+            archiveEntry.WriteTo(streamToWriteTo, null, progress);
 
         private void WriteTo(
             Stream streamToWriteTo,

--- a/src/SharpCompress/Archives/IArchiveEntryExtensions.cs
+++ b/src/SharpCompress/Archives/IArchiveEntryExtensions.cs
@@ -17,7 +17,13 @@ public static class IArchiveEntryExtensions
         /// </summary>
         /// <param name="streamToWriteTo">The stream to write the entry content to.</param>
         /// <param name="progress">Optional progress reporter for tracking extraction progress.</param>
-        public void WriteTo(Stream streamToWriteTo, IProgress<ProgressReport>? progress = null)
+        public void WriteTo(Stream streamToWriteTo, IProgress<ProgressReport>? progress = null) => archiveEntry.WriteTo(streamToWriteTo, null, progress);
+
+        private void WriteTo(
+            Stream streamToWriteTo,
+            int? bufferSize,
+            IProgress<ProgressReport>? progress = null
+        )
         {
             if (archiveEntry.IsDirectory)
             {
@@ -26,7 +32,7 @@ public static class IArchiveEntryExtensions
 
             using var entryStream = archiveEntry.OpenEntryStream();
             var sourceStream = WrapWithProgress(entryStream, archiveEntry, progress);
-            sourceStream.CopyTo(streamToWriteTo, Constants.BufferSize);
+            sourceStream.CopyTo(streamToWriteTo, bufferSize ?? Constants.BufferSize);
         }
 
         /// <summary>
@@ -37,6 +43,18 @@ public static class IArchiveEntryExtensions
         /// <param name="progress">Optional progress reporter for tracking extraction progress.</param>
         public async ValueTask WriteToAsync(
             Stream streamToWriteTo,
+            IProgress<ProgressReport>? progress = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            await archiveEntry
+                .WriteToAsync(streamToWriteTo, Constants.BufferSize, progress, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        private async ValueTask WriteToAsync(
+            Stream streamToWriteTo,
+            int? bufferSize,
             IProgress<ProgressReport>? progress = null,
             CancellationToken cancellationToken = default
         )
@@ -57,7 +75,7 @@ public static class IArchiveEntryExtensions
 #endif
             var sourceStream = WrapWithProgress(entryStream, archiveEntry, progress);
             await sourceStream
-                .CopyToAsync(streamToWriteTo, Constants.BufferSize, cancellationToken)
+                .CopyToAsync(streamToWriteTo, bufferSize ?? Constants.BufferSize, cancellationToken)
                 .ConfigureAwait(false);
         }
     }
@@ -133,16 +151,18 @@ public static class IArchiveEntryExtensions
         /// <summary>
         /// Extract to specific file
         /// </summary>
-        public void WriteToFile(string destinationFileName, ExtractionOptions? options = null) =>
+        public void WriteToFile(string destinationFileName, ExtractionOptions? options = null)
+        {
             entry.WriteEntryToFile(
                 destinationFileName,
                 options,
                 (x, fm) =>
                 {
-                    using var fs = File.Open(destinationFileName, fm);
-                    entry.WriteTo(fs);
+                    using var fs = File.Open(x, fm);
+                    entry.WriteTo(fs, options?.BufferSize ?? Constants.BufferSize);
                 }
             );
+        }
 
         /// <summary>
         /// Extract to specific file asynchronously
@@ -158,8 +178,10 @@ public static class IArchiveEntryExtensions
                     options,
                     async (x, fm, ct) =>
                     {
-                        using var fs = File.Open(destinationFileName, fm);
-                        await entry.WriteToAsync(fs, null, ct).ConfigureAwait(false);
+                        using var fs = File.Open(x, fm);
+                        await entry
+                            .WriteToAsync(fs, options?.BufferSize, null, ct)
+                            .ConfigureAwait(false);
                     },
                     cancellationToken
                 )

--- a/src/SharpCompress/Common/Constants.cs
+++ b/src/SharpCompress/Common/Constants.cs
@@ -8,6 +8,7 @@ public static class Constants
     /// The default buffer size for stream operations, matching .NET's Stream.CopyTo default of 81920 bytes.
     /// This can be modified globally at runtime.
     /// </summary>
+    // TODO: Revisit remaining non-extraction usages after extraction buffering moves to ExtractionOptions.
     public static int BufferSize { get; set; } = 81920;
 
     /// <summary>

--- a/src/SharpCompress/Common/ExtractionOptions.cs
+++ b/src/SharpCompress/Common/ExtractionOptions.cs
@@ -39,6 +39,11 @@ public sealed record ExtractionOptions : IExtractionOptions
     public bool PreserveAttributes { get; set; }
 
     /// <summary>
+    /// Buffer size for extraction stream copy operations.
+    /// </summary>
+    public int BufferSize { get; set; } = Constants.BufferSize;
+
+    /// <summary>
     /// Delegate for writing symbolic links to disk.
     /// The first parameter is the source path (where the symlink is created).
     /// The second parameter is the target path (what the symlink refers to).

--- a/src/SharpCompress/Common/Options/IExtractionOptions.cs
+++ b/src/SharpCompress/Common/Options/IExtractionOptions.cs
@@ -31,6 +31,11 @@ public interface IExtractionOptions
     bool PreserveAttributes { get; set; }
 
     /// <summary>
+    /// Buffer size for extraction stream copy operations.
+    /// </summary>
+    int BufferSize { get; set; }
+
+    /// <summary>
     /// Delegate for writing symbolic links to disk.
     /// The first parameter is the source path (where the symlink is created).
     /// The second parameter is the target path (what the symlink refers to).

--- a/src/SharpCompress/Common/Options/IWriterOptions.cs
+++ b/src/SharpCompress/Common/Options/IWriterOptions.cs
@@ -20,6 +20,11 @@ public interface IWriterOptions : IStreamOptions, IEncodingOptions, IProgressOpt
     int CompressionLevel { get; set; }
 
     /// <summary>
+    /// Buffer size for writer stream copy operations.
+    /// </summary>
+    int BufferSize { get; set; }
+
+    /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom providers, such as
     /// System.IO.Compression for Deflate/GZip on modern .NET.

--- a/src/SharpCompress/Readers/AbstractReader.Async.cs
+++ b/src/SharpCompress/Readers/AbstractReader.Async.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using SharpCompress.Common;
-using SharpCompress.IO;
 
 namespace SharpCompress.Readers;
 
@@ -138,19 +137,19 @@ public abstract partial class AbstractReader<TEntry, TVolume>
         _wroteCurrentEntry = true;
     }
 
-    internal async ValueTask WriteAsync(Stream writeStream, CancellationToken cancellationToken)
+    private async ValueTask WriteAsync(Stream writeStream, CancellationToken cancellationToken)
     {
 #if LEGACY_DOTNET
         using Stream s = await OpenEntryStreamAsync(cancellationToken).ConfigureAwait(false);
         var sourceStream = WrapWithProgress(s, Entry);
         await sourceStream
-            .CopyToAsync(writeStream, Constants.BufferSize, cancellationToken)
+            .CopyToAsync(writeStream, Options.BufferSize, cancellationToken)
             .ConfigureAwait(false);
 #else
         await using Stream s = await OpenEntryStreamAsync(cancellationToken).ConfigureAwait(false);
         var sourceStream = WrapWithProgress(s, Entry);
         await sourceStream
-            .CopyToAsync(writeStream, Constants.BufferSize, cancellationToken)
+            .CopyToAsync(writeStream, Options.BufferSize, cancellationToken)
             .ConfigureAwait(false);
 #endif
     }
@@ -187,9 +186,7 @@ public abstract partial class AbstractReader<TEntry, TVolume>
     /// <summary>
     /// Moves the current async enumerator to the next entry.
     /// </summary>
-    internal virtual ValueTask<bool> NextEntryForCurrentStreamAsync(
-        CancellationToken cancellationToken
-    )
+    private ValueTask<bool> NextEntryForCurrentStreamAsync(CancellationToken cancellationToken)
     {
         if (_entriesForCurrentReadStreamAsync is not null)
         {
@@ -202,6 +199,9 @@ public abstract partial class AbstractReader<TEntry, TVolume>
     // Async iterator method
     protected virtual async IAsyncEnumerable<TEntry> GetEntriesAsync(Stream stream)
     {
+#pragma warning disable VSTHRD111
+        await Task.CompletedTask;
+#pragma warning restore VSTHRD111
         foreach (var entry in GetEntries(stream))
         {
             yield return entry;

--- a/src/SharpCompress/Readers/AbstractReader.cs
+++ b/src/SharpCompress/Readers/AbstractReader.cs
@@ -179,7 +179,10 @@ public abstract partial class AbstractReader<TEntry, TVolume> : IReader, IAsyncR
         s.SkipEntry();
     }
 
-    public void WriteEntryTo(Stream writableStream)
+    public void WriteEntryTo(Stream writableStream) =>
+        WriteEntryTo(writableStream, Options.BufferSize);
+
+    private void WriteEntryTo(Stream writableStream, int bufferSize)
     {
         if (_wroteCurrentEntry)
         {
@@ -194,15 +197,17 @@ public abstract partial class AbstractReader<TEntry, TVolume> : IReader, IAsyncR
             );
         }
 
-        Write(writableStream);
+        Write(writableStream, bufferSize);
         _wroteCurrentEntry = true;
     }
 
-    internal void Write(Stream writeStream)
+    internal void Write(Stream writeStream) => Write(writeStream, Options.BufferSize);
+
+    internal void Write(Stream writeStream, int bufferSize)
     {
         using Stream s = OpenEntryStream();
         var sourceStream = WrapWithProgress(s, Entry);
-        sourceStream.CopyTo(writeStream, Constants.BufferSize);
+        sourceStream.CopyTo(writeStream, bufferSize);
     }
 
     private Stream WrapWithProgress(Stream source, Entry entry)

--- a/src/SharpCompress/Readers/IAsyncReaderExtensions.cs
+++ b/src/SharpCompress/Readers/IAsyncReaderExtensions.cs
@@ -1,7 +1,9 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using SharpCompress.Common;
+using SharpCompress.IO;
 
 namespace SharpCompress.Readers;
 
@@ -42,7 +44,8 @@ public static class IAsyncReaderExtensions
                     async (x, fm, ct) =>
                     {
                         using var fs = File.Open(x, fm);
-                        await reader.WriteEntryToAsync(fs, ct).ConfigureAwait(false);
+                        await CopyEntryToAsync(reader, fs, options?.BufferSize, ct)
+                            .ConfigureAwait(false);
                     },
                     cancellationToken
                 )
@@ -77,7 +80,8 @@ public static class IAsyncReaderExtensions
                     async (x, fm, ct) =>
                     {
                         using var fs = File.Open(x, fm);
-                        await reader.WriteEntryToAsync(fs, ct).ConfigureAwait(false);
+                        await CopyEntryToAsync(reader, fs, options?.BufferSize, ct)
+                            .ConfigureAwait(false);
                     },
                     cancellationToken
                 )
@@ -91,5 +95,59 @@ public static class IAsyncReaderExtensions
             await reader
                 .WriteEntryToAsync(destinationFileInfo.FullName, options, cancellationToken)
                 .ConfigureAwait(false);
+    }
+
+    private static async ValueTask CopyEntryToAsync(
+        IAsyncReader reader,
+        Stream writableStream,
+        int? bufferSize,
+        CancellationToken cancellationToken
+    )
+    {
+#if LEGACY_DOTNET
+        using var entryStream = await reader
+            .OpenEntryStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+#else
+        await using var entryStream = await reader
+            .OpenEntryStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+#endif
+        var sourceStream = WrapWithProgress(entryStream, reader.Entry);
+        await sourceStream
+            .CopyToAsync(writableStream, bufferSize ?? Constants.BufferSize, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static Stream WrapWithProgress(Stream source, IEntry entry)
+    {
+        var progress = entry.Options.Progress;
+        if (progress is null)
+        {
+            return source;
+        }
+
+        var entryPath = entry.Key ?? string.Empty;
+        var totalBytes = GetEntrySizeSafe(entry);
+        return new ProgressReportingStream(
+            source,
+            progress,
+            entryPath,
+            totalBytes,
+            leaveOpen: true
+        );
+    }
+
+    private static long? GetEntrySizeSafe(IEntry entry)
+    {
+        try
+        {
+            var size = entry.Size;
+            return size >= 0 ? size : null;
+        }
+        catch (NotImplementedException)
+        {
+            return null;
+        }
     }
 }

--- a/src/SharpCompress/Readers/IReaderExtensions.cs
+++ b/src/SharpCompress/Readers/IReaderExtensions.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using SharpCompress.Common;
+using SharpCompress.IO;
 
 namespace SharpCompress.Readers;
 
@@ -58,9 +60,48 @@ public static class IReaderExtensions
                 options,
                 (x, fm) =>
                 {
-                    using var fs = File.Open(destinationFileName, fm);
-                    reader.WriteEntryTo(fs);
+                    using var fs = File.Open(x, fm);
+                    CopyEntryTo(reader, fs, options?.BufferSize ?? Constants.BufferSize);
                 }
             );
+    }
+
+    private static void CopyEntryTo(IReader reader, Stream writableStream, int bufferSize)
+    {
+        using var entryStream = reader.OpenEntryStream();
+        var sourceStream = WrapWithProgress(entryStream, reader.Entry);
+        sourceStream.CopyTo(writableStream, bufferSize);
+    }
+
+    private static Stream WrapWithProgress(Stream source, IEntry entry)
+    {
+        var progress = entry.Options.Progress;
+        if (progress is null)
+        {
+            return source;
+        }
+
+        var entryPath = entry.Key ?? string.Empty;
+        var totalBytes = GetEntrySizeSafe(entry);
+        return new ProgressReportingStream(
+            source,
+            progress,
+            entryPath,
+            totalBytes,
+            leaveOpen: true
+        );
+    }
+
+    private static long? GetEntrySizeSafe(IEntry entry)
+    {
+        try
+        {
+            var size = entry.Size;
+            return size >= 0 ? size : null;
+        }
+        catch (NotImplementedException)
+        {
+            return null;
+        }
     }
 }

--- a/src/SharpCompress/Utility.Async.cs
+++ b/src/SharpCompress/Utility.Async.cs
@@ -65,13 +65,14 @@ internal static partial class Utility
         public async ValueTask<long> TransferToAsync(
             Stream destination,
             long maxLength,
+            int? bufferSize = null,
             CancellationToken cancellationToken = default
         )
         {
             // Use ReadOnlySubStream to limit reading and leverage framework's CopyToAsync
             using var limitedStream = new IO.ReadOnlySubStream(source, maxLength);
             await limitedStream
-                .CopyToAsync(destination, Constants.BufferSize, cancellationToken)
+                .CopyToAsync(destination, bufferSize ?? Constants.BufferSize, cancellationToken)
                 .ConfigureAwait(false);
             return limitedStream.Position;
         }

--- a/src/SharpCompress/Utility.cs
+++ b/src/SharpCompress/Utility.cs
@@ -150,11 +150,11 @@ internal static partial class Utility
 
     extension(Stream source)
     {
-        public long TransferTo(Stream destination, long maxLength)
+        public long TransferTo(Stream destination, long maxLength, int? bufferSize)
         {
             // Use ReadOnlySubStream to limit reading and leverage framework's CopyTo
             using var limitedStream = new IO.ReadOnlySubStream(source, maxLength);
-            limitedStream.CopyTo(destination, Constants.BufferSize);
+            limitedStream.CopyTo(destination, bufferSize ?? Constants.BufferSize);
             return limitedStream.Position;
         }
 

--- a/src/SharpCompress/Writers/GZip/GZipWriter.cs
+++ b/src/SharpCompress/Writers/GZip/GZipWriter.cs
@@ -86,7 +86,7 @@ public sealed partial class GZipWriter : AbstractWriter
         }
 
         var progressStream = WrapWithProgress(source, filename);
-        progressStream.CopyTo(OutputStream.NotNull(), Constants.BufferSize);
+        progressStream.CopyTo(OutputStream.NotNull(), WriterOptions.BufferSize);
         _wroteToStream = true;
     }
 

--- a/src/SharpCompress/Writers/GZip/GZipWriterOptions.cs
+++ b/src/SharpCompress/Writers/GZip/GZipWriterOptions.cs
@@ -69,6 +69,11 @@ public sealed record GZipWriterOptions : IWriterOptions
     public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
+    /// Buffer size for writer stream copy operations.
+    /// </summary>
+    public int BufferSize { get; set; } = Constants.BufferSize;
+
+    /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations, such as
     /// System.IO.Compression for GZip on modern .NET.
@@ -115,6 +120,7 @@ public sealed record GZipWriterOptions : IWriterOptions
         LeaveStreamOpen = options.LeaveStreamOpen;
         ArchiveEncoding = options.ArchiveEncoding;
         Progress = options.Progress;
+        BufferSize = options.BufferSize;
         Providers = options.Providers;
     }
 
@@ -128,6 +134,7 @@ public sealed record GZipWriterOptions : IWriterOptions
         LeaveStreamOpen = options.LeaveStreamOpen;
         ArchiveEncoding = options.ArchiveEncoding;
         Progress = options.Progress;
+        BufferSize = options.BufferSize;
         Providers = options.Providers;
     }
 }

--- a/src/SharpCompress/Writers/SevenZip/SevenZipWriterOptions.cs
+++ b/src/SharpCompress/Writers/SevenZip/SevenZipWriterOptions.cs
@@ -58,6 +58,11 @@ public sealed record SevenZipWriterOptions : IWriterOptions
     public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
+    /// Buffer size for writer stream copy operations.
+    /// </summary>
+    public int BufferSize { get; set; } = Constants.BufferSize;
+
+    /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations.
     /// </summary>
@@ -103,6 +108,7 @@ public sealed record SevenZipWriterOptions : IWriterOptions
         LeaveStreamOpen = options.LeaveStreamOpen;
         ArchiveEncoding = options.ArchiveEncoding;
         Progress = options.Progress;
+        BufferSize = options.BufferSize;
         Providers = options.Providers;
     }
 
@@ -117,6 +123,7 @@ public sealed record SevenZipWriterOptions : IWriterOptions
         LeaveStreamOpen = options.LeaveStreamOpen;
         ArchiveEncoding = options.ArchiveEncoding;
         Progress = options.Progress;
+        BufferSize = options.BufferSize;
         Providers = options.Providers;
     }
 

--- a/src/SharpCompress/Writers/Tar/TarWriter.Async.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriter.Async.cs
@@ -104,7 +104,12 @@ public partial class TarWriter
         await header.WriteAsync(OutputStream.NotNull(), cancellationToken).ConfigureAwait(false);
         var progressStream = WrapWithProgress(source, filename);
         var written = await progressStream
-            .TransferToAsync(OutputStream.NotNull(), realSize, cancellationToken)
+            .TransferToAsync(
+                OutputStream.NotNull(),
+                realSize,
+                WriterOptions.BufferSize,
+                cancellationToken
+            )
             .ConfigureAwait(false);
         await PadTo512Async(written, cancellationToken).ConfigureAwait(false);
     }

--- a/src/SharpCompress/Writers/Tar/TarWriter.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriter.cs
@@ -133,7 +133,11 @@ public partial class TarWriter : AbstractWriter
         header.Size = realSize;
         header.Write(OutputStream.NotNull());
         var progressStream = WrapWithProgress(source, filename);
-        size = progressStream.TransferTo(OutputStream.NotNull(), realSize);
+        size = progressStream.TransferTo(
+            OutputStream.NotNull(),
+            realSize,
+            WriterOptions.BufferSize
+        );
         PadTo512(size.Value);
     }
 

--- a/src/SharpCompress/Writers/Tar/TarWriterOptions.cs
+++ b/src/SharpCompress/Writers/Tar/TarWriterOptions.cs
@@ -45,6 +45,11 @@ public sealed record TarWriterOptions : IWriterOptions
     public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
+    /// Buffer size for writer stream copy operations.
+    /// </summary>
+    public int BufferSize { get; set; } = Constants.BufferSize;
+
+    /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations.
     /// </summary>
@@ -104,6 +109,7 @@ public sealed record TarWriterOptions : IWriterOptions
         LeaveStreamOpen = options.LeaveStreamOpen;
         ArchiveEncoding = options.ArchiveEncoding;
         Progress = options.Progress;
+        BufferSize = options.BufferSize;
         Providers = options.Providers;
     }
 
@@ -118,6 +124,7 @@ public sealed record TarWriterOptions : IWriterOptions
         LeaveStreamOpen = options.LeaveStreamOpen;
         ArchiveEncoding = options.ArchiveEncoding;
         Progress = options.Progress;
+        BufferSize = options.BufferSize;
         Providers = options.Providers;
     }
 

--- a/src/SharpCompress/Writers/WriterOptions.cs
+++ b/src/SharpCompress/Writers/WriterOptions.cs
@@ -57,6 +57,11 @@ public sealed record WriterOptions : IWriterOptions
     public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
+    /// Buffer size for writer stream copy operations.
+    /// </summary>
+    public int BufferSize { get; set; } = Constants.BufferSize;
+
+    /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations, such as
     /// System.IO.Compression for Deflate/GZip on modern .NET.

--- a/src/SharpCompress/Writers/WriterOptionsExtensions.cs
+++ b/src/SharpCompress/Writers/WriterOptionsExtensions.cs
@@ -54,6 +54,15 @@ public static class WriterOptionsExtensions
         };
 
     /// <summary>
+    /// Creates a copy with the specified buffer size.
+    /// </summary>
+    public static WriterOptions WithBufferSize(this WriterOptions options, int bufferSize) =>
+        options with
+        {
+            BufferSize = bufferSize,
+        };
+
+    /// <summary>
     /// Creates a copy with the specified compression level.
     /// </summary>
     /// <param name="options">The source options.</param>

--- a/src/SharpCompress/Writers/Zip/ZipWriter.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriter.cs
@@ -16,7 +16,6 @@ using SharpCompress.Compressors.PPMd;
 using SharpCompress.Compressors.ZStandard;
 using SharpCompress.IO;
 using SharpCompress.Providers;
-using Constants = SharpCompress.Common.Constants;
 
 namespace SharpCompress.Writers.Zip;
 
@@ -89,7 +88,7 @@ public partial class ZipWriter : AbstractWriter
     {
         using var output = WriteToStream(entryPath, zipWriterEntryOptions);
         var progressStream = WrapWithProgress(source, entryPath);
-        progressStream.CopyTo(output, Constants.BufferSize);
+        progressStream.CopyTo(output, WriterOptions.BufferSize);
     }
 
     public Stream WriteToStream(string entryPath, ZipWriterEntryOptions options)

--- a/src/SharpCompress/Writers/Zip/ZipWriterOptions.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriterOptions.cs
@@ -62,6 +62,11 @@ public sealed record ZipWriterOptions : IWriterOptions
     public IProgress<ProgressReport>? Progress { get; set; }
 
     /// <summary>
+    /// Buffer size for writer stream copy operations.
+    /// </summary>
+    public int BufferSize { get; set; } = Constants.BufferSize;
+
+    /// <summary>
     /// Registry of compression providers.
     /// Defaults to <see cref="CompressionProviderRegistry.Default" /> but can be replaced with custom implementations.
     /// </summary>
@@ -128,6 +133,7 @@ public sealed record ZipWriterOptions : IWriterOptions
         LeaveStreamOpen = options.LeaveStreamOpen;
         ArchiveEncoding = options.ArchiveEncoding;
         Progress = options.Progress;
+        BufferSize = options.BufferSize;
         Providers = options.Providers;
     }
 
@@ -141,6 +147,7 @@ public sealed record ZipWriterOptions : IWriterOptions
         LeaveStreamOpen = options.LeaveStreamOpen;
         ArchiveEncoding = options.ArchiveEncoding;
         Progress = options.Progress;
+        BufferSize = options.BufferSize;
         Providers = options.Providers;
     }
 

--- a/src/SharpCompress/packages.lock.json
+++ b/src/SharpCompress/packages.lock.json
@@ -321,9 +321,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
@@ -441,9 +441,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.28, )",
-        "resolved": "8.0.28",
-        "contentHash": "XMqgVjlLxLqWmEh3c49haXLQwsMNtvo6YscUaqfvEGfg1iA8hnYgkUVq3i9Zu9gKeNKMWiiZKVwZExc/qyEAsQ=="
+        "requested": "[8.0.27, )",
+        "resolved": "8.0.27",
+        "contentHash": "rQi9TxifHRnXP7lVRZH05DxD2/XGbJp12q0ozcbrlBlBnyyzssFTH/2vLhtKWUp2CT1qVscTrcYTFiwTyKPKRg=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",

--- a/src/SharpCompress/packages.lock.json
+++ b/src/SharpCompress/packages.lock.json
@@ -321,9 +321,9 @@
     "net10.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
@@ -441,9 +441,9 @@
     "net8.0": {
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.27, )",
-        "resolved": "8.0.27",
-        "contentHash": "rQi9TxifHRnXP7lVRZH05DxD2/XGbJp12q0ozcbrlBlBnyyzssFTH/2vLhtKWUp2CT1qVscTrcYTFiwTyKPKRg=="
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "XMqgVjlLxLqWmEh3c49haXLQwsMNtvo6YscUaqfvEGfg1iA8hnYgkUVq3i9Zu9gKeNKMWiiZKVwZExc/qyEAsQ=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",

--- a/tests/SharpCompress.AotSmoke/packages.lock.json
+++ b/tests/SharpCompress.AotSmoke/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.9, )",
-        "resolved": "10.0.9",
-        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",

--- a/tests/SharpCompress.AotSmoke/packages.lock.json
+++ b/tests/SharpCompress.AotSmoke/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",

--- a/tests/SharpCompress.Test/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Test/OptionsUsabilityTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using SharpCompress.Archives;
 using SharpCompress.Common;
@@ -229,6 +230,54 @@ public class OptionsUsabilityTests : TestBase
         var preserveMetadata = ExtractionOptions.PreserveMetadata;
         Assert.True(preserveMetadata.PreserveFileTime);
         Assert.True(preserveMetadata.PreserveAttributes);
+
+        Assert.Equal(Constants.BufferSize, new ExtractionOptions().BufferSize);
+    }
+
+    [Fact]
+    public void ArchiveEntry_WriteToFile_Uses_ExtractionOptions_BufferSize()
+    {
+        using var source = new TrackingReadStream(new byte[16]);
+        var entry = new TestArchiveEntry(source);
+        var destination = Path.Combine(SCRATCH_FILES_PATH, "buffer-size.txt");
+
+        entry.WriteToFile(destination, new ExtractionOptions { BufferSize = 7 });
+
+        Assert.Equal(7, source.CopyBufferSize);
+    }
+
+    [Fact]
+    public async Task ArchiveEntry_WriteToFileAsync_Uses_ExtractionOptions_BufferSize()
+    {
+        using var source = new TrackingReadStream(new byte[16]);
+        var entry = new TestArchiveEntry(source);
+        var destination = Path.Combine(SCRATCH_FILES_PATH, "buffer-size-async.txt");
+
+        await entry.WriteToFileAsync(destination, new ExtractionOptions { BufferSize = 9 });
+
+        Assert.Equal(9, source.CopyBufferSize);
+    }
+
+    [Fact]
+    public void Reader_WriteEntryToFile_Uses_ExtractionOptions_BufferSize()
+    {
+        using var reader = new TrackingReader();
+        var destination = Path.Combine(SCRATCH_FILES_PATH, "reader-buffer-size.txt");
+
+        reader.WriteEntryToFile(destination, new ExtractionOptions { BufferSize = 11 });
+
+        Assert.Equal(11, reader.EntryStreamCopyBufferSize);
+    }
+
+    [Fact]
+    public async Task Reader_WriteEntryToFileAsync_Uses_ExtractionOptions_BufferSize()
+    {
+        await using var reader = new TrackingReader();
+        var destination = Path.Combine(SCRATCH_FILES_PATH, "reader-buffer-size-async.txt");
+
+        await reader.WriteEntryToFileAsync(destination, new ExtractionOptions { BufferSize = 13 });
+
+        Assert.Equal(13, reader.EntryStreamCopyBufferSize);
     }
 
     [Fact]
@@ -320,5 +369,128 @@ public class OptionsUsabilityTests : TestBase
         Assert.True(noPassword.LookForHeader);
         Assert.Null(noPassword.Password);
         Assert.Equal(1_048_576, noPassword.RewindableBufferSize);
+    }
+
+    private sealed class TrackingReadStream(byte[] data) : MemoryStream(data)
+    {
+        public int? CopyBufferSize { get; private set; }
+
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            CopyBufferSize = bufferSize;
+            base.CopyTo(destination, bufferSize);
+        }
+
+        public override Task CopyToAsync(
+            Stream destination,
+            int bufferSize,
+            CancellationToken cancellationToken
+        )
+        {
+            CopyBufferSize = bufferSize;
+            return base.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+    }
+
+    private sealed class TestArchiveEntry(Stream source) : IArchiveEntry
+    {
+        public CompressionType CompressionType => CompressionType.None;
+        public DateTime? ArchivedTime => null;
+        public long CompressedSize => source.Length;
+        public long Crc => 0;
+        public DateTime? CreatedTime => null;
+        public string? Key => "buffer-size.txt";
+        public string? LinkTarget => null;
+        public bool IsDirectory => false;
+        public bool IsEncrypted => false;
+        public bool IsSplitAfter => false;
+        public bool IsSolid => false;
+        public int VolumeIndexFirst => 0;
+        public int VolumeIndexLast => 0;
+        public DateTime? LastAccessedTime => null;
+        public DateTime? LastModifiedTime => null;
+        public long Size => source.Length;
+        public int? Attrib => null;
+        public SharpCompress.Common.Options.IReaderOptions Options =>
+            ReaderOptions.ForExternalStream;
+        public bool IsComplete => true;
+        public IArchive Archive => throw new NotSupportedException();
+
+        public Stream OpenEntryStream()
+        {
+            source.Position = 0;
+            return source;
+        }
+
+        public ValueTask<Stream> OpenEntryStreamAsync(CancellationToken cancellationToken = default)
+        {
+            source.Position = 0;
+            return new ValueTask<Stream>(source);
+        }
+    }
+
+    private sealed class TrackingReader : IReader, IAsyncReader
+    {
+        public ArchiveType Type => ArchiveType.Zip;
+        public TrackingReadStream Source { get; } = new(new byte[100]);
+        public IEntry Entry => new TestArchiveEntry(Source);
+        public bool Cancelled => false;
+        public int? EntryStreamCopyBufferSize { get; private set; }
+
+        public void Dispose() { }
+
+        public ValueTask DisposeAsync() => default;
+
+        public void WriteEntryTo(Stream writableStream) => throw new NotSupportedException();
+
+        public ValueTask WriteEntryToAsync(
+            Stream writableStream,
+            CancellationToken cancellationToken = default
+        ) => throw new NotSupportedException();
+
+        public void Cancel() { }
+
+        public bool MoveToNextEntry() => false;
+
+        public ValueTask<bool> MoveToNextEntryAsync(
+            CancellationToken cancellationToken = default
+        ) => new(false);
+
+        public EntryStream OpenEntryStream()
+        {
+            Source.Position = 0;
+            return new TrackingEntryStream(
+                this,
+                Source,
+                bufferSize => EntryStreamCopyBufferSize = bufferSize
+            );
+        }
+
+        public ValueTask<EntryStream> OpenEntryStreamAsync(
+            CancellationToken cancellationToken = default
+        ) => new(OpenEntryStream());
+    }
+
+    private sealed class TrackingEntryStream(
+        IReader reader,
+        Stream stream,
+        Action<int> copyBufferSize
+    ) : EntryStream(reader, stream)
+    {
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            copyBufferSize(bufferSize);
+            base.CopyTo(destination, bufferSize);
+        }
+
+        public override Task CopyToAsync(
+            Stream destination,
+            int bufferSize,
+            CancellationToken cancellationToken
+        )
+        {
+            copyBufferSize(bufferSize);
+            return base.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
     }
 }

--- a/tests/SharpCompress.Test/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Test/OptionsUsabilityTests.cs
@@ -11,6 +11,7 @@ using SharpCompress.Readers;
 using SharpCompress.Test.Mocks;
 using SharpCompress.Writers;
 using SharpCompress.Writers.GZip;
+using SharpCompress.Writers.Tar;
 using SharpCompress.Writers.Zip;
 using Xunit;
 
@@ -133,11 +134,16 @@ public class OptionsUsabilityTests : TestBase
     [Fact]
     public void WriterOptions_Fluent_Methods_Modify_Correctly()
     {
-        var options = WriterOptions.ForZip().WithLeaveStreamOpen(false).WithCompressionLevel(9);
+        var options = WriterOptions
+            .ForZip()
+            .WithLeaveStreamOpen(false)
+            .WithCompressionLevel(9)
+            .WithBufferSize(65536);
 
         Assert.Equal(CompressionType.Deflate, options.CompressionType);
         Assert.Equal(9, options.CompressionLevel);
         Assert.False(options.LeaveStreamOpen);
+        Assert.Equal(65536, options.BufferSize);
     }
 
     [Fact]
@@ -159,6 +165,73 @@ public class OptionsUsabilityTests : TestBase
         Assert.Equal(factoryApproach.CompressionType, constructorApproach.CompressionType);
         Assert.Equal(factoryApproach.CompressionLevel, constructorApproach.CompressionLevel);
         Assert.Equal(factoryApproach.LeaveStreamOpen, constructorApproach.LeaveStreamOpen);
+    }
+
+    [Fact]
+    public void WriterOptions_Default_BufferSize_Uses_Constants_BufferSize()
+    {
+        Assert.Equal(Constants.BufferSize, WriterOptions.ForZip().BufferSize);
+        Assert.Equal(
+            Constants.BufferSize,
+            new ZipWriterOptions(CompressionType.Deflate).BufferSize
+        );
+        Assert.Equal(
+            Constants.BufferSize,
+            new TarWriterOptions(CompressionType.None, true).BufferSize
+        );
+        Assert.Equal(Constants.BufferSize, new GZipWriterOptions().BufferSize);
+    }
+
+    [Fact]
+    public void Format_WriterOptions_Copy_BufferSize()
+    {
+        var options = WriterOptions.ForZip().WithBufferSize(12345);
+
+        Assert.Equal(12345, new ZipWriterOptions(options).BufferSize);
+        Assert.Equal(12345, new TarWriterOptions(options).BufferSize);
+        Assert.Equal(12345, new GZipWriterOptions(options).BufferSize);
+    }
+
+    [Fact]
+    public void ZipWriter_Uses_WriterOptions_BufferSize()
+    {
+        using var source = new TrackingReadStream(new byte[100]);
+        using var destination = new MemoryStream();
+        using var writer = new ZipWriter(
+            destination,
+            new ZipWriterOptions(CompressionType.None) { BufferSize = 17 }
+        );
+
+        writer.Write("buffer-size.txt", source, DateTime.Now);
+
+        Assert.Equal(17, source.CopyBufferSize);
+    }
+
+    [Fact]
+    public void GZipWriter_Uses_WriterOptions_BufferSize()
+    {
+        using var source = new TrackingReadStream(new byte[100]);
+        using var destination = new MemoryStream();
+        using var writer = new GZipWriter(destination, new GZipWriterOptions { BufferSize = 19 });
+
+        writer.Write("buffer-size.txt", source, DateTime.Now);
+
+        Assert.Equal(19, source.CopyBufferSize);
+    }
+
+    [Fact]
+    public void TarWriter_Uses_WriterOptions_BufferSize()
+    {
+        using var source = new TrackingReadStream(new byte[100]);
+        using var destination = new MemoryStream();
+        using var writer = new TarWriter(
+            destination,
+            new TarWriterOptions(CompressionType.None, true) { BufferSize = 0 }
+        );
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            writer.Write("buffer-size.txt", source, DateTime.Now)
+        );
     }
 
     [Fact]
@@ -375,12 +448,6 @@ public class OptionsUsabilityTests : TestBase
     {
         public int? CopyBufferSize { get; private set; }
 
-        public override void CopyTo(Stream destination, int bufferSize)
-        {
-            CopyBufferSize = bufferSize;
-            base.CopyTo(destination, bufferSize);
-        }
-
         public override Task CopyToAsync(
             Stream destination,
             int bufferSize,
@@ -477,12 +544,6 @@ public class OptionsUsabilityTests : TestBase
         Action<int> copyBufferSize
     ) : EntryStream(reader, stream)
     {
-        public override void CopyTo(Stream destination, int bufferSize)
-        {
-            copyBufferSize(bufferSize);
-            base.CopyTo(destination, bufferSize);
-        }
-
         public override Task CopyToAsync(
             Stream destination,
             int bufferSize,

--- a/tests/SharpCompress.Test/OptionsUsabilityTests.cs
+++ b/tests/SharpCompress.Test/OptionsUsabilityTests.cs
@@ -1,3 +1,4 @@
+#if !LEGACY_DOTNET
 using System;
 using System.IO;
 using System.Linq;
@@ -220,9 +221,9 @@ public class OptionsUsabilityTests : TestBase
     }
 
     [Fact]
-    public void TarWriter_Uses_WriterOptions_BufferSize()
+    public void TarWriter_Uses_WriterOptions_BufferSize_ForTransfer()
     {
-        using var source = new TrackingReadStream(new byte[100]);
+        using var source = new MemoryStream(new byte[100]);
         using var destination = new MemoryStream();
         using var writer = new TarWriter(
             destination,
@@ -305,30 +306,6 @@ public class OptionsUsabilityTests : TestBase
         Assert.True(preserveMetadata.PreserveAttributes);
 
         Assert.Equal(Constants.BufferSize, new ExtractionOptions().BufferSize);
-    }
-
-    [Fact]
-    public void ArchiveEntry_WriteToFile_Uses_ExtractionOptions_BufferSize()
-    {
-        using var source = new TrackingReadStream(new byte[16]);
-        var entry = new TestArchiveEntry(source);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "buffer-size.txt");
-
-        entry.WriteToFile(destination, new ExtractionOptions { BufferSize = 7 });
-
-        Assert.Equal(7, source.CopyBufferSize);
-    }
-
-    [Fact]
-    public async Task ArchiveEntry_WriteToFileAsync_Uses_ExtractionOptions_BufferSize()
-    {
-        using var source = new TrackingReadStream(new byte[16]);
-        var entry = new TestArchiveEntry(source);
-        var destination = Path.Combine(SCRATCH_FILES_PATH, "buffer-size-async.txt");
-
-        await entry.WriteToFileAsync(destination, new ExtractionOptions { BufferSize = 9 });
-
-        Assert.Equal(9, source.CopyBufferSize);
     }
 
     [Fact]
@@ -444,21 +421,6 @@ public class OptionsUsabilityTests : TestBase
         Assert.Equal(1_048_576, noPassword.RewindableBufferSize);
     }
 
-    private sealed class TrackingReadStream(byte[] data) : MemoryStream(data)
-    {
-        public int? CopyBufferSize { get; private set; }
-
-        public override Task CopyToAsync(
-            Stream destination,
-            int bufferSize,
-            CancellationToken cancellationToken
-        )
-        {
-            CopyBufferSize = bufferSize;
-            return base.CopyToAsync(destination, bufferSize, cancellationToken);
-        }
-    }
-
     private sealed class TestArchiveEntry(Stream source) : IArchiveEntry
     {
         public CompressionType CompressionType => CompressionType.None;
@@ -496,10 +458,31 @@ public class OptionsUsabilityTests : TestBase
         }
     }
 
+    private sealed class TrackingReadStream(byte[] data) : MemoryStream(data)
+    {
+        public int? CopyBufferSize { get; private set; }
+
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            CopyBufferSize = bufferSize;
+            base.CopyTo(destination, bufferSize);
+        }
+
+        public override Task CopyToAsync(
+            Stream destination,
+            int bufferSize,
+            CancellationToken cancellationToken
+        )
+        {
+            CopyBufferSize = bufferSize;
+            return base.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+    }
+
     private sealed class TrackingReader : IReader, IAsyncReader
     {
         public ArchiveType Type => ArchiveType.Zip;
-        public TrackingReadStream Source { get; } = new(new byte[100]);
+        public MemoryStream Source { get; } = new(new byte[100]);
         public IEntry Entry => new TestArchiveEntry(Source);
         public bool Cancelled => false;
         public int? EntryStreamCopyBufferSize { get; private set; }
@@ -544,6 +527,12 @@ public class OptionsUsabilityTests : TestBase
         Action<int> copyBufferSize
     ) : EntryStream(reader, stream)
     {
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            copyBufferSize(bufferSize);
+            base.CopyTo(destination, bufferSize);
+        }
+
         public override Task CopyToAsync(
             Stream destination,
             int bufferSize,
@@ -555,3 +544,4 @@ public class OptionsUsabilityTests : TestBase
         }
     }
 }
+#endif

--- a/tests/SharpCompress.Test/UtilityTests.cs
+++ b/tests/SharpCompress.Test/UtilityTests.cs
@@ -579,7 +579,7 @@ public class UtilityTests
         using var source = new MemoryStream(sourceData);
         using var destination = new MemoryStream();
 
-        var transferred = source.TransferTo(destination, 5);
+        var transferred = source.TransferTo(destination, 5, null);
 
         Assert.Equal(5, transferred);
         Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, destination.ToArray());
@@ -592,7 +592,7 @@ public class UtilityTests
         using var source = new MemoryStream(sourceData);
         using var destination = new MemoryStream();
 
-        var transferred = source.TransferTo(destination, 100);
+        var transferred = source.TransferTo(destination, 100, null);
 
         Assert.Equal(3, transferred);
         Assert.Equal(sourceData, destination.ToArray());
@@ -604,7 +604,7 @@ public class UtilityTests
         using var source = new MemoryStream();
         using var destination = new MemoryStream();
 
-        var transferred = source.TransferTo(destination, 100);
+        var transferred = source.TransferTo(destination, 100, null);
 
         Assert.Equal(0, transferred);
         Assert.Empty(destination.ToArray());


### PR DESCRIPTION
Addresses https://github.com/adamhathcock/sharpcompress/issues/1351

This pull request introduces configurable buffer sizes for extraction and writing operations, allowing users to control the memory usage and performance of archive operations. The changes add a `BufferSize` property to both `ExtractionOptions` and `WriterOptions`, update the relevant APIs and extension methods to use these buffer sizes, and update documentation and usage examples accordingly.

**Configurable Buffer Size for Extraction and Writing:**

* Added a `BufferSize` property to `ExtractionOptions` and `WriterOptions` (and their interfaces) to allow users to specify the buffer size used during stream copy operations. Default is set to `Constants.BufferSize` (81920 bytes). [[1]](diffhunk://#diff-c039d222cbe3e827d844a6543e03fc0d1815484a851496ec8e89e9b52ae56adaR41-R45) [[2]](diffhunk://#diff-a0a2905d41815a8413aba21617704f6988487bf287257ed99d15e8372be8f6d5R33-R37) [[3]](diffhunk://#diff-09cbb9eed9db335a09d2820b178e259f70cda4568032f1d654a653d51d5cb159R22-R26)
* Updated `IArchiveEntryExtensions`, `IReaderExtensions`, and `IAsyncReaderExtensions` to use the buffer size from the provided options, falling back to the default if not specified. This includes both synchronous and asynchronous extraction methods. [[1]](diffhunk://#diff-61084e55d70b594ef97e944a0bc645b95f63a1854f75f17a038ab224850cfa0cL20-R27) [[2]](diffhunk://#diff-61084e55d70b594ef97e944a0bc645b95f63a1854f75f17a038ab224850cfa0cL29-R36) [[3]](diffhunk://#diff-61084e55d70b594ef97e944a0bc645b95f63a1854f75f17a038ab224850cfa0cR50-R61) [[4]](diffhunk://#diff-61084e55d70b594ef97e944a0bc645b95f63a1854f75f17a038ab224850cfa0cL60-R79) [[5]](diffhunk://#diff-61084e55d70b594ef97e944a0bc645b95f63a1854f75f17a038ab224850cfa0cL136-R166) [[6]](diffhunk://#diff-61084e55d70b594ef97e944a0bc645b95f63a1854f75f17a038ab224850cfa0cL161-R185) [[7]](diffhunk://#diff-69c0212f00f8e96b177398eeb01932738ef5b003df9afc9b69e2d5ceea550cabL45-R48) [[8]](diffhunk://#diff-69c0212f00f8e96b177398eeb01932738ef5b003df9afc9b69e2d5ceea550cabL80-R84) [[9]](diffhunk://#diff-69c0212f00f8e96b177398eeb01932738ef5b003df9afc9b69e2d5ceea550cabR99-R152) [[10]](diffhunk://#diff-443c9ab0287c8bbe74110c572f7aeaae5d47cd5d1a48e90721019bc5d9203c3fL61-R106)
* Refactored internal reader and writer implementations to propagate the buffer size from options, ensuring consistent usage throughout the codebase. [[1]](diffhunk://#diff-083fd66e1dab6e8c43abba168d79aad52ea814263e77dcca1eb34f7ce342842fL182-R185) [[2]](diffhunk://#diff-083fd66e1dab6e8c43abba168d79aad52ea814263e77dcca1eb34f7ce342842fL197-R210) [[3]](diffhunk://#diff-b33165ea57d8f8506db96d9c32b02de265f303d8e226fc21027bd981f3f31bcdL141-R152)

**Documentation and Usage Updates:**

* Updated documentation (`API.md`, `USAGE.md`) to show how to set the buffer size in `ExtractionOptions` and `WriterOptions`, and explained the effect of the buffer size on extraction and writing. [[1]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L95-R96) [[2]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797L105-R112) [[3]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R322-R324) [[4]](diffhunk://#diff-b57590968a12cee85a37c1b91d8cc7092cd8b68e50b242c39a178121db82a797R344-R350) [[5]](diffhunk://#diff-52296615debf3994195e43d91c94e02bfdc615a27620e0dbc72140b3de98dde1L103-R108)

**Other Notable Changes:**

* Bumped the `csharpier` tool version in `.config/dotnet-tools.json` from 1.2.6 to 1.3.0.
* Minor refactoring for clarity and maintainability, such as extracting helper methods for progress reporting and stream copying. [[1]](diffhunk://#diff-443c9ab0287c8bbe74110c572f7aeaae5d47cd5d1a48e90721019bc5d9203c3fR1-R4) [[2]](diffhunk://#diff-69c0212f00f8e96b177398eeb01932738ef5b003df9afc9b69e2d5ceea550cabR1-R6)

These changes give users more control over performance and resource usage during archive extraction and writing, and make the API more flexible and transparent regarding buffer management.