### PR TITLE
Improve LZMA decoding for Solid Archives

### DIFF
--- a/src/SharpCompress/Archives/SevenZip/SevenZipArchive.cs
+++ b/src/SharpCompress/Archives/SevenZip/SevenZipArchive.cs
@@ -78,6 +78,12 @@ public partial class SevenZipArchive : AbstractArchive<SevenZipArchiveEntry, Sev
         }
     }
 
+    public override void Dispose()
+    {
+        _database?.DisposeCachedFolderStream();
+        base.Dispose();
+    }
+
     private void LoadFactory(Stream stream)
     {
         if (_database is null)

--- a/src/SharpCompress/Common/SevenZip/ArchiveDatabase.Async.cs
+++ b/src/SharpCompress/Common/SevenZip/ArchiveDatabase.Async.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,5 +35,72 @@ internal sealed partial class ArchiveDatabase
                 cancellationToken
             )
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Async counterpart of the caching <c>GetFolderStream</c> overload. Reuses a cached decoder
+    /// stream for the folder when possible instead of recreating and re-decoding from the start.
+    /// </summary>
+    internal async ValueTask<Stream> GetFolderStreamAsync(
+        Stream stream,
+        CFolder folder,
+        IPasswordProvider pw,
+        long skipSize,
+        long entrySize,
+        CancellationToken cancellationToken
+    )
+    {
+        if (_cachedFolder == folder && _cachedFolderStream != null)
+        {
+            if (skipSize >= _cachedFolderStreamPosition)
+            {
+                var delta = skipSize - _cachedFolderStreamPosition;
+                if (delta > 0)
+                {
+                    await _cachedFolderStream
+                        .SkipAsync(delta, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                // Assume the caller will fully consume the returned entry stream, advancing the
+                // shared stream by entrySize bytes.
+                _cachedFolderStreamPosition = skipSize + entrySize;
+                return _cachedFolderStream;
+            }
+
+            // Non-sequential (backward) access within the same folder requires restarting.
+            await DisposeCachedFolderStreamAsync().ConfigureAwait(false);
+        }
+        else if (_cachedFolderStream != null)
+        {
+            await DisposeCachedFolderStreamAsync().ConfigureAwait(false);
+        }
+
+        var newStream = await GetFolderStreamAsync(stream, folder, pw, cancellationToken)
+            .ConfigureAwait(false);
+        if (skipSize > 0)
+        {
+            await newStream.SkipAsync(skipSize, cancellationToken).ConfigureAwait(false);
+        }
+
+        _cachedFolder = folder;
+        _cachedFolderStream = newStream;
+        _cachedFolderStreamPosition = skipSize + entrySize;
+        return newStream;
+    }
+
+    private async ValueTask DisposeCachedFolderStreamAsync()
+    {
+        if (_cachedFolderStream is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else
+        {
+#pragma warning disable VSTHRD103 // Fallback for streams that do not support async disposal.
+            _cachedFolderStream?.Dispose();
+#pragma warning restore VSTHRD103
+        }
+        _cachedFolderStream = null;
+        _cachedFolder = null;
     }
 }

--- a/src/SharpCompress/Common/SevenZip/ArchiveDatabase.cs
+++ b/src/SharpCompress/Common/SevenZip/ArchiveDatabase.cs
@@ -163,4 +163,71 @@ internal partial class ArchiveDatabase
             pw
         );
     }
+
+    // Cache used to avoid re-decoding a solid folder from scratch for every file it contains.
+    // Without this, extracting N files from the same solid folder decodes O(N^2) bytes since each
+    // file's stream was previously created fresh from the folder start and skipped forward.
+    private CFolder? _cachedFolder;
+    private Stream? _cachedFolderStream;
+    private long _cachedFolderStreamPosition;
+
+    /// <summary>
+    /// Returns a stream positioned at <paramref name="skipSize"/> bytes into the decompressed
+    /// contents of <paramref name="folder"/>. Reuses a cached decoder stream for the folder when
+    /// possible instead of recreating and re-decoding from the start.
+    /// </summary>
+    internal Stream GetFolderStream(
+        Stream stream,
+        CFolder folder,
+        IPasswordProvider pw,
+        long skipSize,
+        long entrySize
+    )
+    {
+        if (_cachedFolder == folder && _cachedFolderStream != null)
+        {
+            if (skipSize >= _cachedFolderStreamPosition)
+            {
+                var delta = skipSize - _cachedFolderStreamPosition;
+                if (delta > 0)
+                {
+                    _cachedFolderStream.Skip(delta);
+                }
+                // Assume the caller will fully consume the returned entry stream, advancing the
+                // shared stream by entrySize bytes.
+                _cachedFolderStreamPosition = skipSize + entrySize;
+                return _cachedFolderStream;
+            }
+
+            // Non-sequential (backward) access within the same folder requires restarting.
+            _cachedFolderStream.Dispose();
+            _cachedFolderStream = null;
+            _cachedFolder = null;
+        }
+        else if (_cachedFolderStream != null)
+        {
+            _cachedFolderStream.Dispose();
+            _cachedFolderStream = null;
+            _cachedFolder = null;
+        }
+
+        var newStream = GetFolderStream(stream, folder, pw);
+        if (skipSize > 0)
+        {
+            newStream.Skip(skipSize);
+        }
+
+        _cachedFolder = folder;
+        _cachedFolderStream = newStream;
+        _cachedFolderStreamPosition = skipSize + entrySize;
+        return newStream;
+    }
+
+    internal void DisposeCachedFolderStream()
+    {
+        _cachedFolderStream?.Dispose();
+        _cachedFolderStream = null;
+        _cachedFolder = null;
+        _cachedFolderStreamPosition = 0;
+    }
 }

--- a/src/SharpCompress/Common/SevenZip/SevenZipFilePart.cs
+++ b/src/SharpCompress/Common/SevenZip/SevenZipFilePart.cs
@@ -44,7 +44,6 @@ internal class SevenZipFilePart : FilePart
         {
             return Stream.Null;
         }
-        var folderStream = _database.GetFolderStream(_stream, Folder!, _database.PasswordProvider);
 
         var firstFileIndex = _database._folderStartFileIndex[_database._folders.IndexOf(Folder!)];
         var skipCount = Index - firstFileIndex;
@@ -53,11 +52,15 @@ internal class SevenZipFilePart : FilePart
         {
             skipSize += _database._files[firstFileIndex + i].Size;
         }
-        if (skipSize > 0)
-        {
-            folderStream.Skip(skipSize);
-        }
-        return new ReadOnlySubStream(folderStream, Header.Size, leaveOpen: false);
+
+        var folderStream = _database.GetFolderStream(
+            _stream,
+            Folder!,
+            _database.PasswordProvider,
+            skipSize,
+            Header.Size
+        );
+        return new ReadOnlySubStream(folderStream, Header.Size, leaveOpen: true);
     }
 
     internal override async ValueTask<Stream?> GetCompressedStreamAsync(
@@ -68,9 +71,6 @@ internal class SevenZipFilePart : FilePart
         {
             return Stream.Null;
         }
-        var folderStream = await _database
-            .GetFolderStreamAsync(_stream, Folder!, _database.PasswordProvider, cancellationToken)
-            .ConfigureAwait(false);
 
         var firstFileIndex = _database._folderStartFileIndex[_database._folders.IndexOf(Folder!)];
         var skipCount = Index - firstFileIndex;
@@ -79,11 +79,18 @@ internal class SevenZipFilePart : FilePart
         {
             skipSize += _database._files[firstFileIndex + i].Size;
         }
-        if (skipSize > 0)
-        {
-            await folderStream.SkipAsync(skipSize, cancellationToken).ConfigureAwait(false);
-        }
-        return new ReadOnlySubStream(folderStream, Header.Size, leaveOpen: false);
+
+        var folderStream = await _database
+            .GetFolderStreamAsync(
+                _stream,
+                Folder!,
+                _database.PasswordProvider,
+                skipSize,
+                Header.Size,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        return new ReadOnlySubStream(folderStream, Header.Size, leaveOpen: true);
     }
 
     public CompressionType CompressionType

--- a/src/SharpCompress/IO/BufferedSubStream.Async.cs
+++ b/src/SharpCompress/IO/BufferedSubStream.Async.cs
@@ -36,8 +36,10 @@ internal partial class BufferedSubStream
         BytesLeftToRead -= _cacheLength;
     }
 
-    [Zomp.SyncMethodGenerator.CreateSyncVersion]
-    public override async Task<int> ReadAsync(
+    // Fast, synchronous-completion path used when the requested bytes are already sitting in the
+    // in-memory cache. Avoids the async state-machine / Task allocation overhead incurred by every
+    // single-byte read the LZMA range decoder issues, without changing buffering/caching semantics.
+    public override Task<int> ReadAsync(
         byte[] buffer,
         int offset,
         int count,
@@ -49,6 +51,24 @@ internal partial class BufferedSubStream
             count = (int)Length;
         }
 
+        if (count > 0 && _cacheOffset < _cacheLength)
+        {
+            count = Math.Min(count, _cacheLength - _cacheOffset);
+            Buffer.BlockCopy(_cache!, _cacheOffset, buffer, offset, count);
+            _cacheOffset += count;
+            return Task.FromResult(count);
+        }
+
+        return ReadSlowAsync(buffer, offset, count, cancellationToken);
+    }
+
+    private async Task<int> ReadSlowAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken
+    )
+    {
         if (count > 0)
         {
             if (_cacheOffset == _cacheLength)
@@ -65,9 +85,31 @@ internal partial class BufferedSubStream
     }
 
 #if !LEGACY_DOTNET
-    public override async ValueTask<int> ReadAsync(
+    public override ValueTask<int> ReadAsync(
         Memory<byte> buffer,
         CancellationToken cancellationToken = default
+    )
+    {
+        var count = buffer.Length;
+        if (count > Length)
+        {
+            count = (int)Length;
+        }
+
+        if (count > 0 && _cacheOffset < _cacheLength)
+        {
+            count = Math.Min(count, _cacheLength - _cacheOffset);
+            _cache!.AsSpan(_cacheOffset, count).CopyTo(buffer.Span);
+            _cacheOffset += count;
+            return new ValueTask<int>(count);
+        }
+
+        return ReadSlowAsync(buffer, cancellationToken);
+    }
+
+    private async ValueTask<int> ReadSlowAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken
     )
     {
         var count = buffer.Length;

--- a/src/SharpCompress/IO/BufferedSubStream.cs
+++ b/src/SharpCompress/IO/BufferedSubStream.cs
@@ -73,6 +73,28 @@ internal partial class BufferedSubStream : Stream, IStreamStack
         return _cache![_cacheOffset++];
     }
 
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (count > Length)
+        {
+            count = (int)Length;
+        }
+
+        if (count > 0)
+        {
+            if (_cacheOffset == _cacheLength)
+            {
+                RefillCache();
+            }
+
+            count = Math.Min(count, _cacheLength - _cacheOffset);
+            Buffer.BlockCopy(_cache!, _cacheOffset, buffer, offset, count);
+            _cacheOffset += count;
+        }
+
+        return count;
+    }
+
     public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
     public override void SetLength(long value) => throw new NotSupportedException();


### PR DESCRIPTION
The main intention of this PR was to bring down the extraction time for 7z solid archives and while trying to do so, I think I improved also some other archive types. I noticed while running tests that on my own machine on top of the latest master, we went down from ~10 seconds to run the entire `SevenZip` test suite to ~3,9s.

Additionally, your performance benchmark [is showing up to 80% improvements for 7zip archives](https://github.com/julianxhokaxhiu/sharpcompress/actions/runs/30411717736) on my last run on top of my own fork ( with these patches ).

The improvements have been made using the performance agent with Claude Sonnet 5. I've personally tested the changes and they seem to bring no regression, at least locally.

Below you can find a detailed summary of what has been done ( generated using Sonnet 5 ).

Any question feel free to ask :)

---

## Solid 7z Extraction Performance Optimization

### Summary

This change addresses significant performance regressions when extracting solid 7z archives, along with a related async correctness bug uncovered during the fix. Local test suite runtime for `SharpCompress.Test.SevenZip` dropped from **9.8s to 3.9s**.

### Problem

Extracting individual entries from a solid 7z folder was **O(N²)**: each file's compressed stream was recreated from the start of the folder and re-decoded/skipped forward to reach that entry's offset. For folders with many files, this meant re-decoding the same bytes over and over.

### Changes

#### 1. Solid-folder decoder stream caching (sync + async)
- `src/SharpCompress/Common/SevenZip/ArchiveDatabase.cs` / `ArchiveDatabase.Async.cs`: added a cached folder-stream overload of `GetFolderStream`/`GetFolderStreamAsync` that reuses the same decoder stream across sequential entries in the same solid folder, only skipping the incremental delta between entries instead of restarting from the folder's beginning. Falls back to a full restart for non-sequential (backward) access.
- `src/SharpCompress/Common/SevenZip/SevenZipFilePart.cs`: updated both sync and async `GetCompressedStream(Async)` to request the cached folder stream with the correct skip position and entry size, sharing the underlying stream via `ReadOnlySubStream(..., leaveOpen: true)`.
- `src/SharpCompress/Archives/SevenZip/SevenZipArchive.cs`: added `Dispose()` override to release the cached decoder stream.

#### 2. Fixed async correctness regression (PPMd)
The initial caching implementation tracked the cache position as the *start* of the current entry rather than accounting for the bytes the caller would actually consume. Since the shared stream is read directly by the caller (not just skipped), this caused a double-skip on the next entry, corrupting the PPMd decode state and throwing `IncompleteArchiveException: Unexpected end of stream`.

**Fix:** pass the entry size into the cached-stream lookup so the cache position is advanced to `skipSize + entrySize` (the expected position after the entry is fully consumed), matching actual stream consumption.

#### 3. Reduced async read overhead in `BufferedSubStream`
- `src/SharpCompress/IO/BufferedSubStream.cs` / `BufferedSubStream.Async.cs`: added a fast synchronous-completion path to `Read`/`ReadAsync` when requested bytes are already available in the in-memory cache, avoiding unnecessary `async` state-machine overhead on the common (already-buffered) path.

### Results

#### Benchmark.NET (`SevenZipBenchmarks`)

| Benchmark | Before | After | Δ |
|---|---:|---:|---:|
| `SevenZipLzma2Extract` (sync, mean) | 3.152 ms | 2.901 ms | ~7.9% faster |
| `SevenZipLzma2ExtractAsync` (mean) | 9.950 ms | 9.971 ms | no change (noise-level) |
| Async allocated memory | 540.75 KB | 540.77 KB | unchanged |
| Sync allocated memory | 239.22 KB | 239.22 KB | unchanged |

#### Test suite

| Metric | Result |
|---|---|
| `SharpCompress.Test.SevenZip` wall-clock runtime | 9.8s → 3.9s |
| `SevenZipArchiveTests` + `SevenZipArchiveAsyncTests` (targeted run) | **114 / 114 passed**, 0 failed |
| Full `SharpCompress.Test` project (all archive formats) | **3,682 / 3,682 passed**, 0 failed, 0 skipped (~30.4s) |
| Full solution build (`SharpCompress.csproj`, all TFMs) | Succeeded — .NET 10, .NET 8, .NET 6, .NET Standard 2.1/2.0, .NET Framework 4.8 |

### Investigated but not pursued

Profiling showed the async LZMA2 path (~3.2–3.4x slower than sync) is dominated by fine-grained `async`/`await` overhead inside the range decoder's per-bit/per-byte decode loop (`Decoder.DecodeNormalAsync` ~23% self CPU, `RangeCoder.Decoder.Normalize2Async` ~13% self CPU, `BitDecoder.DecodeAsyncHelper` ~13% self CPU), rather than actual I/O wait time. A read-ahead buffering attempt at the range-decoder level was tried but reverted — LZMA2 interleaves chunk-header reads and range-decoder reads on the same underlying stream, and buffering at that layer stole bytes meant for the next chunk header, breaking decoding (`IncompleteArchiveException`, reproduced on 6 tests including `SevenZipArchive_Solid_WriteToDirectoryAsync_WithProgress`). Properly fixing this requires restructuring the async decode loop to batch-decode against an already-buffered chunk and await only at genuine buffer-fill boundaries — a larger, higher-risk architectural change recommended as a separate follow-up effort with dedicated test coverage.

### Testing

- All 3,682 tests in `SharpCompress.Test` pass.
- All 114 SevenZip-specific tests (sync + async, all codecs including PPMd/LZMA/LZMA2/BZip2, solid/split archives) pass.
- Full solution builds successfully across all target frameworks (.NET 10, .NET 8, .NET 6, .NET Standard 2.1/2.0, .NET Framework 4.8).