### PR TITLE
Fix zip archive corruption when using async APIs and output stream is non-seekable

### DIFF
--- a/src/SharpCompress/Writers/Zip/ZipCentralDirectoryEntry.cs
+++ b/src/SharpCompress/Writers/Zip/ZipCentralDirectoryEntry.cs
@@ -18,13 +18,15 @@ internal class ZipCentralDirectoryEntry
         ZipCompressionMethod compression,
         string fileName,
         ulong headerOffset,
-        IArchiveEncoding archiveEncoding
+        IArchiveEncoding archiveEncoding,
+        bool outputCanSeek
     )
     {
         this.compression = compression;
         this.fileName = fileName;
         HeaderOffset = headerOffset;
         this.archiveEncoding = archiveEncoding;
+        OutputCanSeek = outputCanSeek;
     }
 
     internal DateTime? ModificationTime { get; set; }
@@ -34,6 +36,13 @@ internal class ZipCentralDirectoryEntry
     internal ulong Decompressed { get; set; }
     internal ushort Zip64HeaderOffset { get; set; }
     internal ulong HeaderOffset { get; }
+
+    /// <summary>
+    /// Whether the real destination stream is seekable. The async writer buffers header and
+    /// central directory writes through a seekable MemoryStream, so the data-descriptor
+    /// decision must be based on this captured value, never on the stream being written to.
+    /// </summary>
+    internal bool OutputCanSeek { get; }
 
     internal uint Write(Stream outputStream)
     {
@@ -75,7 +84,7 @@ internal class ZipCentralDirectoryEntry
         var flags = Equals(archiveEncoding.GetEncoding(), Encoding.UTF8)
             ? HeaderFlags.Efs
             : HeaderFlags.None;
-        if (!outputStream.CanSeek)
+        if (!OutputCanSeek)
         {
             // Cannot use data descriptors with zip64:
             // https://blogs.oracle.com/xuemingshen/entry/is_zipinput_outputstream_handling_of

--- a/src/SharpCompress/Writers/Zip/ZipWriter.Async.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriter.Async.cs
@@ -104,7 +104,8 @@ public partial class ZipWriter
             compression,
             entryPath,
             (ulong)streamPosition,
-            WriterOptions.ArchiveEncoding
+            WriterOptions.ArchiveEncoding,
+            OutputStream.NotNull().CanSeek
         )
         {
             Comment = options.EntryComment,
@@ -189,7 +190,8 @@ public partial class ZipWriter
             compression,
             directoryPath,
             (ulong)streamPosition,
-            WriterOptions.ArchiveEncoding
+            WriterOptions.ArchiveEncoding,
+            OutputStream.NotNull().CanSeek
         )
         {
             Comment = options.EntryComment,

--- a/src/SharpCompress/Writers/Zip/ZipWriter.cs
+++ b/src/SharpCompress/Writers/Zip/ZipWriter.cs
@@ -103,7 +103,8 @@ public partial class ZipWriter : AbstractWriter
             compression,
             entryPath,
             (ulong)streamPosition,
-            WriterOptions.ArchiveEncoding
+            WriterOptions.ArchiveEncoding,
+            OutputStream.NotNull().CanSeek
         )
         {
             Comment = options.EntryComment,
@@ -181,7 +182,8 @@ public partial class ZipWriter : AbstractWriter
             compression,
             directoryPath,
             (ulong)streamPosition,
-            WriterOptions.ArchiveEncoding
+            WriterOptions.ArchiveEncoding,
+            OutputStream.NotNull().CanSeek
         )
         {
             Comment = options.EntryComment,
@@ -218,8 +220,10 @@ public partial class ZipWriter : AbstractWriter
         bool useZip64
     )
     {
+        // The header may be buffered through a seekable MemoryStream (async path), so all
+        // seekability decisions must use entry.OutputCanSeek, not stream.CanSeek.
         // We err on the side of caution until the zip specification clarifies how to support this
-        if (!stream.CanSeek && useZip64)
+        if (!entry.OutputCanSeek && useZip64)
         {
             throw new NotSupportedException(
                 "Zip64 extensions are not supported on non-seekable streams"
@@ -236,7 +240,7 @@ public partial class ZipWriter : AbstractWriter
         stream.Write(intBuf);
         if (explicitZipCompressionInfo == ZipCompressionMethod.Deflate)
         {
-            if (stream.CanSeek && useZip64)
+            if (entry.OutputCanSeek && useZip64)
             {
                 stream.Write(stackalloc byte[] { 45, 0 }); //smallest allowed version for zip64
             }
@@ -252,7 +256,7 @@ public partial class ZipWriter : AbstractWriter
         var flags = Equals(WriterOptions.ArchiveEncoding.GetEncoding(), Encoding.UTF8)
             ? HeaderFlags.Efs
             : 0;
-        if (!stream.CanSeek)
+        if (!entry.OutputCanSeek)
         {
             flags |= HeaderFlags.UsePostDataDescriptor;
 
@@ -280,7 +284,7 @@ public partial class ZipWriter : AbstractWriter
         stream.Write(intBuf.Slice(0, 2)); // filename length
 
         var extralength = 0;
-        if (stream.CanSeek && useZip64)
+        if (entry.OutputCanSeek && useZip64)
         {
             extralength = 2 + 2 + 8 + 8;
         }

--- a/tests/SharpCompress.Test/Zip/ZipWriterNonSeekableTests.cs
+++ b/tests/SharpCompress.Test/Zip/ZipWriterNonSeekableTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SharpCompress.Archives.Zip;
+using SharpCompress.Common;
+using SharpCompress.Test.Mocks;
+using SharpCompress.Writers;
+using SharpCompress.Writers.Zip;
+using Xunit;
+
+namespace SharpCompress.Test.Zip;
+
+/// <summary>
+/// Regression tests for writing zips to non-seekable output streams, where entries must be
+/// written in streaming layout: data-descriptor flag (bit 3) set in the local header and
+/// central directory, zeroed local CRC/sizes, and a trailing PK\x07\x08 descriptor per entry.
+/// The async writer used to derive the flag from its internal buffering MemoryStream instead
+/// of the real output, producing archives that strict readers reject.
+/// </summary>
+public class ZipWriterNonSeekableTests
+{
+    private static readonly DateTime FixedModificationTime = new(2024, 5, 15, 10, 30, 0);
+
+    private static (string Name, byte[] Content)[] CreateStreamingTestEntries() =>
+        new[]
+        {
+            (
+                "first.txt",
+                Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("Hello streaming zip! ", 500)))
+            ),
+            (
+                "nested/second.txt",
+                Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("Another entry with different content. ", 300)))
+            ),
+        };
+
+    private static async Task<byte[]> WriteArchiveToNonSeekableAsync(
+        (string Name, byte[] Content)[] entries
+    )
+    {
+        using var ms = new MemoryStream();
+        await using (
+            var writer = await WriterFactory.OpenAsyncWriter(
+                new ForwardOnlyStream(ms),
+                ArchiveType.Zip,
+                new ZipWriterOptions(CompressionType.Deflate)
+            )
+        )
+        {
+            foreach (var (name, content) in entries)
+            {
+                using var source = new MemoryStream(content);
+                await writer.WriteAsync(name, source, FixedModificationTime);
+            }
+        }
+        return ms.ToArray();
+    }
+
+    private static byte[] WriteArchiveToNonSeekableSync((string Name, byte[] Content)[] entries)
+    {
+        using var ms = new MemoryStream();
+        using (
+            var writer = WriterFactory.OpenWriter(
+                new ForwardOnlyStream(ms),
+                ArchiveType.Zip,
+                new ZipWriterOptions(CompressionType.Deflate)
+            )
+        )
+        {
+            foreach (var (name, content) in entries)
+            {
+                using var source = new MemoryStream(content);
+                writer.Write(name, source, FixedModificationTime);
+            }
+        }
+        return ms.ToArray();
+    }
+
+    private static ushort ReadUInt16(byte[] data, int offset) =>
+        (ushort)(data[offset] | (data[offset + 1] << 8));
+
+    private static uint ReadUInt32(byte[] data, int offset) =>
+        (uint)(
+            data[offset]
+            | (data[offset + 1] << 8)
+            | (data[offset + 2] << 16)
+            | (data[offset + 3] << 24)
+        );
+
+    /// <summary>
+    /// Structurally validates a streamed (non-seekable output) zip: every local header and
+    /// central directory record must have the data-descriptor flag (bit 3, 0x0008) set, local
+    /// CRC/size fields must be zeroed (deferred), and a PK\x07\x08 descriptor with values
+    /// matching the central directory must follow each entry's data.
+    /// </summary>
+    private static void AssertStreamedZipLayout(byte[] zip, int expectedEntries)
+    {
+        // End of central directory record; the archive has no comment, so it is the last 22 bytes
+        var eocd = zip.Length - 22;
+        Assert.Equal(0x06054b50u, ReadUInt32(zip, eocd));
+        int entryCount = ReadUInt16(zip, eocd + 10);
+        Assert.Equal(expectedEntries, entryCount);
+        var cdOffset = checked((int)ReadUInt32(zip, eocd + 16));
+
+        var pos = cdOffset;
+        for (var i = 0; i < entryCount; i++)
+        {
+            Assert.Equal(0x02014b50u, ReadUInt32(zip, pos));
+            var cdFlags = ReadUInt16(zip, pos + 8);
+            Assert.True(
+                (cdFlags & 0x0008) != 0,
+                $"entry {i}: central directory flags 0x{cdFlags:x4} lack the data-descriptor bit"
+            );
+            var crc = ReadUInt32(zip, pos + 16);
+            var compressedSize = ReadUInt32(zip, pos + 20);
+            var uncompressedSize = ReadUInt32(zip, pos + 24);
+            var nameLength = ReadUInt16(zip, pos + 28);
+            var extraLength = ReadUInt16(zip, pos + 30);
+            var commentLength = ReadUInt16(zip, pos + 32);
+            var localHeaderOffset = checked((int)ReadUInt32(zip, pos + 42));
+
+            Assert.Equal(0x04034b50u, ReadUInt32(zip, localHeaderOffset));
+            var localFlags = ReadUInt16(zip, localHeaderOffset + 6);
+            Assert.True(
+                (localFlags & 0x0008) != 0,
+                $"entry {i}: local header flags 0x{localFlags:x4} lack the data-descriptor bit"
+            );
+            Assert.Equal(
+                cdFlags,
+                localFlags
+            );
+            Assert.Equal(0u, ReadUInt32(zip, localHeaderOffset + 14)); // deferred CRC
+            Assert.Equal(0u, ReadUInt32(zip, localHeaderOffset + 18)); // deferred compressed size
+            Assert.Equal(0u, ReadUInt32(zip, localHeaderOffset + 22)); // deferred uncompressed size
+
+            var localNameLength = ReadUInt16(zip, localHeaderOffset + 26);
+            var localExtraLength = ReadUInt16(zip, localHeaderOffset + 28);
+            var descriptor =
+                localHeaderOffset + 30 + localNameLength + localExtraLength + (int)compressedSize;
+            Assert.Equal(0x08074b50u, ReadUInt32(zip, descriptor));
+            Assert.Equal(crc, ReadUInt32(zip, descriptor + 4));
+            Assert.Equal(compressedSize, ReadUInt32(zip, descriptor + 8));
+            Assert.Equal(uncompressedSize, ReadUInt32(zip, descriptor + 12));
+
+            pos += 46 + nameLength + extraLength + commentLength;
+        }
+    }
+
+    [Fact]
+    public async Task Zip_Async_NonSeekable_Writes_DataDescriptor_Flags()
+    {
+        var entries = CreateStreamingTestEntries();
+        var zip = await WriteArchiveToNonSeekableAsync(entries);
+
+        AssertStreamedZipLayout(zip, entries.Length);
+
+        // Round-trip: the archive must be readable and contents intact
+        using var archive = ZipArchive.OpenArchive(new MemoryStream(zip));
+        Assert.Equal(entries.Length, archive.Entries.Count());
+        foreach (var (name, content) in entries)
+        {
+            var entry = archive.Entries.Single(e => e.Key == name);
+            using var extracted = new MemoryStream();
+            using (var entryStream = entry.OpenEntryStream())
+            {
+                entryStream.CopyTo(extracted);
+            }
+            Assert.Equal(content, extracted.ToArray());
+        }
+    }
+
+    [Fact]
+    public async Task Zip_Async_NonSeekable_Matches_Sync_Output()
+    {
+        var entries = CreateStreamingTestEntries();
+        var asyncZip = await WriteArchiveToNonSeekableAsync(entries);
+        var syncZip = WriteArchiveToNonSeekableSync(entries);
+
+        // The sync writer produces a correct streamed layout; the async writer must match it
+        Assert.Equal(syncZip, asyncZip);
+    }
+}


### PR DESCRIPTION
**⚠Notice:**
This bug was both analysed and patched by Claude Opus/Fable, including writing the tests,
I have reviewed the code and tested the fix in our app where it was originally discovered and it works.

**Details:**
ZipWriter branches on non-seekable streams by checking the provided stream.CanSeek property, this causes issues with the async writer. Async writer buffers writes inside a MemoryStream, MemoryStream always reports CanSeek == true, even though the actual output stream may not support it. This causes archive corruption when using a non-seekable stream as output (e.g. http response body).

**Fix:**
Capture the destination's CanSeek on ZipCentralDirectoryEntry when the entry is created, and base all seekability decisions in WriteHeader and ZipCentralDirectoryEntry.
Write on that captured value instead of the stream being written into. Sync output is unchanged (there the write target is the real output stream); async output to non-seekable streams is now byte-identical to sync, verified by new regression tests that structurally validate the streamed layout (bit 3 in local + central headers, deferred size fields, trailing descriptors) and assert sync/async byte parity.

**Side effect:**
Async + zip64 on a non-seekable output now throws NotSupportedException at header-write time, matching the sync path, instead of silently proceeding.