### PR TITLE
Rar: Fix CPU performance regression

### DIFF
--- a/src/SharpCompress/Compressors/Rar/RarCRC.cs
+++ b/src/SharpCompress/Compressors/Rar/RarCRC.cs
@@ -1,10 +1,16 @@
 using System;
+using SharpCompress.Crypto;
 
 namespace SharpCompress.Compressors.Rar;
 
 internal static class RarCRC
 {
-    private static readonly uint[] crcTab;
+    // Reuse Crc32Stream's cached slice-by-16 table (same polynomial) instead of a separate
+    // byte-at-a-time table, so bulk CRC checks during Rar extraction get the same throughput
+    // as Zip/GZip/7Zip/LZip CRC32 validation instead of a much slower one-byte-per-iteration loop.
+    private static readonly uint[] crcTab = Crc32Stream.InitializeTable(
+        Crc32Stream.DEFAULT_POLYNOMIAL
+    );
 
     public static uint CheckCrc(uint startCrc, byte b) =>
         (crcTab[((int)startCrc ^ b) & 0xff] ^ (startCrc >> 8));
@@ -12,35 +18,6 @@ internal static class RarCRC
     public static uint CheckCrc(uint startCrc, ReadOnlySpan<byte> data, int offset, int count)
     {
         var size = Math.Min(data.Length - offset, count);
-
-        for (var i = 0; i < size; i++)
-        {
-            startCrc = (crcTab[((int)startCrc ^ data[offset + i]) & 0xff] ^ (startCrc >> 8));
-        }
-        return (startCrc);
-    }
-
-    static RarCRC()
-    {
-        {
-            crcTab = new uint[256];
-            for (uint i = 0; i < 256; i++)
-            {
-                var c = i;
-                for (var j = 0; j < 8; j++)
-                {
-                    if ((c & 1) != 0)
-                    {
-                        c >>= 1;
-                        c ^= 0xEDB88320;
-                    }
-                    else
-                    {
-                        c >>= 1;
-                    }
-                }
-                crcTab[i] = c;
-            }
-        }
+        return Crc32Stream.CalculateCrc(crcTab, startCrc, data.Slice(offset, size));
     }
 }


### PR DESCRIPTION
This PR fixes some lost CPU performance for the `Rar: Extract all entries (Archive API)` benchmark.

Root cause seems to have been around the CRC calculation, and since we improved it overall via #1398 we reused the same approach for RAR, which didn't fix fully the regression but made it less worser than before ( see https://github.com/julianxhokaxhiu/sharpcompress/actions/runs/30936540453 ).

Details as usual follow below. This patch was assisted using **Claude Sonnet 5**.

---

## Rar: Restore Archive API extraction throughput lost to CRC verification

### Problem

The benchmark `Rar: Extract all entries (Archive API)` regressed significantly in
CPU time (roughly +30% on the sync extraction path).

Bisecting with `git worktree` (direct on-machine A/B timing of the exact benchmark
code across commits, to rule out CI run-to-run noise) pinned the regression to
`e9e05520` ("7Zip and Rar"). That commit changed
`RarArchiveEntry.OpenEntryStream()` to always wrap the returned stream in
`RarCrcStream` / `RarBLAKE2spStream`, whereas before it returned a plain
`RarStream` with **no integrity verification at all**.

This is an **intentional correctness fix**, not a bug: the Reader API already
verified CRC32/BLAKE2sp during extraction, but the Archive API silently skipped
it. That gap is not something to revert — extraction should catch corrupted
archives the same way `unrar` and the Reader API do.

The actual issue was *how* that verification was implemented:
`RarCRC.CheckCrc` computed CRC32 with a naive byte-at-a-time table lookup,
instead of the faster slice-by-16 implementation already used elsewhere in the
codebase (Zip/GZip/7Zip/LZip) via `Crc32Stream`.

### Fix

- [`src/SharpCompress/Compressors/Rar/RarCRC.cs`](src/SharpCompress/Compressors/Rar/RarCRC.cs):
  reuse `Crc32Stream`'s cached slice-by-16 CRC32 table/algorithm instead of a
  separate hand-rolled byte-wise table. Same polynomial (`0xEDB88320`) and
  identical `table[0..255]` layout, so the existing single-byte call sites
  (`RarCrcBinaryReader`) needed no changes.

No public API changes.

### Results

Measured locally with a throwaway harness running the exact
`RarExtractArchiveApi` benchmark body (20,000 iterations, JIT-warmed, sync
Archive API path) at each commit:

| Version | Time / iteration |
|---|---|
| Before CRC verification was added (pre-`e9e05520`) | ~565–571 µs |
| After CRC verification added, naive CRC32 table (regression) | ~734 µs (+30%) |
| After this fix (slice-by-16 CRC32 reused from `Crc32Stream`) | ~603 µs (**-18%** vs. regressed) |

The remaining gap versus the pre-verification baseline is the inherent,
unavoidable cost of actually computing the checksum — correctness the Archive
API was previously missing.

### Testing

- `dotnet test tests/SharpCompress.Test/SharpCompress.Test.csproj -c Release -f net10.0 --filter "FullyQualifiedName~Rar"` — 363 passed, 0 failed.
- `dotnet build SharpCompress.slnx -c Release` — builds clean across all target frameworks (net48, netstandard2.0/2.1, net6.0, net8.0, net10.0).
- `dotnet csharpier format .` — only `RarCRC.cs` changed.