### PR TITLE
Fix SeekableSharpCompressStream.StopRecording() to rewind to recorded…

### DIFF
--- a/src/SharpCompress/IO/SeekableSharpCompressStream.cs
+++ b/src/SharpCompress/IO/SeekableSharpCompressStream.cs
@@ -83,7 +83,16 @@ internal sealed partial class SeekableSharpCompressStream : SharpCompressStream
     public override void StartRecording(int? minBufferSize = null) =>
         _recordedPosition = _stream.Position;
 
-    public override void StopRecording() => _recordedPosition = null;
+    public override void StopRecording()
+    {
+        if (_recordedPosition.HasValue)
+        {
+            // Seek back to the recording anchor position, matching the behavior of the
+            // non-seekable SharpCompressStream.StopRecording() which rewinds _logicalPosition.
+            _stream.Seek(_recordedPosition.Value, SeekOrigin.Begin);
+        }
+        _recordedPosition = null;
+    }
 
     protected override void Dispose(bool disposing)
     {

--- a/tests/SharpCompress.Test/GZip/GZipReaderAsyncTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipReaderAsyncTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
 using SharpCompress.Common;
 using SharpCompress.IO;
@@ -36,5 +37,34 @@ public class GZipReaderAsyncTests : ReaderTests
                 await entryStream.CopyToAsync(ms);
             }
         }
+    }
+
+    [Fact]
+    public async ValueTask GZip_ReaderFactory_FlatGZip_Async()
+    {
+        var source = new byte[2048];
+        for (var i = 0; i < source.Length; i++)
+        {
+            source[i] = 0xFF;
+        }
+
+        var gzipPath = Path.Combine(SCRATCH_FILES_PATH, "Flat.bin.gz");
+        using (var output = File.Create(gzipPath))
+        await using (var gzip = new GZipStream(output, CompressionMode.Compress))
+        {
+            await gzip.WriteAsync(source, 0, source.Length);
+        }
+
+        await using Stream stream = File.OpenRead(gzipPath);
+        await using var reader = await ReaderFactory.OpenAsyncReader(stream);
+        Assert.IsType<GZipReader>(reader);
+        Assert.True(await reader.MoveToNextEntryAsync());
+
+        using var ms = new MemoryStream();
+        await reader.WriteEntryToAsync(ms);
+        Assert.Equal(source.Length, ms.Length);
+        Assert.Equal(source, ms.ToArray());
+
+        Assert.False(await reader.MoveToNextEntryAsync());
     }
 }

--- a/tests/SharpCompress.Test/GZip/GZipReaderAsyncTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipReaderAsyncTests.cs
@@ -50,12 +50,12 @@ public class GZipReaderAsyncTests : ReaderTests
 
         var gzipPath = Path.Combine(SCRATCH_FILES_PATH, "Flat.bin.gz");
         using (var output = File.Create(gzipPath))
-        await using (var gzip = new GZipStream(output, CompressionMode.Compress))
+        using (var gzip = new GZipStream(output, CompressionMode.Compress))
         {
             await gzip.WriteAsync(source, 0, source.Length);
         }
 
-        await using Stream stream = File.OpenRead(gzipPath);
+        using Stream stream = File.OpenRead(gzipPath);
         await using var reader = await ReaderFactory.OpenAsyncReader(stream);
         Assert.IsType<GZipReader>(reader);
         Assert.True(await reader.MoveToNextEntryAsync());

--- a/tests/SharpCompress.Test/GZip/GZipReaderTests.cs
+++ b/tests/SharpCompress.Test/GZip/GZipReaderTests.cs
@@ -48,6 +48,12 @@ public class GZipReaderTests : ReaderTests
         using var reader = ReaderFactory.OpenReader(stream);
         Assert.IsType<GZipReader>(reader);
         Assert.True(reader.MoveToNextEntry());
+
+        using var ms = new MemoryStream();
+        reader.WriteEntryTo(ms);
+        Assert.Equal(source.Length, ms.Length);
+        Assert.Equal(source, ms.ToArray());
+
         Assert.False(reader.MoveToNextEntry());
     }
 }


### PR DESCRIPTION
… position

When SeekableSharpCompressStream.StopRecording() was called (e.g. after the tar probe in GZipFactory.TryOpenReader), it cleared _recordedPosition without seeking back to it. This left the underlying FileStream at the advanced position reached during the probe, so the subsequent GZipReader would start reading from the wrong offset, producing Key=null and 0 extracted bytes.

Fix: seek back to _recordedPosition before clearing it, matching the behavior of the non-seekable SharpCompressStream.StopRecording() which rewinds _logicalPosition.

Also enhance the existing GZip_ReaderFactory_FlatGZip test to actually verify the extracted content (not just MoveToNextEntry returns true), and add an async variant.

Closes #1391

Supersedes https://github.com/adamhathcock/sharpcompress/pull/1392